### PR TITLE
Add upgrade proxy & finalize deployment subtasks

### DIFF
--- a/packages/deployer/subtasks/deploy-contract.js
+++ b/packages/deployer/subtasks/deploy-contract.js
@@ -1,0 +1,61 @@
+const logger = require('../utils/logger');
+const { getContractNameFromPath, getContractBytecodeHash } = require('../utils/contracts');
+const { subtask } = require('hardhat/config');
+const { SUBTASK_DEPLOY_CONTRACT } = require('../task-names');
+
+subtask(
+  SUBTASK_DEPLOY_CONTRACT,
+  'Deploys the given contract and update the contractData object.'
+).setAction(async ({ contractPath, contractData, constructorArgs = [] }, hre) => {
+  const contractName = getContractNameFromPath(contractPath);
+  const sourceBytecodeHash = getContractBytecodeHash(contractPath);
+
+  // Create contract & start the transaction on the network
+  const { contract, transaction } = await _createAndDeployContract(contractName, constructorArgs);
+
+  hre.deployer.data.transactions[transaction.hash] = { status: 'pending' };
+
+  // Wait for the transaction to finish
+  const { gasUsed, status } = await _waitForTransaction(transaction);
+
+  hre.deployer.data.transactions[transaction.hash].status = status;
+
+  const totalGasUsed = hre.ethers.BigNumber.from(hre.deployer.data.properties.totalGasUsed)
+    .add(gasUsed)
+    .toString();
+  hre.deployer.data.properties.totalGasUsed = totalGasUsed;
+
+  contractData.deployedAddress = contract.address;
+  contractData.deployTransaction = transaction.hash;
+  contractData.bytecodeHash = sourceBytecodeHash;
+});
+
+/**
+ * Deploy the given contract using ethers.js
+ */
+async function _createAndDeployContract(contractName, constructorArgs = []) {
+  logger.success(`Deploying ${contractName}`);
+
+  const factory = await hre.ethers.getContractFactory(contractName);
+  const contract = await factory.deploy(...constructorArgs);
+
+  if (!contract.address) {
+    throw new Error(`Error deploying ${contractName}`);
+  }
+
+  return { contract, transaction: contract.deployTransaction };
+}
+
+/**
+ * Given a transaction, wait for it to finish and return the state with the gas used.
+ */
+async function _waitForTransaction(transaction) {
+  const receipt = await hre.ethers.provider.getTransactionReceipt(transaction.hash);
+  const { gasUsed } = receipt;
+  const status = receipt.status === 1 ? 'confirmed' : 'failed';
+
+  logger.info(`Transaction hash: ${transaction.hash}`);
+  logger.info(`Status: ${status} - Gas used: ${gasUsed}`);
+
+  return { gasUsed, status };
+}

--- a/packages/deployer/subtasks/deploy-contracts.js
+++ b/packages/deployer/subtasks/deploy-contracts.js
@@ -77,33 +77,3 @@ async function _processContracts(contracts) {
 
   return { toSkip, toUpdate, toCreate };
 }
-
-/**
- * Deploy the given contract using ethers.js
- */
-async function _createAndDeployContract(contractName) {
-  logger.success(`Deploying ${contractName}`);
-
-  const factory = await hre.ethers.getContractFactory(contractName);
-  const contract = await factory.deploy();
-
-  if (!contract.address) {
-    throw new Error(`Error deploying ${contractName}`);
-  }
-
-  return { contract, transaction: contract.deployTransaction };
-}
-
-/**
- * Given a transaction, wait for it to finish and return the state with the gas used.
- */
-async function _waitForTransaction(transaction) {
-  const receipt = await hre.ethers.provider.getTransactionReceipt(transaction.hash);
-  const { gasUsed } = receipt;
-  const status = receipt.status === 1 ? 'confirmed' : 'failed';
-
-  logger.info(`Transaction hash: ${transaction.hash}`);
-  logger.info(`Status: ${status} - Gas used: ${gasUsed}`);
-
-  return { gasUsed, status };
-}

--- a/packages/deployer/subtasks/deploy-contracts.js
+++ b/packages/deployer/subtasks/deploy-contracts.js
@@ -1,6 +1,6 @@
 const logger = require('../utils/logger');
 const prompter = require('../utils/prompter');
