### PR TITLE
Add deploy modules subtask

### DIFF
--- a/packages/deployer/subtasks/deploy-contracts.js
+++ b/packages/deployer/subtasks/deploy-contracts.js
@@ -100,7 +100,7 @@ async function _processContracts(contracts) {
 }
 
 /**
- * Deploy the give contract using ethers.js
+ * Deploy the given contract using ethers.js
  */
 async function _createAndDeployContract(contractName) {
   logger.success(`Deploying ${contractName}`);

--- a/packages/deployer/subtasks/deploy-contracts.js
+++ b/packages/deployer/subtasks/deploy-contracts.js
@@ -10,7 +10,7 @@ const { SUBTASK_DEPLOY_CONTRACTS } = require('../task-names');
 
 subtask(
   SUBTASK_DEPLOY_CONTRACTS,
-  'Deploys a list of contracts, avoiding contracts that do not need to be compiled, and prompting the user for confirmation.'
+  'Deploys a list of contracts, avoiding contracts that do not need to be deployed, and prompting the user for confirmation.'
 ).setAction(async ({ contracts }, hre) => {
   const { toSkip, toUpdate, toCreate } = await _processContracts(contracts);
 

--- a/packages/deployer/subtasks/deploy-contracts.js
+++ b/packages/deployer/subtasks/deploy-contracts.js
@@ -1,0 +1,130 @@
+const logger = require('../utils/logger');
+const prompter = require('../utils/prompter');
+const {
+  getContractNameFromPath,
+  getContractBytecodeHash,
+  getAddressBytecodeHash,
+} = require('../utils/contracts');
+const { subtask } = require('hardhat/config');
+const { SUBTASK_DEPLOY_CONTRACTS } = require('../task-names');
+
+subtask(
+  SUBTASK_DEPLOY_CONTRACTS,
+  'Deploys a list of contracts, avoiding contracts that do not need to be compiled, and prompting the user for confirmation.'
+).setAction(async ({ contracts }, hre) => {
+  const { toSkip, toUpdate, toCreate } = await _processContracts(contracts);
+
+  if (toUpdate.length === 0 && toCreate.length === 0) {
+    logger.info('No contracts need to be deployed, continuing...');
+    return;
+  } else {
+    await _confirmDeployments({ toSkip, toUpdate, toCreate });
+  }
+
+  // Update & create the contracts
+  for (const [contractPath, contractData] of [...toUpdate, ...toCreate]) {
+    const contractName = getContractNameFromPath(contractPath);
+    const sourceBytecodeHash = getContractBytecodeHash(contractPath);
+
+    // Create contract & start the transaction on the network
+    const { contract, transaction } = await _createAndDeployContract(contractName);
+
+    hre.deployer.data.transactions[transaction.hash] = { status: 'pending' };
+
+    // Wait for the transaction to finish
+    const { gasUsed, status } = await _waitForTransaction(transaction);
+
+    hre.deployer.data.transactions[transaction.hash].status = status;
+
+    const totalGasUsed = hre.ethers.BigNumber.from(hre.deployer.data.properties.totalGasUsed)
+      .add(gasUsed)
+      .toString();
+    hre.deployer.data.properties.totalGasUsed = totalGasUsed;
+
+    contractData.deployedAddress = contract.address;
+    contractData.deployTransaction = transaction.hash;
+    contractData.bytecodeHash = sourceBytecodeHash;
+  }
+});
+
+/**
+ * Prompts the user to confirm the give deployments if necessary
+ */
+async function _confirmDeployments({ toSkip, toUpdate, toCreate }) {
+  if (toSkip.length > 0) {
+    logger.info(`There are ${toSkip.length} contracts that are already up-to-date:`);
+    toSkip.forEach(([source]) => logger.notice(`  ${source}`));
+  }
+
+  if (toUpdate.length > 0) {
+    logger.info(`The following ${toUpdate.length} contracts are going to be updated:`);
+    toUpdate.forEach(([source]) => logger.notice(`  ${source}`));
+  }
+
+  if (toCreate.length > 0) {
+    logger.info(
+      `The following ${toCreate.length} contracts are going to be deployed for the first time:`
+    );
+    toCreate.forEach(([source]) => logger.notice(`  ${source}`));
+  }
+
+  await prompter.confirmAction('Are you sure you want to make these changes?');
+}
+
+/**
+ * Sort contracts by the ones that doesn't need deployment, the ones that are going
+ * to be re-deployed with updated code, and the ones that are going to be deployed
+ * for the first time.
+ */
+async function _processContracts(contracts) {
+  const toSkip = [];
+  const toUpdate = [];
+  const toCreate = [];
+
+  for (const [contractPath, contractData] of Object.entries(contracts)) {
+    if (hre.network.name === 'hardhat' || !contractData.deployedAddress) {
+      toCreate.push([contractPath, contractData]);
+    } else {
+      const sourceBytecodeHash = getContractBytecodeHash(contractPath);
+      const remoteBytecodeHash = await getAddressBytecodeHash(contractData.deployedAddress);
+
+      if (sourceBytecodeHash === remoteBytecodeHash) {
+        toSkip.push([contractPath, contractData]);
+      } else {
+        toUpdate.push([contractPath, contractData]);
+      }
+    }
+  }
+
+  return { toSkip, toUpdate, toCreate };
+}
+
+/**
+ * Deploy the give contract using ethers.js
+ */
+async function _createAndDeployContract(contractName) {
+  logger.success(`Deploying ${contractName}`);
+
+  const factory = await hre.ethers.getContractFactory(contractName);
+  const contract = await factory.deploy();
+
+  if (!contract.address) {
+    throw new Error(`Error deploying ${contractName}`);
+  }
+
+  return { contract, transaction: contract.deployTransaction };
+}
+
+/**
+ * Given a transaction, wait for it to finish and return the state with the gas used.
+ */
+async function _waitForTransaction(transaction) {
+  const receipt = await hre.ethers.provider.getTransactionReceipt(transaction.hash);
+  const { gasUsed } = receipt;
+  const status = receipt.status === 1 ? 'confirmed' : 'failed';
+
+  logger.info(`Transaction hash: ${transaction.hash}`);
+  logger.info(`Status: ${status} - Gas used: ${gasUsed}`);
+
+  return { gasUsed, status };
+}

--- a/packages/deployer/subtasks/deploy-modules.js
+++ b/packages/deployer/subtasks/deploy-modules.js
@@ -1,0 +1,12 @@
+const logger = require('../utils/logger');
+const { subtask } = require('hardhat/config');
+
+const { SUBTASK_DEPLOY_CONTRACTS, SUBTASK_DEPLOY_MODULES } = require('../task-names');
+
+subtask(SUBTASK_DEPLOY_MODULES).setAction(async (_, hre) => {
+  logger.subtitle('Deploying modules');
+
+  await hre.run(SUBTASK_DEPLOY_CONTRACTS, {
+    contracts: hre.deployer.data.contracts.modules,
+  });
+});

--- a/packages/deployer/subtasks/prepare-deployment.js
+++ b/packages/deployer/subtasks/prepare-deployment.js
@@ -68,7 +68,7 @@ async function _clearDeploymentData(folder) {
  * Initialize a new deployment file, or, if existant, try to continue using it.
  * @param {string} folder deployment folder where to find files
  * @param {string} [alias]
- * @returns {{ previous: string, current: string }}
+ * @returns {{ currentFile: string, previousFile: string }}
  */
 async function _determineDeploymentFiles(folder, alias) {
   const deployments = glob

--- a/packages/deployer/subtasks/sync-sources.js
+++ b/packages/deployer/subtasks/sync-sources.js
@@ -54,15 +54,9 @@ async function _addNewSources({ sources, data, previousData }) {
   const toAdd = sources.filter((source) => {
     const previousModule = previousData?.contracts.modules[source];
     data.contracts.modules[source] = data.contracts.modules[source] ||
-      previousModule || { deployedAddress: '', bytecodeHash: '' };
+      previousModule || { deployedAddress: '', deployTransaction: '', bytecodeHash: '' };
     return !previousModule;
   });
-
-  if (toAdd.length > 0) {
-    logger.notice('The following modules are going to be deployed for the first time:');
-    toAdd.forEach((source) => logger.notice(`  ${source}`));
-    await prompter.confirmAction('Do you confirm these new modules?');
-  }
 
   return toAdd.length > 0;
 }

--- a/packages/deployer/task-names.js
+++ b/packages/deployer/task-names.js
@@ -1,4 +1,6 @@
 module.exports = {
+  SUBTASK_DEPLOY_CONTRACTS: 'deploy-contracts',
+  SUBTASK_DEPLOY_MODULES: 'generate-deploy-modules',
   SUBTASK_PREPARE_DEPLOYMENT: 'prepare-deployment',
   SUBTASK_PRINT_INFO: 'print-info',
   SUBTASK_SYNC_SOURCES: 'sync-sources',

--- a/packages/deployer/tasks/deploy.js
+++ b/packages/deployer/tasks/deploy.js
@@ -3,6 +3,7 @@ const { task } = require('hardhat/config');
 const { TASK_COMPILE } = require('hardhat/builtin-tasks/task-names');
 
 const {
+  SUBTASK_DEPLOY_MODULES,
   SUBTASK_PREPARE_DEPLOYMENT,
   SUBTASK_PRINT_INFO,
   SUBTASK_SYNC_SOURCES,
@@ -49,4 +50,5 @@ task(TASK_DEPLOY, 'Deploys all system modules')
     await hre.run(SUBTASK_PRINT_INFO, taskArguments);
     await hre.run(TASK_COMPILE, { force: true, quiet: true });
     await hre.run(SUBTASK_SYNC_SOURCES);
+    await hre.run(SUBTASK_DEPLOY_MODULES);
   });

--- a/packages/deployer/utils/contracts.js
+++ b/packages/deployer/utils/contracts.js
@@ -23,27 +23,8 @@ function getContractBytecodeHash(contractPath) {
   return hre.ethers.utils.sha256(data.deployedBytecode);
 }
 
-async function getContractSelectors({ contractName }) {
-  const contract = await hre.ethers.getContractAt(
-    contractName,
-    '0x0000000000000000000000000000000000000001'
-  );
-
-  return contract.interface.fragments.reduce((selectors, fragment) => {
-    if (fragment.type === 'function') {
-      selectors.push({
-        name: fragment.name,
-        selector: contract.interface.getSighash(fragment),
-      });
-    }
-
-    return selectors;
-  }, []);
-}
-
 module.exports = {
   getContractNameFromPath,
   getAddressBytecodeHash,
   getContractBytecodeHash,
-  getContractSelectors,
 };

--- a/packages/deployer/utils/contracts.js
+++ b/packages/deployer/utils/contracts.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 
 function getContractNameFromPath(contractPath) {
-  return path.basename(contractPath).replace(new RegExp(/\.sol$/), '');
+  return path.basename(contractPath, '.sol');
 }
 
 async function getAddressBytecodeHash(address) {

--- a/packages/deployer/utils/contracts.js
+++ b/packages/deployer/utils/contracts.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const path = require('path');
+
+function getContractNameFromPath(contractPath) {
+  return path.basename(contractPath).replace(new RegExp(/\.sol$/), '');
+}
+
+async function getAddressBytecodeHash(address) {
+  const bytecode = await hre.ethers.provider.getCode(address);
+  return hre.ethers.utils.sha256(bytecode);
+}
+
+function getContractBytecodeHash(contractPath) {
+  const artifactsPath = hre.config.paths.artifacts;
+
+  const filePath = path.join(
+    artifactsPath,
+    contractPath,
+    `${getContractNameFromPath(contractPath)}.json`
+  );
+
+  const data = JSON.parse(fs.readFileSync(filePath));
+  return hre.ethers.utils.sha256(data.deployedBytecode);
+}
+
+async function getContractSelectors({ contractName }) {
+  const contract = await hre.ethers.getContractAt(
+    contractName,
+    '0x0000000000000000000000000000000000000001'
+  );
+
+  return contract.interface.fragments.reduce((selectors, fragment) => {
+    if (fragment.type === 'function') {
+      selectors.push({
+        name: fragment.name,
+        selector: contract.interface.getSighash(fragment),
+      });
+    }
+
+    return selectors;
+  }, []);
+}
+
+module.exports = {
+  getContractNameFromPath,
+  getAddressBytecodeHash,
+  getContractBytecodeHash,
+  getContractSelectors,
+};


### PR DESCRIPTION
This PR adds the subtasks necessary for deploying all the contracts on the `contracts/modules` folder.

Before deploying, searches for all the modules files at `contracts/modules/**/*.sol` and checks the following strategy:
1. If the current network is `hardhat`, it will deploy all the modules again.
2. Checks on the blockchain if the same module was deployed on another Deployment, and if weren't any changes on the bytecode, it skips the deployment of that module.
3. If the bytecode is different, it notifies the user that is going to update that specific module.
4. If the module weren't previously deployed, notifies about its creation (deployment for the first time).
