### PR TITLE
Bootstraps sample-project tests

### DIFF
--- a/packages/deployer/subtasks/prepare-deployment.js
+++ b/packages/deployer/subtasks/prepare-deployment.js
@@ -26,7 +26,7 @@ subtask(
   SUBTASK_PREPARE_DEPLOYMENT,
   'Prepares the deployment file associated with the active deployment.'
 ).setAction(async (taskArguments, hre) => {
-  const { clear, alias } = taskArguments;
+  const { clear, alias, instance } = taskArguments;
 
   if (clear) {
     await _clearDeploymentData(hre.deployer.paths.instance);
@@ -34,7 +34,7 @@ subtask(
 
   mkdirp.sync(hre.deployer.paths.instance);
 
-  const { previousFile, currentFile } = await _determineDeploymentFiles(alias);
+  const { previousFile, currentFile } = await _determineDeploymentFiles(instance, alias);
 
   hre.deployer.file = currentFile;
   hre.deployer.data = autosaveObject(hre.deployer.file, DEPLOYMENT_SCHEMA);

--- a/packages/deployer/tasks/deploy.js
+++ b/packages/deployer/tasks/deploy.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const { task } = require('hardhat/config');
 const { TASK_COMPILE } = require('hardhat/builtin-tasks/task-names');
 
@@ -16,7 +15,7 @@ const {
 } = require('../task-names');
 const logger = require('../utils/logger');
 const prompter = require('../utils/prompter');
-const relativePath = require('../utils/relative-path');
+const { getDeploymentPaths } = require('../utils/deployments');
 const { capitalize } = require('../utils/string');
 
 const isWord = (str) => /^[\w\d]+$/.test(str);
@@ -47,20 +46,7 @@ task(TASK_DEPLOY, 'Deploys all system modules')
 
     hre.deployer.routerModule = ['GenRouter', hre.network.name, instance].map(capitalize).join('');
 
-    const { paths } = hre.deployer;
-
-    paths.deployments = path.resolve(hre.config.paths.root, hre.config.deployer.paths.deployments);
-    paths.modules = path.resolve(hre.config.paths.root, hre.config.deployer.paths.modules);
-    paths.network = path.join(paths.deployments, hre.network.name);
-    paths.instance = path.join(paths.network, instance);
-    paths.extended = path.join(paths.instance, 'extended');
-    paths.routerTemplate = path.resolve(__dirname, '../templates/GenRouter.sol.mustache');
-    paths.routerPath = relativePath(
-      path.join(hre.config.paths.sources, `${hre.deployer.routerModule}.sol`)
-    );
-    paths.proxyPath = relativePath(
-      path.join(hre.config.paths.sources, `${hre.config.deployer.proxyName}.sol`)
-    );
+    hre.deployer.paths = getDeploymentPaths(instance);
 
     await hre.run(SUBTASK_PREPARE_DEPLOYMENT, taskArguments);
     await hre.run(SUBTASK_PRINT_INFO, taskArguments);

--- a/packages/deployer/test/sample-project/test/SettingsModule.test.js
+++ b/packages/deployer/test/sample-project/test/SettingsModule.test.js
@@ -1,0 +1,31 @@
+const hre = require('hardhat');
+const assert = require('assert');
+const { ethers } = hre;
+const { getMainProxyAddress } = require('../../../utils/deployments');
+
+describe('SettingsModule', () => {
+  let SettingsModule;
+
+  let owner;
+
+  before('identify signers', async () => {
+    [owner] = await ethers.getSigners();
+  });
+
+  before('identify modules', async () => {
+    const proxyAddress = getMainProxyAddress();
+
+    SettingsModule = await ethers.getContractAt('SettingsModule', proxyAddress);
+  });
+
+  describe('when the owner sets a value', () => {
+    before('change a setting', async () => {
+      const tx = await SettingsModule.connect(owner).setASettingValue(42);
+      await tx.wait();
+    });
+
+    it('shows that the value was set', async () => {
+      assert.equal(await SettingsModule.getASettingValue(), 42);
+    });
+  });
+});

--- a/packages/deployer/utils/deployments.js
+++ b/packages/deployer/utils/deployments.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+const path = require('path');
+const glob = require('glob');
+const naturalCompare = require('string-natural-compare');
+const relativePath = require('./relative-path');
+
+// Regex for deployment file formats, e.g.: 2021-08-31-00-sirius.json
+const DEPLOYMENT_FILE_FORMAT = /^[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2,}(?:-[a-z0-9]+)?\.json$/;
+
+function getMainProxyAddress(instance = 'official') {
+  const data = getDeploymentData(instance);
+
+  return data.contracts['contracts/MainProxy.sol'].deployedAddress;
+}
+
+function getDeploymentData(instance = 'official') {
+  const file = getDeploymentFile(instance);
+
+  if (!file) {
+    throw new Error(
+      `No deployment file found on network "${hre.network.name}" for instance "${instance}".`
+    );
+  }
+
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function getDeploymentFile(instance = 'official') {
+  const deployments = getDeploymentFiles(instance);
+
+  return deployments.length > 0 ? deployments[deployments.length - 1] : null;
+}
+
+function getDeploymentFiles(instance = 'official') {
+  const paths = getDeploymentPaths(instance);
+  const folder = paths.instance;
+
+  return glob
+    .sync(`${folder}/*.json`)
+    .filter((file) => DEPLOYMENT_FILE_FORMAT.test(path.basename(file)))
+    .sort(naturalCompare);
+}
+
+function getDeploymentPaths(instance = 'official') {
+  const paths = {};
+
+  paths.deployments = path.resolve(hre.config.paths.root, hre.config.deployer.paths.deployments);
+  paths.modules = path.resolve(hre.config.paths.root, hre.config.deployer.paths.modules);
+  paths.network = path.join(paths.deployments, hre.network.name);
+  paths.instance = path.join(paths.network, instance);
+  paths.extended = path.join(paths.instance, 'extended');
+  paths.routerTemplate = path.resolve(__dirname, '../templates/GenRouter.sol.mustache');
+  paths.routerPath = relativePath(
+    path.join(hre.config.paths.sources, `${hre.deployer.routerModule}.sol`)
+  );
+  paths.proxyPath = relativePath(
+    path.join(hre.config.paths.sources, `${hre.config.deployer.proxyName}.sol`)
+  );
+
+  return paths;
+}
+
+module.exports = {
+  getMainProxyAddress,
+  getDeploymentFile,
+  getDeploymentFiles,
+  getDeploymentData,
+  getDeploymentPaths,
+};


### PR DESCRIPTION
Fix #26 

The gist of this PR is the addition of the new file:
`deployer/test/sample-project/test/SettingsModule.test.js`

This tests works on an existing deployment on local, and is run with
`npx hardhat test`

The tricky part was getting the address of the main proxy of the latest deployment. A lot of logic could have been added to the test for that, but all tests would need that logic. So, perhaps it could be a helper? But then projects using the plugin would need these helpers, and the logic probably already exists in the deployer itself. So, I tried to start exposing these "common operations" from the deployer:
https://github.com/Synthetixio/synthetix-v3/pull/50/files#diff-d27aebaf2b1cb5b872cfa531db45487b4f7376085356e4886d1024107b55d5deR16

Indeed, it does make tests really simple, but I'm left with the feeling that coding the plugin with hre data injection makes these exposed tools weird. Notice how I moved some stuff out of `prepare-deployments` because it involved the logic needed by the test.

My question is: if there was no hre runtime injection, wouldn't all the tools be immediately usable by outsiders? Consider that outsiders don't have this runtime environment that gets populated during deployment.

