### PR TITLE
Add custom alphanumeric type for hardhat argument

### DIFF
--- a/packages/deployer/tasks/deploy.js
+++ b/packages/deployer/tasks/deploy.js
@@ -18,32 +18,24 @@ const logger = require('../utils/logger');
 const prompter = require('../utils/prompter');
 const relativePath = require('../utils/relative-path');
 const { capitalize } = require('../utils/string');
-
-const isWord = (str) => /^[\w\d]+$/.test(str);
+const types = require('../utils/argument-types');
 
 task(TASK_DEPLOY, 'Deploys all system modules')
   .addFlag('noConfirm', 'Skip all confirmation prompts', false)
   .addFlag('debug', 'Display debug logs', false)
   .addFlag('clear', 'Clear all previous deployment data for the selected network', false)
-  .addOptionalParam('alias', 'The alias name for the deployment')
-  .addOptionalParam('instance', 'The name of the target instance for deployment', 'official')
+  .addOptionalParam('alias', 'The alias name for the deployment', undefined, types.alphanumeric)
+  .addOptionalParam(
+    'instance',
+    'The name of the target instance for deployment',
+    'official',
+    types.alphanumeric
+  )
   .setAction(async (taskArguments, hre) => {
-    const { alias, instance, debug, noConfirm } = taskArguments;
+    const { instance, debug, noConfirm } = taskArguments;
 
     logger.debugging = debug;
     prompter.noConfirm = noConfirm;
-
-    if (!isWord(instance)) {
-      throw new Error(
-        'Invalid --instance parameter value, it can only be a lowercase word with numbers'
-      );
-    }
-
-    if (alias && !isWord(alias)) {
-      throw new Error(
-        'Invalid --alias parameter value, it can only be a lowercase word with numbers'
-      );
-    }
 
     hre.deployer.routerModule = ['GenRouter', hre.network.name, instance].map(capitalize).join('');
 

--- a/packages/deployer/utils/argument-types.js
+++ b/packages/deployer/utils/argument-types.js
@@ -1,0 +1,21 @@
+const { ERRORS } = require('hardhat/internal/core/errors-list');
+const { HardhatError } = require('hardhat/internal/core/errors');
+
+const alphanumeric = {
+  name: 'word',
+  parse: (argName, value) => (typeof value === 'string' ? value.toLowerCase() : value),
+  validate: (argName, value) => {
+    const valid = typeof value === 'string' && /^[a-z0-9]+$/.test(value);
+    if (!valid) {
+      throw new HardhatError(ERRORS.ARGUMENTS.INVALID_VALUE_FOR_TYPE, {
+        value,
+        name: argName,
+        type: alphanumeric.name,
+      });
+    }
+  },
+};
+
+module.exports = {
+  alphanumeric,
+};


### PR DESCRIPTION
This PRs adds a custom hardhat argument type for sake of celemines on the main deploy task. This validation is necessary to make sure that we generate correct deployment files formats.