-const { getContractBytecodeHash, getAddressBytecodeHash } = require('../utils/contracts');
+const { alreadyDeployed } = require('../utils/contracts');
 const { subtask } = require('hardhat/config');
 const { SUBTASK_DEPLOY_CONTRACTS, SUBTASK_DEPLOY_CONTRACT } = require('../task-names');
 
@@ -64,10 +64,7 @@ async function _processContracts(contracts) {
     if (hre.network.name === 'hardhat' || !contractData.deployedAddress) {
       toCreate.push([contractPath, contractData]);
     } else {
-      const sourceBytecodeHash = getContractBytecodeHash(contractPath);
-      const remoteBytecodeHash = await getAddressBytecodeHash(contractData.deployedAddress);
-
-      if (sourceBytecodeHash === remoteBytecodeHash) {
+      if (await alreadyDeployed(contractPath, contractData)) {
         toSkip.push([contractPath, contractData]);
       } else {
         toUpdate.push([contractPath, contractData]);

--- a/packages/deployer/subtasks/deploy-router.js
+++ b/packages/deployer/subtasks/deploy-router.js
@@ -2,7 +2,7 @@ const logger = require('../utils/logger');
 const { subtask } = require('hardhat/config');
 const { TASK_COMPILE } = require('hardhat/builtin-tasks/task-names');
 
-const { SUBTASK_DEPLOY_CONTRACTS, SUBTASK_DEPLOY_ROUTER } = require('../task-names');
+const { SUBTASK_DEPLOY_CONTRACT, SUBTASK_DEPLOY_ROUTER } = require('../task-names');
 
 subtask(SUBTASK_DEPLOY_ROUTER).setAction(async (_, hre) => {
   logger.subtitle('Deploying router');
@@ -21,7 +21,8 @@ subtask(SUBTASK_DEPLOY_ROUTER).setAction(async (_, hre) => {
     contractData = hre.deployer.data.contracts[contractPath];
   }
 
-  await hre.run(SUBTASK_DEPLOY_CONTRACTS, {
-    contracts: { [contractPath]: contractData },
+  await hre.run(SUBTASK_DEPLOY_CONTRACT, {
+    contractPath,
+    contractData,
   });
 });

--- a/packages/deployer/subtasks/deploy-router.js
+++ b/packages/deployer/subtasks/deploy-router.js
@@ -9,7 +9,19 @@ subtask(SUBTASK_DEPLOY_ROUTER).setAction(async (_, hre) => {
 
   await hre.run(TASK_COMPILE, { force: false, quiet: true });
 
+  const contractPath = hre.deployer.paths.routerPath;
+  let contractData = hre.deployer.data.contracts[contractPath];
+
+  if (!contractData) {
+    hre.deployer.data.contracts[contractPath] = {
+      deployedAddress: '',
+      deployTransaction: '',
+      bytecodeHash: '',
+    };
+    contractData = hre.deployer.data.contracts[contractPath];
+  }
+
   await hre.run(SUBTASK_DEPLOY_CONTRACTS, {
-    contracts: { [hre.deployer.paths.routerPath]: {} },
+    contracts: { [contractPath]: contractData },
   });
 });

--- a/packages/deployer/subtasks/finalize-deployment.js
+++ b/packages/deployer/subtasks/finalize-deployment.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const logger = require('../utils/logger');
+const { subtask } = require('hardhat/config');
+const { SUBTASK_FINALIZE_DEPLOYMENT } = require('../task-names');
+
+/*
+ * Marks a deployment as completed, or deletes it if it didn't produce any changes.
+ * */
+subtask(SUBTASK_FINALIZE_DEPLOYMENT).setAction(async (_, hre) => {
+  logger.subtitle('Finalizing deployment');
+
+  if (hre.deployer.data.properties.totalGasUsed === '0') {
+    logger.checked('Deployment did not produce any changes, deleting temp file');
+
+    fs.unlinkSync(hre.deployer.file);
+  } else {
+    logger.complete('Deployment marked as completed');
+
+    hre.deployer.data.properties.completed = true;
+  }
+});

--- a/packages/deployer/subtasks/prepare-deployment.js
+++ b/packages/deployer/subtasks/prepare-deployment.js
@@ -18,7 +18,7 @@ const DEPLOYMENT_FILE_FORMAT = /^[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2,}(?:-[a-z0-9
 const DEPLOYMENT_SCHEMA = {
   properties: {
     completed: false,
-    totalGasUsed: 0,
+    totalGasUsed: '0',
   },
   transactions: {},
   contracts: {

--- a/packages/deployer/subtasks/upgrade-proxy.js
+++ b/packages/deployer/subtasks/upgrade-proxy.js
@@ -1,7 +1,7 @@
 const logger = require('../utils/logger');
 const prompter = require('../utils/prompter');
 const { subtask } = require('hardhat/config');
-const { processTransaction, processReceipt } = require('../utils/transactions');
+// const { processTransaction, processReceipt } = require('../utils/transactions');
 const { SUBTASK_UPGRADE_PROXY, SUBTASK_DEPLOY_CONTRACTS } = require('../task-names');
 
 const UPGRADE_ABI = [
@@ -40,9 +40,9 @@ const UPGRADE_ABI = [
 subtask(SUBTASK_UPGRADE_PROXY).setAction(async (_, hre) => {
   logger.subtitle('Upgrading main proxy');
 
-  const data = hre.deployer.data.contracts;
+  const routerData = hre.deployer.data.contracts[hre.deployer.paths.routerPath];
+  const { deployedAddress: implementationAddress } = routerData;
 
-  const implementationAddress = data[`Router_${hre.network.name}`].deployedAddress;
   logger.info(`Target implementation: ${implementationAddress}`);
 
   const wasProxyDeployed = await _deployProxy({ implementationAddress });

--- a/packages/deployer/subtasks/upgrade-proxy.js
+++ b/packages/deployer/subtasks/upgrade-proxy.js
@@ -1,0 +1,97 @@
+const logger = require('../utils/logger');
+const prompter = require('../utils/prompter');
+const { subtask } = require('hardhat/config');
+const { processTransaction, processReceipt } = require('../utils/transactions');
+const { SUBTASK_UPGRADE_PROXY, SUBTASK_DEPLOY_CONTRACTS } = require('../task-names');
+
+const UPGRADE_ABI = [
+  {
+    inputs: [],
+    name: 'getImplementation',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'newImplementation',
+        type: 'address',
+      },
+    ],
+    name: 'upgradeTo',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+];
+
+/*
+ * Checks if the main proxy needs to be deployed,
+ * and upgrades it if needed.
+ * */
+subtask(SUBTASK_UPGRADE_PROXY).setAction(async (_, hre) => {
+  logger.subtitle('Upgrading main proxy');
+
+  const data = hre.deployer.data.contracts;
+
+  const implementationAddress = data[`Router_${hre.network.name}`].deployedAddress;
+  logger.info(`Target implementation: ${implementationAddress}`);
+
+  const wasProxyDeployed = await _deployProxy({ implementationAddress });
+
+  // TODO: For some very strange reason, hre within _upgradeProxy is undefined.
+  // This only seems to happen if _deployProxy was called first!
+  // Hardhat seems to loose hre from the global context as soon as
+  // a third depth level of subtasks is reached.
+  // The workaround is to pass hre which is still maintained in the scope of
+  // the subtask.
+  if (!wasProxyDeployed) {
+    await _upgradeProxy({ implementationAddress, hre });
+  }
+});
+
+async function _deployProxy({ implementationAddress }) {
+  const deployed = await hre.run(SUBTASK_DEPLOY_CONTRACTS, {
+    contractNames: [hre.config.deployer.proxyName],
+    constructorArgs: [[implementationAddress]],
+  });
+
+  return deployed.length > 0;
+}
+
+async function _upgradeProxy({ implementationAddress, hre }) {
+  const data = hre.deployer.data.contracts;
+  const proxyAddress = data[hre.config.deployer.proxyName].deployedAddress;
+
+  const upgradeable = await hre.ethers.getContractAt(UPGRADE_ABI, proxyAddress);
+  const activeImplementationAddress = await upgradeable.getImplementation();
+  logger.info(`Active implementation: ${activeImplementationAddress}`);
+
+  if (activeImplementationAddress !== implementationAddress) {
+    logger.notice(
+      `Proxy upgrade needed - Main proxy implementation ${activeImplementationAddress} is different from the target implementation`
+    );
+
+    await prompter.confirmAction('Upgrade system');
+
+    logger.notice(`Upgrading main proxy to ${implementationAddress}`);
+
+    const tx = await upgradeable.upgradeTo(implementationAddress);
+    processTransaction({ transaction: tx, hre });
+
+    const receipt = await tx.wait();
+    processReceipt({ receipt, hre });
+
+    logger.success(`Main proxy upgraded to ${await upgradeable.getImplementation()}`);
+  } else {
+    logger.checked('No need to upgrade the main proxy');
+  }
+}

--- a/packages/deployer/subtasks/upgrade-proxy.js
+++ b/packages/deployer/subtasks/upgrade-proxy.js
@@ -40,15 +40,14 @@ const UPGRADE_ABI = [
 subtask(SUBTASK_UPGRADE_PROXY).setAction(async (_, hre) => {
   logger.subtitle('Upgrading main proxy');
 
-  const routerAddress = _getDeployedAddress(hre.config.deployer.routerPath);
+  const routerAddress = _getDeployedAddress(hre.deployer.paths.routerPath, hre);
 
   logger.info(`Target implementation: ${routerAddress}`);
 
-  const wasProxyDeployed = await _deployProxy(routerAddress);
+  const wasProxyDeployed = await _deployProxy(routerAddress, hre);
 
   if (!wasProxyDeployed) {
-    const proxyAddress = _getDeployedAddress(hre.config.deployer.proxyName);
-
+    const proxyAddress = _getDeployedAddress(hre.deployer.paths.proxyPath, hre);
     await _upgradeProxy({ proxyAddress, routerAddress, hre });
   }
 });
@@ -57,7 +56,7 @@ function _getDeployedAddress(contractPath, hre) {
   return hre.deployer.data.contracts[contractPath].deployedAddress;
 }
 
-async function _deployProxy(routerAddress) {
+async function _deployProxy(routerAddress, hre) {
   const contractPath = hre.deployer.paths.proxyPath;
   let contractData = hre.deployer.data.contracts[contractPath];
 

--- a/packages/deployer/task-names.js
+++ b/packages/deployer/task-names.js
@@ -1,4 +1,5 @@
 module.exports = {
+  SUBTASK_DEPLOY_CONTRACT: 'deploy-contract',
   SUBTASK_DEPLOY_CONTRACTS: 'deploy-contracts',
   SUBTASK_DEPLOY_MODULES: 'generate-deploy-modules',
   SUBTASK_DEPLOY_ROUTER: 'generate-deploy-router',

--- a/packages/deployer/task-names.js
+++ b/packages/deployer/task-names.js
@@ -6,6 +6,7 @@ module.exports = {
   SUBTASK_PREPARE_DEPLOYMENT: 'prepare-deployment',
   SUBTASK_PRINT_INFO: 'print-info',
   SUBTASK_SYNC_SOURCES: 'sync-sources',
+  SUBTASK_UPGRADE_PROXY: 'upgrade-proxy',
   SUBTASK_VALIDATE_ROUTER: 'validate-router',
   TASK_DEPLOY: 'deploy',
 };

--- a/packages/deployer/tasks/deploy.js
+++ b/packages/deployer/tasks/deploy.js
@@ -9,6 +9,7 @@ const {
   SUBTASK_PREPARE_DEPLOYMENT,
   SUBTASK_PRINT_INFO,
   SUBTASK_SYNC_SOURCES,
+  SUBTASK_UPGRADE_PROXY,
   SUBTASK_VALIDATE_ROUTER,
   TASK_DEPLOY,
 } = require('../task-names');
@@ -65,4 +66,5 @@ task(TASK_DEPLOY, 'Deploys all system modules')
     await hre.run(SUBTASK_GENERATE_ROUTER_SOURCE);
     await hre.run(SUBTASK_VALIDATE_ROUTER);
     await hre.run(SUBTASK_DEPLOY_ROUTER);
+    await hre.run(SUBTASK_UPGRADE_PROXY);
   });

--- a/packages/deployer/tasks/deploy.js
+++ b/packages/deployer/tasks/deploy.js
@@ -5,6 +5,7 @@ const { TASK_COMPILE } = require('hardhat/builtin-tasks/task-names');
 const {
   SUBTASK_DEPLOY_MODULES,
   SUBTASK_DEPLOY_ROUTER,
+  SUBTASK_FINALIZE_DEPLOYMENT,
   SUBTASK_GENERATE_ROUTER_SOURCE,
   SUBTASK_PREPARE_DEPLOYMENT,
   SUBTASK_PRINT_INFO,
@@ -69,5 +70,6 @@ task(TASK_DEPLOY, 'Deploys all system modules')
     await hre.run(SUBTASK_GENERATE_ROUTER_SOURCE);
     await hre.run(SUBTASK_VALIDATE_ROUTER);
     await hre.run(SUBTASK_DEPLOY_ROUTER);
-    // await hre.run(SUBTASK_UPGRADE_PROXY);
+    await hre.run(SUBTASK_UPGRADE_PROXY);
+    await hre.run(SUBTASK_FINALIZE_DEPLOYMENT);
   });

--- a/packages/deployer/tasks/deploy.js
+++ b/packages/deployer/tasks/deploy.js
@@ -66,5 +66,5 @@ task(TASK_DEPLOY, 'Deploys all system modules')
     await hre.run(SUBTASK_GENERATE_ROUTER_SOURCE);
     await hre.run(SUBTASK_VALIDATE_ROUTER);
     await hre.run(SUBTASK_DEPLOY_ROUTER);
-    await hre.run(SUBTASK_UPGRADE_PROXY);
+    // await hre.run(SUBTASK_UPGRADE_PROXY);
   });

--- a/packages/deployer/tasks/deploy.js
+++ b/packages/deployer/tasks/deploy.js
@@ -57,6 +57,9 @@ task(TASK_DEPLOY, 'Deploys all system modules')
     paths.routerPath = relativePath(
       path.join(hre.config.paths.sources, `${hre.deployer.routerModule}.sol`)
     );
+    paths.proxyPath = relativePath(
+      path.join(hre.config.paths.sources, `${hre.config.deployer.proxyName}.sol`)
+    );
 
     await hre.run(SUBTASK_PREPARE_DEPLOYMENT, taskArguments);
     await hre.run(SUBTASK_PRINT_INFO, taskArguments);

--- a/packages/deployer/utils/contracts.js
+++ b/packages/deployer/utils/contracts.js
@@ -41,9 +41,19 @@ async function getContractSelectors(contractName) {
   }, []);
 }
 
+async function alreadyDeployed(contractPath, contractData) {
+  if (!contractData.deployedAddress) return false;
+
+  const sourceBytecodeHash = getContractBytecodeHash(contractPath);
+  const remoteBytecodeHash = await getAddressBytecodeHash(contractData.deployedAddress);
+
+  return sourceBytecodeHash === remoteBytecodeHash;
+}
+
 module.exports = {
   getContractNameFromPath,
   getAddressBytecodeHash,
   getContractBytecodeHash,
   getContractSelectors,
+  alreadyDeployed,
 };

--- a/packages/deployer/utils/transactions.js
+++ b/packages/deployer/utils/transactions.js
@@ -1,0 +1,24 @@
+function processTransaction(transaction, hre) {
+  hre.deployer.data.transactions[transaction.hash] = { status: 'pending' };
+}
+
+function processReceipt(receipt, hre) {
+  // Wait for the transaction to finish
+  const { gasUsed } = receipt;
+  const status = receipt.status === 1 ? 'confirmed' : 'failed';
+
+  hre.deployer.data.transactions[receipt.transactionHash].status = status;
+
+  const totalGasUsed = hre.ethers.BigNumber.from(hre.deployer.data.properties.totalGasUsed)
+    .add(gasUsed)
+    .toString();
+
+  hre.deployer.data.properties.totalGasUsed = totalGasUsed;
+
+  return { status, gasUsed };
+}
+
+module.exports = {
+  processTransaction,
+  processReceipt,
+};


### PR DESCRIPTION
Add the necessary subtasks for upgrading the current proxy to point to the new Router if necessary, and finalize the deployment file.

## Extra
Refactor of the `deploy-contracts.js` subtask to be divided in a single `deploy-contract` script, and a `deploy-contracts` which uses the first one.