### PR TITLE
Clean up environment.js

### DIFF
--- a/packages/deployer/extensions/environment.js
+++ b/packages/deployer/extensions/environment.js
@@ -10,8 +10,8 @@ extendEnvironment((hre) => {
     paths: {
       routerTemplate: path.resolve(__dirname, '../templates/Router.sol.mustache'),
     },
-    data: null,
-    previousData: null
+    deployment: null,
+    previousDeployment: null,
   };
 
   // Prevent any properties being added to hre.deployer

--- a/packages/deployer/extensions/environment.js
+++ b/packages/deployer/extensions/environment.js
@@ -13,4 +13,8 @@ extendEnvironment((hre) => {
     data: null,
     previousData: null
   };
+
+  // Prevent any properties being added to hre.deployer
+  // other than those defined above.
+  Object.preventExtensions(hre.deployer);
 });

--- a/packages/deployer/extensions/environment.js
+++ b/packages/deployer/extensions/environment.js
@@ -11,5 +11,6 @@ extendEnvironment((hre) => {
       routerTemplate: path.resolve(__dirname, '../templates/Router.sol.mustache'),
     },
     data: null,
+    previousData: null
   };
 });

--- a/packages/deployer/index.js
+++ b/packages/deployer/index.js
@@ -1,6 +1,10 @@
 const fs = require('fs');
 const path = require('path');
 
+// Forces "use strict" on all modules.
+require('use-strict');
+
+// Loads all plugin files.
 ['tasks', 'subtasks', 'extensions'].forEach((folder) =>
   fs
     .readdirSync(path.join(__dirname, folder))

--- a/packages/deployer/internal/autosave-object.js
+++ b/packages/deployer/internal/autosave-object.js
@@ -45,6 +45,8 @@ module.exports = function autosaveObject(file, initialState = {}) {
         write(file, data);
         logger.debug(`File saved (${Date.now() - now}ms): ${relativePath(file)}`);
       }
+
+      return true;
     },
   };
 

--- a/packages/deployer/internal/process-transactions.js
+++ b/packages/deployer/internal/process-transactions.js
@@ -1,5 +1,5 @@
 function processTransaction(transaction, hre) {
-  hre.deployer.data.transactions[transaction.hash] = { status: 'pending' };
+  hre.deployer.deployment.transactions[transaction.hash] = { status: 'pending' };
 }
 
 function processReceipt(receipt, hre) {
@@ -7,13 +7,13 @@ function processReceipt(receipt, hre) {
   const { gasUsed } = receipt;
   const status = receipt.status === 1 ? 'confirmed' : 'failed';
 
-  hre.deployer.data.transactions[receipt.transactionHash].status = status;
+  hre.deployer.deployment.transactions[receipt.transactionHash].status = status;
 
-  const totalGasUsed = hre.ethers.BigNumber.from(hre.deployer.data.properties.totalGasUsed)
+  const totalGasUsed = hre.ethers.BigNumber.from(hre.deployer.deployment.properties.totalGasUsed)
     .add(gasUsed)
     .toString();
 
-  hre.deployer.data.properties.totalGasUsed = totalGasUsed;
+  hre.deployer.deployment.properties.totalGasUsed = totalGasUsed;
 
   return { status, gasUsed };
 }

--- a/packages/deployer/package-lock.json
+++ b/packages/deployer/package-lock.json
@@ -15,7 +15,8 @@
         "mkdirp": "1.0.4",
         "mustache": "4.2.0",
         "rimraf": "3.0.2",
-        "string-natural-compare": "3.0.1"
+        "string-natural-compare": "3.0.1",
+        "use-strict": "1.0.1"
       },
       "peerDependencies": {
         "hardhat": "^2.0.0"
@@ -3830,6 +3831,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/use-strict": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/use-strict/-/use-strict-1.0.1.tgz",
+      "integrity": "sha1-C7gNlPSaSgUZK4Sox9NOlfGn46A="
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -7140,6 +7146,11 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "peer": true
+    },
+    "use-strict": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/use-strict/-/use-strict-1.0.1.tgz",
+      "integrity": "sha1-C7gNlPSaSgUZK4Sox9NOlfGn46A="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -19,6 +19,7 @@
     "mkdirp": "1.0.4",
     "mustache": "4.2.0",
     "rimraf": "3.0.2",
-    "string-natural-compare": "3.0.1"
+    "string-natural-compare": "3.0.1",
+    "use-strict": "1.0.1"
   }
 }

