### PR TITLE
Refactor utils dependance on global environment

### DIFF
--- a/packages/deployer/extensions/config.js
+++ b/packages/deployer/extensions/config.js
@@ -3,8 +3,8 @@ const { extendConfig } = require('hardhat/config');
 
 const DEFAULTS = {
   proxyName: 'MainProxy',
-  routerTemplate: path.resolve(__dirname, '../templates/GenRouter.sol.mustache'),
   paths: {
+    routerTemplate: path.resolve(__dirname, '../templates/GenRouter.sol.mustache'),
     modules: 'contracts/modules',
     deployments: 'deployments',
   },
@@ -14,13 +14,19 @@ extendConfig((config, userConfig) => {
   const { root } = config.paths;
   const { deployer: givenConfig = {} } = userConfig;
 
+  // Resolve the absolute path from the root of the configurable path
+  function resolvePath(key) {
+    return path.resolve(root, givenConfig?.paths?.[key] || DEFAULTS.paths[key]);
+  }
+
   config.deployer = {
     ...DEFAULTS,
     ...givenConfig,
     paths: {
       ...DEFAULTS.paths,
-      modules: path.resolve(root, givenConfig.paths.modules || DEFAULTS.paths.modules),
-      deployments: path.resolve(root, givenConfig.paths.deployments || DEFAULTS.paths.deployments),
+      routerTemplate: resolvePath('routerTemplate'),
+      modules: resolvePath('modules'),
+      deployments: resolvePath('deployments'),
     },
   };
 });

--- a/packages/deployer/extensions/config.js
+++ b/packages/deployer/extensions/config.js
@@ -1,23 +1,26 @@
+const path = require('path');
 const { extendConfig } = require('hardhat/config');
 
-extendConfig((config, userConfig) => {
-  if (!userConfig.deployer) {
-    throw new Error('Deployer plugin config not found in hardhat.config.js');
-  }
+const DEFAULTS = {
+  proxyName: 'MainProxy',
+  routerTemplate: path.resolve(__dirname, '../templates/GenRouter.sol.mustache'),
+  paths: {
+    modules: 'contracts/modules',
+    deployments: 'deployments',
+  },
+};
 
-  if (!userConfig.deployer.proxyName) {
-    throw new Error(
-      'Please specify a "deployer.proxyName" in your hardhat configuration file. This is the main entry point of the system, and should be a proxy that forwards calls to an implementation that has an `upgradeTo` function.'
-    );
-  }
+extendConfig((config, userConfig) => {
+  const { root } = config.paths;
+  const { deployer: givenConfig = {} } = userConfig;
 
   config.deployer = {
-    proxyName: '',
-    ...userConfig.deployer,
+    ...DEFAULTS,
+    ...givenConfig,
     paths: {
-      modules: 'contracts/modules',
-      deployments: 'deployments',
-      ...(userConfig.deployer.paths || {}),
+      ...DEFAULTS.paths,
+      modules: path.resolve(root, givenConfig.paths.modules || DEFAULTS.paths.modules),
+      deployments: path.resolve(root, givenConfig.paths.deployments || DEFAULTS.paths.deployments),
     },
   };
 });

--- a/packages/deployer/subtasks/deploy-router.js
+++ b/packages/deployer/subtasks/deploy-router.js
@@ -9,7 +9,7 @@ subtask(SUBTASK_DEPLOY_ROUTER).setAction(async (_, hre) => {
 
   await hre.run(TASK_COMPILE, { force: false, quiet: true });
 
-  const contractPath = hre.deployer.paths.routerPath;
+  const contractPath = hre.deployer.paths.router;
   let contractData = hre.deployer.data.contracts[contractPath];
 
   if (!contractData) {

--- a/packages/deployer/subtasks/generate-router.js
+++ b/packages/deployer/subtasks/generate-router.js
@@ -13,7 +13,10 @@ subtask(
   SUBTASK_GENERATE_ROUTER_SOURCE,
   'Reads deployed modules from the deployment data file and generates the source for a new router contract.'
 ).setAction(async (_, hre) => {
+  const routerPath = hre.deployer.paths.router;
+
   logger.subtitle('Generating router source');
+  logger.info(`location: ${routerPath}`);
 
   const modulesPaths = Object.keys(hre.deployer.data.contracts.modules);
   logger.debug(`modules: ${JSON.stringify(modulesPaths, null, 2)}`);
@@ -31,14 +34,13 @@ subtask(
     repo: package.repository?.url || '',
     branch: getBranch(),
     commit: getCommit(),
-    moduleName: getContractNameFromPath(hre.deployer.paths.routerPath),
+    moduleName: getContractNameFromPath(routerPath),
     modules: _renderModules(hre.deployer.data.contracts.modules),
     selectors: _renderSelectors({ binaryData }),
   });
 
-  logger.debug(`generated source: ${generatedSource}`);
+  logger.debug(`Generated source: ${generatedSource}`);
 
-  const { routerPath } = hre.deployer.paths;
   const currentSource = fs.existsSync(routerPath) ? fs.readFileSync(routerPath) : '';
   if (currentSource !== generatedSource) {
     fs.writeFileSync(routerPath, generatedSource);

--- a/packages/deployer/subtasks/generate-router.js
+++ b/packages/deployer/subtasks/generate-router.js
@@ -26,12 +26,12 @@ subtask(
 
   const package = readPackageJson();
 
-  const generatedSource = renderTemplate(hre.deployer.paths.routerTemplate, {
+  const generatedSource = renderTemplate(hre.config.deployer.paths.routerTemplate, {
     project: package.name,
     repo: package.repository?.url || '',
     branch: getBranch(),
     commit: getCommit(),
-    moduleName: hre.deployer.routerModule,
+    moduleName: getContractNameFromPath(hre.deployer.paths.routerPath),
     modules: _renderModules(hre.deployer.data.contracts.modules),
     selectors: _renderSelectors({ binaryData }),
   });

--- a/packages/deployer/subtasks/prepare-deployment.js
+++ b/packages/deployer/subtasks/prepare-deployment.js
@@ -42,7 +42,6 @@ subtask(
   hre.deployer.data = autosaveObject(hre.deployer.file, DEPLOYMENT_SCHEMA);
 
   if (previousFile) {
-    hre.deployer.previousFile = previousFile;
     hre.deployer.previousData = JSON.parse(fs.readFileSync(previousFile));
   }
 });

--- a/packages/deployer/subtasks/prepare-deployment.js
+++ b/packages/deployer/subtasks/prepare-deployment.js
@@ -26,15 +26,17 @@ subtask(
   SUBTASK_PREPARE_DEPLOYMENT,
   'Prepares the deployment file associated with the active deployment.'
 ).setAction(async (taskArguments, hre) => {
-  const { clear, alias, instance } = taskArguments;
+  const { clear, alias } = taskArguments;
+
+  const deploymentsFolder = hre.deployer.paths.deployments;
 
   if (clear) {
-    await _clearDeploymentData(hre.deployer.paths.instance);
+    await _clearDeploymentData(deploymentsFolder);
   }
 
-  mkdirp.sync(hre.deployer.paths.instance);
+  mkdirp.sync(deploymentsFolder);
 
-  const { previousFile, currentFile } = await _determineDeploymentFiles(instance, alias);
+  const { previousFile, currentFile } = await _determineDeploymentFiles(deploymentsFolder, alias);
 
   hre.deployer.file = currentFile;
   hre.deployer.data = autosaveObject(hre.deployer.file, DEPLOYMENT_SCHEMA);
@@ -63,10 +65,8 @@ async function _clearDeploymentData(folder) {
  * @param {string} [alias]
  * @returns {{ currentFile: string, previousFile: string }}
  */
-async function _determineDeploymentFiles(instance, alias) {
-  const folder = hre.deployer.paths.instance;
-
-  const deployments = getDeploymentFiles(instance);
+async function _determineDeploymentFiles(deploymentsFolder, alias) {
+  const deployments = getDeploymentFiles(deploymentsFolder);
   const previousFile = deployments.length > 0 ? deployments[deployments.length - 1] : null;
 
   // Check if there is an unfinished deployment and prompt the user if we should
@@ -108,7 +108,10 @@ async function _determineDeploymentFiles(instance, alias) {
     number = `${previousNumber + 1}`.padStart(2, '0');
   }
 
-  const currentFile = path.join(folder, `${today}-${number}${alias ? `-${alias}` : ''}.json`);
+  const currentFile = path.join(
+    deploymentsFolder,
+    `${today}-${number}${alias ? `-${alias}` : ''}.json`
+  );
 
   return {
     previousFile,

--- a/packages/deployer/subtasks/sync-sources.js
+++ b/packages/deployer/subtasks/sync-sources.js
@@ -1,10 +1,8 @@
-const path = require('path');
-const glob = require('glob');
 const { subtask } = require('hardhat/config');
 const logger = require('../utils/logger');
 const prompter = require('../utils/prompter');
+const { getModulesPaths } = require('../utils/deployments');
 const { SUBTASK_SYNC_SOURCES } = require('../task-names');
-const relativePath = require('../utils/relative-path');
 
 /**
  * Synchronizes the deployment file with the latest module sources.
@@ -17,7 +15,7 @@ subtask(
 ).setAction(async (_, hre) => {
   logger.subtitle('Syncing solidity sources with deployment data');
 
-  hre.deployer.sources = _getSources(hre.config.deployer.paths.modules);
+  hre.deployer.sources = getModulesPaths(hre.config.deployer.paths.modules);
 
   const { data, sources, previousData } = hre.deployer;
   const removed = await _removeDeletedSources({ sources, previousData });
@@ -27,10 +25,6 @@ subtask(
     logger.checked('Deployment data is in sync with sources');
   }
 });
-
-function _getSources(folder) {
-  return glob.sync(path.join(folder, '**/*.sol')).map(relativePath);
-}
 
 async function _removeDeletedSources({ sources, previousData }) {
   if (!previousData) return false;

--- a/packages/deployer/subtasks/sync-sources.js
+++ b/packages/deployer/subtasks/sync-sources.js
@@ -17,7 +17,7 @@ subtask(
 ).setAction(async (_, hre) => {
   logger.subtitle('Syncing solidity sources with deployment data');
 
-  hre.deployer.sources = _getSources(hre.deployer.paths.modules);
+  hre.deployer.sources = _getSources(hre.config.deployer.paths.modules);
 
   const { data, sources, previousData } = hre.deployer;
   const removed = await _removeDeletedSources({ sources, previousData });

--- a/packages/deployer/subtasks/upgrade-proxy.js
+++ b/packages/deployer/subtasks/upgrade-proxy.js
@@ -41,7 +41,7 @@ subtask(
   logger.subtitle('Upgrading main proxy');
 
   const proxyPath = getProxyPath(hre.config);
-  const routerAddress = _getDeployedAddress(hre.deployer.paths.routerPath, hre);
+  const routerAddress = _getDeployedAddress(hre.deployer.paths.router, hre);
 
   logger.info(`Target implementation: ${routerAddress}`);
 

--- a/packages/deployer/subtasks/validate-router.js
+++ b/packages/deployer/subtasks/validate-router.js
@@ -11,7 +11,7 @@ subtask(
   logger.subtitle('Validating router');
 
   await _selectorsExistInSource({
-    routerPath: hre.deployer.paths.routerPath,
+    routerPath: hre.deployer.paths.router,
     modules: Object.keys(hre.deployer.data.contracts.modules).map(getContractNameFromPath),
   });
 

--- a/packages/deployer/tasks/deploy.js
+++ b/packages/deployer/tasks/deploy.js
@@ -35,7 +35,10 @@ task(TASK_DEPLOY, 'Deploys all system modules')
     logger.debugging = debug;
     prompter.noConfirm = noConfirm;
 
-    hre.deployer.paths = getDeploymentPaths(instance);
+    hre.deployer.paths = getDeploymentPaths(hre.config, {
+      instance,
+      network: hre.network.name,
+    });
 
     await hre.run(SUBTASK_PREPARE_DEPLOYMENT, taskArguments);
     await hre.run(SUBTASK_PRINT_INFO, taskArguments);

--- a/packages/deployer/tasks/deploy.js
+++ b/packages/deployer/tasks/deploy.js
@@ -16,7 +16,6 @@ const {
 const logger = require('../utils/logger');
 const prompter = require('../utils/prompter');
 const { getDeploymentPaths } = require('../utils/deployments');
-const { capitalize } = require('../utils/string');
 const types = require('../utils/argument-types');
 
 task(TASK_DEPLOY, 'Deploys all system modules')
@@ -35,8 +34,6 @@ task(TASK_DEPLOY, 'Deploys all system modules')
 
     logger.debugging = debug;
     prompter.noConfirm = noConfirm;
-
-    hre.deployer.routerModule = ['GenRouter', hre.network.name, instance].map(capitalize).join('');
 
     hre.deployer.paths = getDeploymentPaths(instance);
 

--- a/packages/deployer/test/sample-project/test/SettingsModule.test.js
+++ b/packages/deployer/test/sample-project/test/SettingsModule.test.js
@@ -1,6 +1,6 @@
 const hre = require('hardhat');
 const assert = require('assert');
-const { ethers } = hre;
+const { config, ethers } = hre;
 const { getMainProxyAddress } = require('../../../utils/deployments');
 
 describe('SettingsModule', () => {
@@ -13,8 +13,7 @@ describe('SettingsModule', () => {
   });
 
   before('identify modules', async () => {
-    const proxyAddress = getMainProxyAddress();
-
+    const proxyAddress = getMainProxyAddress(config);
     SettingsModule = await ethers.getContractAt('SettingsModule', proxyAddress);
   });
 

--- a/packages/deployer/utils/deployments.js
+++ b/packages/deployer/utils/deployments.js
@@ -3,6 +3,7 @@ const path = require('path');
 const glob = require('glob');
 const naturalCompare = require('string-natural-compare');
 const relativePath = require('./relative-path');
+const { capitalize } = require('./string');
 
 // Regex for deployment file formats, e.g.: 2021-08-31-00-sirius.json
 const DEPLOYMENT_FILE_FORMAT = /^[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2,}(?:-[a-z0-9]+)?\.json$/;
@@ -42,20 +43,19 @@ function getDeploymentFiles(instance = 'official') {
 }
 
 function getDeploymentPaths(instance = 'official') {
+  const { name: network } = hre.network;
   const paths = {};
 
-  paths.deployments = path.resolve(hre.config.paths.root, hre.config.deployer.paths.deployments);
-  paths.modules = path.resolve(hre.config.paths.root, hre.config.deployer.paths.modules);
-  paths.network = path.join(paths.deployments, hre.network.name);
+  paths.network = path.join(hre.config.deployer.paths.deployments, network);
   paths.instance = path.join(paths.network, instance);
   paths.extended = path.join(paths.instance, 'extended');
-  paths.routerTemplate = path.resolve(__dirname, '../templates/GenRouter.sol.mustache');
-  paths.routerPath = relativePath(
-    path.join(hre.config.paths.sources, `${hre.deployer.routerModule}.sol`)
-  );
+
   paths.proxyPath = relativePath(
     path.join(hre.config.paths.sources, `${hre.config.deployer.proxyName}.sol`)
   );
+
+  const routerModule = ['GenRouter', network, instance].map(capitalize).join('');
+  paths.routerPath = relativePath(path.join(hre.config.paths.sources, `${routerModule}.sol`));
 
   return paths;
 }

--- a/packages/deployer/utils/deployments.js
+++ b/packages/deployer/utils/deployments.js
@@ -36,8 +36,17 @@ function getDeploymentFiles(deploymentsFolder) {
     .sort(naturalCompare);
 }
 
+function getModulesPaths(config) {
+  return glob
+    .sync(path.join(config.deployer.paths.modules, '**/*.sol'))
+    .map((source) => relativePath(source, hre.config.paths.root));
+}
+
 function getProxyPath(config) {
-  return relativePath(path.join(config.paths.sources, `${config.deployer.proxyName}.sol`));
+  return relativePath(
+    path.join(config.paths.sources, `${config.deployer.proxyName}.sol`),
+    config.paths.root
+  );
 }
 
 function getRouterName({ network = 'local', instance = 'official' } = {}) {
@@ -48,7 +57,11 @@ function getDeploymentPaths(config, { network = 'local', instance = 'official' }
   return {
     deployments: path.join(config.deployer.paths.deployments, network, instance),
     router: relativePath(
-      path.join(config.paths.sources, `${getRouterName({ network, instance })}.sol`)
+      path.join(
+        config.paths.sources,
+        `${getRouterName({ network, instance })}.sol`,
+        config.paths.root
+      )
     ),
   };
 }
@@ -60,5 +73,6 @@ module.exports = {
   getDeploymentData,
   getDeploymentPaths,
   getRouterName,
+  getModulesPaths,
   getProxyPath,
 };

--- a/packages/deployer/utils/deployments.js
+++ b/packages/deployer/utils/deployments.js
@@ -42,20 +42,19 @@ function getDeploymentFiles(instance = 'official') {
     .sort(naturalCompare);
 }
 
-function getDeploymentPaths(instance = 'official') {
-  const { name: network } = hre.network;
+function getProxyPath(config) {
+  return relativePath(path.join(config.paths.sources, `${config.deployer.proxyName}.sol`));
+}
+
+function getDeploymentPaths(config, { network = 'local', instance = 'official' }) {
   const paths = {};
 
-  paths.network = path.join(hre.config.deployer.paths.deployments, network);
+  paths.network = path.join(config.deployer.paths.deployments, network);
   paths.instance = path.join(paths.network, instance);
   paths.extended = path.join(paths.instance, 'extended');
 
-  paths.proxyPath = relativePath(
-    path.join(hre.config.paths.sources, `${hre.config.deployer.proxyName}.sol`)
-  );
-
   const routerModule = ['GenRouter', network, instance].map(capitalize).join('');
-  paths.routerPath = relativePath(path.join(hre.config.paths.sources, `${routerModule}.sol`));
+  paths.routerPath = relativePath(path.join(config.paths.sources, `${routerModule}.sol`));
 
   return paths;
 }
@@ -66,4 +65,5 @@ module.exports = {
   getDeploymentFiles,
   getDeploymentData,
   getDeploymentPaths,
+  getProxyPath,
 };

--- a/packages/deployer/utils/deployments.js
+++ b/packages/deployer/utils/deployments.js
@@ -8,36 +8,30 @@ const { capitalize } = require('./string');
 // Regex for deployment file formats, e.g.: 2021-08-31-00-sirius.json
 const DEPLOYMENT_FILE_FORMAT = /^[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2,}(?:-[a-z0-9]+)?\.json$/;
 
-function getMainProxyAddress(instance = 'official') {
-  const data = getDeploymentData(instance);
-
-  return data.contracts['contracts/MainProxy.sol'].deployedAddress;
+function getMainProxyAddress(config, { network = 'local', instance = 'official' } = {}) {
+  const paths = getDeploymentPaths(config, { network, instance });
+  const data = getDeploymentData(paths.deployments);
+  return data.contracts[getProxyPath(config)].deployedAddress;
 }
 
-function getDeploymentData(instance = 'official') {
-  const file = getDeploymentFile(instance);
+function getDeploymentData(deploymentsFolder) {
+  const file = getDeploymentFile(deploymentsFolder);
 
   if (!file) {
-    throw new Error(
-      `No deployment file found on network "${hre.network.name}" for instance "${instance}".`
-    );
+    throw new Error(`No deployment file found on "${deploymentsFolder}".`);
   }
 
   return JSON.parse(fs.readFileSync(file, 'utf8'));
 }
 
-function getDeploymentFile(instance = 'official') {
-  const deployments = getDeploymentFiles(instance);
-
+function getDeploymentFile(deploymentsFolder) {
+  const deployments = getDeploymentFiles(deploymentsFolder);
   return deployments.length > 0 ? deployments[deployments.length - 1] : null;
 }
 
-function getDeploymentFiles(instance = 'official') {
-  const paths = getDeploymentPaths(instance);
-  const folder = paths.instance;
-
+function getDeploymentFiles(deploymentsFolder) {
   return glob
-    .sync(`${folder}/*.json`)
+    .sync(`${deploymentsFolder}/*.json`)
     .filter((file) => DEPLOYMENT_FILE_FORMAT.test(path.basename(file)))
     .sort(naturalCompare);
 }
@@ -46,17 +40,17 @@ function getProxyPath(config) {
   return relativePath(path.join(config.paths.sources, `${config.deployer.proxyName}.sol`));
 }
 
-function getDeploymentPaths(config, { network = 'local', instance = 'official' }) {
-  const paths = {};
+function getRouterName({ network = 'local', instance = 'official' } = {}) {
+  return ['GenRouter', network, instance].map(capitalize).join('');
+}
 
-  paths.network = path.join(config.deployer.paths.deployments, network);
-  paths.instance = path.join(paths.network, instance);
-  paths.extended = path.join(paths.instance, 'extended');
-
-  const routerModule = ['GenRouter', network, instance].map(capitalize).join('');
-  paths.routerPath = relativePath(path.join(config.paths.sources, `${routerModule}.sol`));
-
-  return paths;
+function getDeploymentPaths(config, { network = 'local', instance = 'official' } = {}) {
+  return {
+    deployments: path.join(config.deployer.paths.deployments, network, instance),
+    router: relativePath(
+      path.join(config.paths.sources, `${getRouterName({ network, instance })}.sol`)
+    ),
+  };
 }
 
 module.exports = {
@@ -65,5 +59,6 @@ module.exports = {
   getDeploymentFiles,
   getDeploymentData,
   getDeploymentPaths,
+  getRouterName,
   getProxyPath,
 };

--- a/packages/deployer/utils/relative-path.js
+++ b/packages/deployer/utils/relative-path.js
@@ -1,8 +1,12 @@
 /**
- * Get the relative path from the current running hardhat project folder.
+ * Get the relative path from the folders, without the leading points.
+ * E.g.:
+ *   const relative = relativePath('/User/hardhat/contracts/modules/Proxy.sol', '/User/hardhat')
+ *   // contracts/modules/Proxy.sol
  * @param {string} filepath
+ * @param {string} [from=process.cwd()]
  * @returns {string}
  */
-module.exports = function relativePath(filepath) {
-  return filepath.replace(new RegExp(`^${hre.config.paths.root}/`), '');
+module.exports = function relativePath(filepath, from = process.cwd()) {
+  return filepath.replace(new RegExp(`^${from}/`), '');
 };


### PR DESCRIPTION
Closes #55

The objetive of this PR is to be more compliant with common hardhat plugin config conventions, and be able to expose more utils without being dependent on global `hre` environment.

* It moves static deployer paths definitions from `hre.deployer.paths` to `hre.config.deployer.paths`
* Removes paths that can be dynamically calculated using utils from `hre.deployer.paths.*`
* Removes all dependencies of a global `hre` on `utils/deployments.js`