### PR TITLE
Fix Router path resolving

### DIFF
--- a/packages/deployer/subtasks/sync-sources.js
+++ b/packages/deployer/subtasks/sync-sources.js
@@ -15,9 +15,9 @@ subtask(
 ).setAction(async (_, hre) => {
   logger.subtitle('Syncing solidity sources with deployment data');
 
-  hre.deployer.sources = getModulesPaths(hre.config.deployer.paths.modules);
+  const { data, previousData } = hre.deployer;
+  const sources = getModulesPaths(hre.config);
 
-  const { data, sources, previousData } = hre.deployer;
   const removed = await _removeDeletedSources({ sources, previousData });
   const added = await _addNewSources({ sources, data, previousData });
 

--- a/packages/deployer/utils/deployments.js
+++ b/packages/deployer/utils/deployments.js
@@ -57,11 +57,8 @@ function getDeploymentPaths(config, { network = 'local', instance = 'official' }
   return {
     deployments: path.join(config.deployer.paths.deployments, network, instance),
     router: relativePath(
-      path.join(
-        config.paths.sources,
-        `${getRouterName({ network, instance })}.sol`,
-        config.paths.root
-      )
+      path.join(config.paths.sources, `${getRouterName({ network, instance })}.sol`),
+      config.paths.root
     ),
   };
 }


### PR DESCRIPTION
This PR removes `hre.deployer.sources` from the context, and fixes the calculation of the Router's path.