--- a/packages/deployer/subtasks/deploy-modules.js
+++ b/packages/deployer/subtasks/deploy-modules.js
@@ -9,7 +9,7 @@ const { SUBTASK_DEPLOY_CONTRACTS, SUBTASK_DEPLOY_MODULES } = require('../task-na
 subtask(SUBTASK_DEPLOY_MODULES).setAction(async (_, hre) => {
   logger.subtitle('Deploying modules');
 
-  const modules = filterObject(hre.deployer.data.contracts, (c) => c.isModule);
+  const modules = filterObject(hre.deployer.deployment.contracts, (c) => c.isModule);
 
   const deployedSomething = await hre.run(SUBTASK_DEPLOY_CONTRACTS, {
     contracts: modules,
@@ -17,8 +17,8 @@ subtask(SUBTASK_DEPLOY_MODULES).setAction(async (_, hre) => {
 
   if (!deployedSomething) {
     logger.info('No modules need to be deployed, clearing generated files and exiting...');
-    logger.info(`Deleting ${hre.deployer.data.file}`);
-    rimraf.sync(path.resolve(hre.config.paths.root, hre.deployer.data.file));
+    logger.info(`Deleting ${hre.deployer.deployment.file}`);
+    rimraf.sync(path.resolve(hre.config.paths.root, hre.deployer.deployment.file));
     process.exit(0);
   }
 });

--- a/packages/deployer/subtasks/deploy-modules.js
+++ b/packages/deployer/subtasks/deploy-modules.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const rimraf = require('rimraf');
 const { subtask } = require('hardhat/config');
 
@@ -16,8 +17,8 @@ subtask(SUBTASK_DEPLOY_MODULES).setAction(async (_, hre) => {
 
   if (!deployedSomething) {
     logger.info('No modules need to be deployed, clearing generated files and exiting...');
-    logger.info(`Deleting ${hre.deployer.file}`);
-    rimraf.sync(hre.deployer.file);
+    logger.info(`Deleting ${hre.deployer.data.file}`);
+    rimraf.sync(path.resolve(hre.config.paths.root, hre.deployer.data.file));
     process.exit(0);
   }
 });

--- a/packages/deployer/subtasks/deploy-router.js
+++ b/packages/deployer/subtasks/deploy-router.js
@@ -17,16 +17,16 @@ subtask(SUBTASK_DEPLOY_ROUTER).setAction(async (_, hre) => {
     `${contractName}.sol`
   );
 
-  let contractData = hre.deployer.data.contracts[contractName];
+  let contractData = hre.deployer.deployment.contracts[contractName];
 
   if (!contractData) {
-    hre.deployer.data.contracts[contractName] = {
+    hre.deployer.deployment.contracts[contractName] = {
       source: conntractPath,
       deployedAddress: '',
       deployTransaction: '',
       bytecodeHash: '',
     };
-    contractData = hre.deployer.data.contracts[contractName];
+    contractData = hre.deployer.deployment.contracts[contractName];
   }
 
   await hre.run(SUBTASK_DEPLOY_CONTRACT, {

--- a/packages/deployer/subtasks/finalize-deployment.js
+++ b/packages/deployer/subtasks/finalize-deployment.js
@@ -10,13 +10,13 @@ const { SUBTASK_FINALIZE_DEPLOYMENT } = require('../task-names');
 subtask(SUBTASK_FINALIZE_DEPLOYMENT).setAction(async (_, hre) => {
   logger.subtitle('Finalizing deployment');
 
-  if (hre.deployer.data.properties.totalGasUsed === '0') {
+  if (hre.deployer.deployment.properties.totalGasUsed === '0') {
     logger.checked('Deployment did not produce any changes, deleting temp file');
 
-    fs.unlinkSync(path.resolve(hre.config.paths.root, hre.deployer.data.file));
+    fs.unlinkSync(path.resolve(hre.config.paths.root, hre.deployer.deployment.file));
   } else {
     logger.complete('Deployment marked as completed');
 
-    hre.deployer.data.properties.completed = true;
+    hre.deployer.deployment.properties.completed = true;
   }
 });

--- a/packages/deployer/subtasks/finalize-deployment.js
+++ b/packages/deployer/subtasks/finalize-deployment.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 const logger = require('@synthetixio/core-js/utils/logger');
 const { subtask } = require('hardhat/config');
 const { SUBTASK_FINALIZE_DEPLOYMENT } = require('../task-names');
@@ -12,7 +13,7 @@ subtask(SUBTASK_FINALIZE_DEPLOYMENT).setAction(async (_, hre) => {
   if (hre.deployer.data.properties.totalGasUsed === '0') {
     logger.checked('Deployment did not produce any changes, deleting temp file');
 
-    fs.unlinkSync(hre.deployer.file);
+    fs.unlinkSync(path.resolve(hre.config.paths.root, hre.deployer.data.file));
   } else {
     logger.complete('Deployment marked as completed');
 

--- a/packages/deployer/subtasks/generate-router.js
+++ b/packages/deployer/subtasks/generate-router.js
@@ -25,7 +25,7 @@ subtask(
   logger.subtitle('Generating router source');
   logger.info(`location: ${routerPath}`);
 
-  const modules = filterObject(hre.deployer.data.contracts, (c) => c.isModule);
+  const modules = filterObject(hre.deployer.deployment.contracts, (c) => c.isModule);
   const modulesNames = Object.keys(modules);
   logger.debug(`modules: ${JSON.stringify(modulesNames, null, 2)}`);
 

--- a/packages/deployer/subtasks/generate-router.js
+++ b/packages/deployer/subtasks/generate-router.js
@@ -35,11 +35,11 @@ subtask(
 
   const binaryData = _buildBinaryData({ selectors });
 
-  const package = readPackageJson();
+  const packageJson = readPackageJson();
 
   const generatedSource = renderTemplate(hre.deployer.paths.routerTemplate, {
-    project: package.name,
-    repo: package.repository?.url || '',
+    project: packageJson.name,
+    repo: packageJson.repository?.url || '',
     branch: getBranch(),
     commit: getCommit(),
     moduleName: routerName,

--- a/packages/deployer/subtasks/prepare-deployment.js
+++ b/packages/deployer/subtasks/prepare-deployment.js
@@ -36,11 +36,11 @@ subtask(
 
   const { previousFile, currentFile } = await _determineDeploymentFiles(deploymentsFolder, alias);
 
-  hre.deployer.data = autosaveObject(currentFile, DEPLOYMENT_SCHEMA);
-  hre.deployer.data.file = relativePath(currentFile);
+  hre.deployer.deployment = autosaveObject(currentFile, DEPLOYMENT_SCHEMA);
+  hre.deployer.deployment.file = relativePath(currentFile);
 
   if (previousFile) {
-    hre.deployer.previousData = JSON.parse(fs.readFileSync(previousFile));
+    hre.deployer.previousDeployment = JSON.parse(fs.readFileSync(previousFile));
   }
 });
 

--- a/packages/deployer/subtasks/prepare-deployment.js
+++ b/packages/deployer/subtasks/prepare-deployment.js
@@ -16,6 +16,7 @@ const DEPLOYMENT_SCHEMA = {
   },
   transactions: {},
   contracts: {},
+  file: null,
 };
 
 subtask(
@@ -35,8 +36,8 @@ subtask(
 
   const { previousFile, currentFile } = await _determineDeploymentFiles(deploymentsFolder, alias);
 
-  hre.deployer.file = currentFile;
-  hre.deployer.data = autosaveObject(hre.deployer.file, DEPLOYMENT_SCHEMA);
+  hre.deployer.data = autosaveObject(currentFile, DEPLOYMENT_SCHEMA);
+  hre.deployer.data.file = relativePath(currentFile);
 
   if (previousFile) {
     hre.deployer.previousData = JSON.parse(fs.readFileSync(previousFile));

--- a/packages/deployer/subtasks/print-info.js
+++ b/packages/deployer/subtasks/print-info.js
@@ -5,7 +5,6 @@ const { subtask } = require('hardhat/config');
 
 const logger = require('@synthetixio/core-js/utils/logger');
 const prompter = require('@synthetixio/core-js/utils/prompter');
-const relativePath = require('@synthetixio/core-js/utils/relative-path');
 const { getCommit, getBranch } = require('@synthetixio/core-js/utils/git');
 const { readPackageJson } = require('@synthetixio/core-js/utils/package');
 const { SUBTASK_PRINT_INFO } = require('../task-names');
@@ -41,7 +40,7 @@ async function _printInfo(taskArguments) {
 
   logger.log(chalk.gray(`instance: ${taskArguments.instance}`));
   logger.log(chalk.gray(`debug: ${taskArguments.debug}`));
-  logger.log(chalk.gray(`deployment file: ${relativePath(hre.deployer.file)}`));
+  logger.log(chalk.gray(`deployment file: ${hre.deployer.data.file}`));
 
   const signer = (await hre.ethers.getSigners())[0];
   const balance = hre.ethers.utils.formatEther(

--- a/packages/deployer/subtasks/print-info.js
+++ b/packages/deployer/subtasks/print-info.js
@@ -40,7 +40,7 @@ async function _printInfo(taskArguments) {
 
   logger.log(chalk.gray(`instance: ${taskArguments.instance}`));
   logger.log(chalk.gray(`debug: ${taskArguments.debug}`));
-  logger.log(chalk.gray(`deployment file: ${hre.deployer.data.file}`));
+  logger.log(chalk.gray(`deployment file: ${hre.deployer.deployment.file}`));
 
   const signer = (await hre.ethers.getSigners())[0];
   const balance = hre.ethers.utils.formatEther(

--- a/packages/deployer/subtasks/sync-sources.js
+++ b/packages/deployer/subtasks/sync-sources.js
@@ -17,21 +17,21 @@ subtask(
 ).setAction(async (_, hre) => {
   logger.subtitle('Syncing solidity sources with deployment data');
 
-  const { data, previousData } = hre.deployer;
+  const { deployment, previousDeployment } = hre.deployer;
   const sources = getModulesPaths(hre.config);
 
-  const removed = await _removeDeletedSources({ sources, previousData });
-  const added = await _addNewSources({ sources, data, previousData });
+  const removed = await _removeDeletedSources({ sources, previousDeployment });
+  const added = await _addNewSources({ sources, deployment, previousDeployment });
 
   if (!removed && !added) {
     logger.checked('Deployment data is in sync with sources');
   }
 });
 
-async function _removeDeletedSources({ sources, previousData }) {
-  if (!previousData) return false;
+async function _removeDeletedSources({ sources, previousDeployment }) {
+  if (!previousDeployment) return false;
 
-  const modules = filterObject(previousData.contracts, (c) => c.isModule);
+  const modules = filterObject(previousDeployment.contracts, (c) => c.isModule);
   const modulesPaths = Object.values(modules).map((c) => c.source);
 
   const toRemove = modulesPaths.filter(
@@ -57,16 +57,16 @@ const _createModuleData = ({ source }) => ({
   bytecodeHash: '',
 });
 
-async function _addNewSources({ sources, data, previousData }) {
+async function _addNewSources({ sources, deployment, previousDeployment }) {
   let created = false;
 
   // Initialize cotract data, using previous deployed one, or empty data.
   for (const source of sources) {
     const contractName = path.basename(source, '.sol');
-    const previousModule = previousData?.contracts[contractName];
+    const previousModule = previousDeployment?.contracts[contractName];
 
-    data.contracts[contractName] =
-      data.contracts[contractName] || previousModule || _createModuleData({ source });
+    deployment.contracts[contractName] =
+      deployment.contracts[contractName] || previousModule || _createModuleData({ source });
 
     if (!previousModule) created = true;
   }

--- a/packages/deployer/subtasks/upgrade-proxy.js
+++ b/packages/deployer/subtasks/upgrade-proxy.js
@@ -67,20 +67,20 @@ subtask(
 });
 
 function _getDeployedAddress(contractName, hre) {
-  return hre.deployer.data.contracts[contractName].deployedAddress;
+  return hre.deployer.deployment.contracts[contractName].deployedAddress;
 }
 
 async function _deployProxy({ proxyName, proxyPath, routerAddress, hre }) {
-  let proxyData = hre.deployer.data.contracts[proxyName];
+  let proxyData = hre.deployer.deployment.contracts[proxyName];
 
   if (!proxyData) {
-    hre.deployer.data.contracts[proxyName] = {
+    hre.deployer.deployment.contracts[proxyName] = {
       source: proxyPath,
       deployedAddress: '',
       deployTransaction: '',
       bytecodeHash: '',
     };
-    proxyData = hre.deployer.data.contracts[proxyName];
+    proxyData = hre.deployer.deployment.contracts[proxyName];
   }
 
   return await hre.run(SUBTASK_DEPLOY_CONTRACT, {

--- a/packages/deployer/subtasks/validate-router.js
+++ b/packages/deployer/subtasks/validate-router.js
@@ -18,7 +18,7 @@ subtask(
     'Router.sol'
   );
 
-  const modules = filterObject(hre.deployer.data.contracts, (c) => c.isModule);
+  const modules = filterObject(hre.deployer.deployment.contracts, (c) => c.isModule);
   const modulesNames = Object.keys(modules);
 
   await _selectorsExistInSource({


### PR DESCRIPTION
Fix #78

* Moves `hre.deployer.file` into `hre.deployer.data.file` so that every file the deployer writes to is 100% self contained.
* Prevents extensions to hre.deployer, so that anything that is not defined in environments.js will trhow.
* Renamed `hre.deployer.data` to `hre.deployer.deployment`.