### PR TITLE
Add .vscode and .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+.DS_Store
 .env
+.vscode
 node_modules
 cache
 artifacts


### PR DESCRIPTION
So we ignore by default:

* VS Code project folder
* OSX finder files