### PR TITLE
Tests contracts in the deployer's sample-project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6464,6 +6464,11 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-strict": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/use-strict/-/use-strict-1.0.1.tgz",
+      "integrity": "sha1-C7gNlPSaSgUZK4Sox9NOlfGn46A="
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
@@ -6964,7 +6969,8 @@
         "mkdirp": "1.0.4",
         "mustache": "4.2.0",
         "rimraf": "3.0.2",
-        "string-natural-compare": "3.0.1"
+        "string-natural-compare": "3.0.1",
+        "use-strict": "1.0.1"
       },
       "peerDependencies": {
         "hardhat": "^2.0.0"
@@ -7738,12 +7744,13 @@
       "requires": {
         "chalk": "4.1.2",
         "figlet": "1.5.2",
-        "filter-values": "*",
+        "filter-values": "0.4.1",
         "glob": "7.1.7",
         "mkdirp": "1.0.4",
         "mustache": "4.2.0",
         "rimraf": "3.0.2",
-        "string-natural-compare": "3.0.1"
+        "string-natural-compare": "3.0.1",
+        "use-strict": "1.0.1"
       },
       "dependencies": {
         "mkdirp": {
@@ -11787,6 +11794,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "use-strict": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/use-strict/-/use-strict-1.0.1.tgz",
+      "integrity": "sha1-C7gNlPSaSgUZK4Sox9NOlfGn46A="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/packages/core-js/utils/assertions.js
+++ b/packages/core-js/utils/assertions.js
@@ -21,5 +21,5 @@ async function assertRevert(tx, expectedMessage) {
 }
 
 module.exports = {
-  assertRevert
+  assertRevert,
 };

--- a/packages/core-js/utils/assertions.js
+++ b/packages/core-js/utils/assertions.js
@@ -1,0 +1,25 @@
+async function assertRevert(tx, expectedMessage) {
+  let error;
+
+  try {
+    await (await tx).wait();
+  } catch (err) {
+    error = err;
+  }
+
+  if (!error) {
+    throw new Error('Transaction was expected to revert, but it did not');
+  } else if (expectedMessage) {
+    const receivedMessage = error.toString();
+
+    if (!receivedMessage.includes(expectedMessage)) {
+      throw new Error(
+        `Transaction was expected to revert with "${expectedMessage}", but reverted with "${receivedMessage}"`
+      );
+    }
+  }
+}
+
+module.exports = {
+  assertRevert
+};

--- a/packages/core-js/utils/logger.js
+++ b/packages/core-js/utils/logger.js
@@ -3,6 +3,7 @@ const chalk = require('chalk');
 const BOX_WIDTH = 90;
 
 module.exports = {
+  quiet: false,
   debugging: false,
   prepend: '',
   postpend: '',
@@ -25,6 +26,10 @@ module.exports = {
   },
 
   log(msg) {
+    if (this.quiet) {
+      return;
+    }
+
     const completeLen = Math.max(BOX_WIDTH + 8 - [...msg].length, 0);
     const completeStr = this.boxing ? chalk.gray('.'.repeat(completeLen)) : '';
 
@@ -32,6 +37,10 @@ module.exports = {
   },
 
   subtitle(msg) {
+    if (this.quiet) {
+      return;
+    }
+
     console.log('\n');
 
     this.boxStart();

--- a/packages/core-js/utils/rpc.js
+++ b/packages/core-js/utils/rpc.js
@@ -1,0 +1,22 @@
+async function takeSnapshot(provider) {
+  const snapshotId = await provider.send('evm_snapshot', []);
+
+  await mineBlock(provider);
+
+  return snapshotId;
+}
+
+async function restoreSnapshot(snapshotId, provider) {
+  await provider.send('evm_revert', [snapshotId]);
+
+  await mineBlock(provider);
+}
+
+async function mineBlock(provider) {
+  await provider.send('evm_mine');
+}
+
+module.exports = {
+  takeSnapshot,
+  restoreSnapshot,
+};

--- a/packages/core-js/utils/tests.js
+++ b/packages/core-js/utils/tests.js
@@ -1,0 +1,9 @@
+const chalk = require('chalk');
+
+function printGasUsed({ test, gasUsed }) {
+  test._runnable.title = `${test._runnable.title} (${chalk.green(gasUsed)}${chalk.gray(' gas)')}`;
+}
+
+module.exports = {
+  printGasUsed,
+};

--- a/packages/deployer/subtasks/prepare-deployment.js
+++ b/packages/deployer/subtasks/prepare-deployment.js
@@ -6,7 +6,7 @@ const { subtask } = require('hardhat/config');
 const prompter = require('@synthetixio/core-js/utils/prompter');
 const relativePath = require('@synthetixio/core-js/utils/relative-path');
 const autosaveObject = require('../internal/autosave-object');
-const { getAllDeploymentsFilesForInstance } = require('../utils/deployments');
+const { getAllDeploymentFiles } = require('../utils/deployments');
 const { SUBTASK_PREPARE_DEPLOYMENT } = require('../task-names');
 
 const DEPLOYMENT_SCHEMA = {
@@ -51,7 +51,7 @@ subtask(
  * @returns {{ currentFile: string, previousFile: string }}
  */
 async function _determineDeploymentFiles(deploymentsFolder, alias) {
-  const deployments = getAllDeploymentsFilesForInstance(deploymentsFolder);
+  const deployments = getAllDeploymentFiles({ folder: deploymentsFolder });
   const latestFile = deployments.length > 0 ? deployments[deployments.length - 1] : null;
 
   // Check if there is an unfinished deployment and prompt the user if we should

--- a/packages/deployer/subtasks/print-info.js
+++ b/packages/deployer/subtasks/print-info.js
@@ -10,6 +10,12 @@ const { readPackageJson } = require('@synthetixio/core-js/utils/package');
 const { SUBTASK_PRINT_INFO } = require('../task-names');
 
 subtask(SUBTASK_PRINT_INFO, 'Prints info about a deployment.').setAction(async (taskArguments) => {
+  const { quiet } = taskArguments;
+
+  if (quiet) {
+    return;
+  }
+
   await _printTitle();
   await _printInfo(taskArguments);
 

--- a/packages/deployer/tasks/deploy.js
+++ b/packages/deployer/tasks/deploy.js
@@ -36,9 +36,7 @@ task(TASK_DEPLOY, 'Deploys all system modules')
   .setAction(async (taskArguments, hre) => {
     const { clear, debug, quiet, noConfirm } = taskArguments;
 
-    if (quiet) {
-      _forceSilenceHardhat(true);
-    }
+    _forceSilenceHardhat(true, quiet);
 
     logger.quiet = quiet;
     logger.debugging = debug;
@@ -59,7 +57,7 @@ task(TASK_DEPLOY, 'Deploys all system modules')
     await hre.run(SUBTASK_UPGRADE_PROXY);
     await hre.run(SUBTASK_FINALIZE_DEPLOYMENT);
 
-    _forceSilenceHardhat(false);
+    _forceSilenceHardhat(false, quiet);
   });
 
 /*
@@ -67,7 +65,11 @@ task(TASK_DEPLOY, 'Deploys all system modules')
  * it stil prints some output. This is a hack to completely silence
  * output during deployment.
  * */
-function _forceSilenceHardhat(silence) {
+function _forceSilenceHardhat(silence, quiet) {
+  if (!quiet) {
+    return;
+  }
+
   if (silence) {
     logCache = console.log;
     console.log = () => {};

--- a/packages/deployer/tasks/deploy.js
+++ b/packages/deployer/tasks/deploy.js
@@ -15,6 +15,8 @@ const {
   TASK_DEPLOY,
 } = require('../task-names');
 
+let logCache;
+
 const logger = require('@synthetixio/core-js/utils/logger');
 const prompter = require('@synthetixio/core-js//utils/prompter');
 const types = require('../internal/argument-types');
@@ -22,6 +24,7 @@ const types = require('../internal/argument-types');
 task(TASK_DEPLOY, 'Deploys all system modules')
   .addFlag('noConfirm', 'Skip all confirmation prompts', false)
   .addFlag('debug', 'Display debug logs', false)
+  .addFlag('quiet', 'Silence all output', false)
   .addFlag('clear', 'Clear all previous deployment data for the selected network', false)
   .addOptionalParam('alias', 'The alias name for the deployment', undefined, types.alphanumeric)
   .addOptionalParam(
@@ -31,8 +34,13 @@ task(TASK_DEPLOY, 'Deploys all system modules')
     types.alphanumeric
   )
   .setAction(async (taskArguments, hre) => {
-    const { clear, debug, noConfirm } = taskArguments;
+    const { clear, debug, quiet, noConfirm } = taskArguments;
 
+    if (quiet) {
+      _forceSilenceHardhat(true);
+    }
+
+    logger.quiet = quiet;
     logger.debugging = debug;
     prompter.noConfirm = noConfirm;
 
@@ -50,4 +58,15 @@ task(TASK_DEPLOY, 'Deploys all system modules')
     await hre.run(SUBTASK_DEPLOY_ROUTER);
     await hre.run(SUBTASK_UPGRADE_PROXY);
     await hre.run(SUBTASK_FINALIZE_DEPLOYMENT);
+
+    _forceSilenceHardhat(false);
   });
+
+function _forceSilenceHardhat(silence) {
+  if (silence) {
+    logCache = console.log;
+    console.log = () => {};
+  } else {
+    console.log = logCache;
+  }
+}

--- a/packages/deployer/tasks/deploy.js
+++ b/packages/deployer/tasks/deploy.js
@@ -62,6 +62,11 @@ task(TASK_DEPLOY, 'Deploys all system modules')
     _forceSilenceHardhat(false);
   });
 
+/*
+ * Note: Even though hardhat's compile task has a quiet option,
+ * it stil prints some output. This is a hack to completely silence
+ * output during deployment.
+ * */
 function _forceSilenceHardhat(silence) {
   if (silence) {
     logCache = console.log;

--- a/packages/deployer/test/sample-project/package.json
+++ b/packages/deployer/test/sample-project/package.json
@@ -8,7 +8,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "hardhat test"
   },
   "keywords": [],
   "author": "",

--- a/packages/deployer/test/sample-project/test/AnotherModule.test.js
+++ b/packages/deployer/test/sample-project/test/AnotherModule.test.js
@@ -1,8 +1,7 @@
 const hre = require('hardhat');
 const assert = require('assert');
-const { config, ethers } = hre;
+const { ethers } = hre;
 const { getProxyAddress } = require('../../../utils/deployments');
-const { assertRevert } = require('@synthetixio/core-js/utils/assertions');
 const { printGasUsed } = require('@synthetixio/core-js/utils/tests');
 const { bootstrap, initializeSystem } = require('./helpers/initializer');
 
@@ -33,7 +32,7 @@ describe('AnotherModule', () => {
       await (await SomeModule.setSomeValue(1)).wait();
     });
 
-    it('using casting', async function() {
+    it('using casting', async function () {
       const tx = await AnotherModule.connect(owner).setSomeValueRouter(42);
       const receipt = await tx.wait();
 
@@ -42,7 +41,7 @@ describe('AnotherModule', () => {
       assert.equal(await SomeModule.getSomeValue(), 42);
     });
 
-    it('using the router', async function() {
+    it('using the router', async function () {
       const tx = await AnotherModule.connect(owner).setSomeValueCast(1337);
       const receipt = await tx.wait();
 

--- a/packages/deployer/test/sample-project/test/AnotherModule.test.js
+++ b/packages/deployer/test/sample-project/test/AnotherModule.test.js
@@ -33,7 +33,7 @@ describe('AnotherModule', () => {
     });
 
     it('using casting', async function () {
-      const tx = await AnotherModule.connect(owner).setSomeValueRouter(42);
+      const tx = await AnotherModule.connect(owner).setSomeValueCast(42);
       const receipt = await tx.wait();
 
       printGasUsed({ test: this, gasUsed: receipt.cumulativeGasUsed });
@@ -42,7 +42,7 @@ describe('AnotherModule', () => {
     });
 
     it('using the router', async function () {
-      const tx = await AnotherModule.connect(owner).setSomeValueCast(1337);
+      const tx = await AnotherModule.connect(owner).setSomeValueRouter(1337);
       const receipt = await tx.wait();
 
       printGasUsed({ test: this, gasUsed: receipt.cumulativeGasUsed });

--- a/packages/deployer/test/sample-project/test/AnotherModule.test.js
+++ b/packages/deployer/test/sample-project/test/AnotherModule.test.js
@@ -1,0 +1,54 @@
+const hre = require('hardhat');
+const assert = require('assert');
+const { config, ethers } = hre;
+const { getProxyAddress } = require('../../../utils/deployments');
+const { assertRevert } = require('@synthetixio/core-js/utils/assertions');
+const { printGasUsed } = require('@synthetixio/core-js/utils/tests');
+const { bootstrap, initializeSystem } = require('./helpers/initializer');
+
+describe('AnotherModule', () => {
+  bootstrap();
+
+  let SomeModule, AnotherModule;
+
+  let owner;
+
+  before('identify signers', async () => {
+    [owner] = await ethers.getSigners();
+  });
+
+  before('initialize the system', async () => {
+    await initializeSystem({ owner });
+  });
+
+  before('identify modules', async () => {
+    const proxyAddress = getProxyAddress();
+
+    SomeModule = await ethers.getContractAt('SomeModule', proxyAddress);
+    AnotherModule = await ethers.getContractAt('AnotherModule', proxyAddress);
+  });
+
+  describe('when setting a value in SomeModule via AnotherModule', () => {
+    before('set value if zero for correct gas measurements', async () => {
+      await (await SomeModule.setSomeValue(1)).wait();
+    });
+
+    it('using casting', async function() {
+      const tx = await AnotherModule.connect(owner).setSomeValueRouter(42);
+      const receipt = await tx.wait();
+
+      printGasUsed({ test: this, gasUsed: receipt.cumulativeGasUsed });
+
+      assert.equal(await SomeModule.getSomeValue(), 42);
+    });
+
+    it('using the router', async function() {
+      const tx = await AnotherModule.connect(owner).setSomeValueCast(1337);
+      const receipt = await tx.wait();
+
+      printGasUsed({ test: this, gasUsed: receipt.cumulativeGasUsed });
+
+      assert.equal(await SomeModule.getSomeValue(), 1337);
+    });
+  });
+});

--- a/packages/deployer/test/sample-project/test/OwnerModule.test.js
+++ b/packages/deployer/test/sample-project/test/OwnerModule.test.js
@@ -22,10 +22,17 @@ describe('OwnerModule', () => {
     OwnerModule = await ethers.getContractAt('OwnerModule', proxyAddress);
   });
 
-  describe('before an owner is set', () => {
+  describe('before an owner is set or nominated', () => {
     it('shows that no owner is set', async () => {
       assert.equal(
         await OwnerModule.getOwner(),
+        '0x0000000000000000000000000000000000000000'
+      );
+    });
+
+    it('shows that no owner is nominated', async () => {
+      assert.equal(
+        await OwnerModule.getNominatedOwner(),
         '0x0000000000000000000000000000000000000000'
       );
     });
@@ -42,6 +49,72 @@ describe('OwnerModule', () => {
         await OwnerModule.getNominatedOwner(),
         owner.address
       );
+    });
+
+    describe('when the address accepts ownership', () => {
+      let receipt;
+
+      before('accept ownership', async () => {
+        const tx = await OwnerModule.connect(owner).acceptOwnership();
+        receipt = await tx.wait();
+      });
+
+      it('emitted an OwnerChanged event', async () => {
+        const event = receipt.events.find(e => e.event === 'OwnerChanged');
+
+        assert.equal(event.args.newOwner, owner.address);
+      });
+
+      it('shows that the address is the new owner', async () => {
+        assert.equal(
+          await OwnerModule.getOwner(),
+          owner.address
+        );
+      });
+
+      it('shows that the address is no longer nominated', async () => {
+        assert.equal(
+          await OwnerModule.getNominatedOwner(),
+          '0x0000000000000000000000000000000000000000'
+        );
+      });
+
+      describe('when a regular user tries to nominate a new owner', () => {
+        it('reverts', async () => {
+          await assertRevert(
+            OwnerModule.connect(user).nominateOwner(user.address),
+            'Only owner allowed'
+          );
+        });
+      });
+
+      describe('when the owner nominates a new owner', () => {
+        before('nominate new owner', async () => {
+          const tx = await OwnerModule.connect(owner).nominateOwner(user.address);
+          await tx.wait();
+        });
+
+        it('shows that the user is nominated', async () => {
+          assert.equal(
+            await OwnerModule.getNominatedOwner(),
+            user.address
+          );
+        });
+
+        describe('when the owner rejects the nomination', () => {
+          before('reject the nomination', async () => {
+            const tx = await OwnerModule.connect(owner).rejectNomination();
+            await tx.wait();
+          });
+
+          it('shows that the address is no longer nominated', async () => {
+            assert.equal(
+              await OwnerModule.getNominatedOwner(),
+              '0x0000000000000000000000000000000000000000'
+            );
+          });
+        });
+      });
     });
   });
 });

--- a/packages/deployer/test/sample-project/test/OwnerModule.test.js
+++ b/packages/deployer/test/sample-project/test/OwnerModule.test.js
@@ -1,9 +1,9 @@
 const hre = require('hardhat');
 const assert = require('assert');
-const { config, ethers } = hre;
+const { ethers } = hre;
 const { getProxyAddress } = require('../../../utils/deployments');
 const { assertRevert } = require('@synthetixio/core-js/utils/assertions');
-const { bootstrap, initializeSystem } = require('./helpers/initializer');
+const { bootstrap } = require('./helpers/initializer');
 
 describe('OwnerModule', () => {
   bootstrap();
@@ -24,10 +24,7 @@ describe('OwnerModule', () => {
 
   describe('before an owner is set or nominated', () => {
     it('shows that no owner is set', async () => {
-      assert.equal(
-        await OwnerModule.getOwner(),
-        '0x0000000000000000000000000000000000000000'
-      );
+      assert.equal(await OwnerModule.getOwner(), '0x0000000000000000000000000000000000000000');
     });
 
     it('shows that no owner is nominated', async () => {
@@ -45,10 +42,7 @@ describe('OwnerModule', () => {
     });
 
     it('shows that the address is nominated', async () => {
-      assert.equal(
-        await OwnerModule.getNominatedOwner(),
-        owner.address
-      );
+      assert.equal(await OwnerModule.getNominatedOwner(), owner.address);
     });
 
     describe('when the address accepts ownership', () => {
@@ -60,16 +54,13 @@ describe('OwnerModule', () => {
       });
 
       it('emitted an OwnerChanged event', async () => {
-        const event = receipt.events.find(e => e.event === 'OwnerChanged');
+        const event = receipt.events.find((e) => e.event === 'OwnerChanged');
 
         assert.equal(event.args.newOwner, owner.address);
       });
 
       it('shows that the address is the new owner', async () => {
-        assert.equal(
-          await OwnerModule.getOwner(),
-          owner.address
-        );
+        assert.equal(await OwnerModule.getOwner(), owner.address);
       });
 
       it('shows that the address is no longer nominated', async () => {
@@ -95,10 +86,7 @@ describe('OwnerModule', () => {
         });
 
         it('shows that the user is nominated', async () => {
-          assert.equal(
-            await OwnerModule.getNominatedOwner(),
-            user.address
-          );
+          assert.equal(await OwnerModule.getNominatedOwner(), user.address);
         });
 
         describe('when the owner rejects the nomination', () => {

--- a/packages/deployer/test/sample-project/test/OwnerModule.test.js
+++ b/packages/deployer/test/sample-project/test/OwnerModule.test.js
@@ -1,0 +1,47 @@
+const hre = require('hardhat');
+const assert = require('assert');
+const { config, ethers } = hre;
+const { getProxyAddress } = require('../../../utils/deployments');
+const { assertRevert } = require('@synthetixio/core-js/utils/assertions');
+const { bootstrap, initializeSystem } = require('./helpers/initializer');
+
+describe('OwnerModule', () => {
+  bootstrap();
+
+  let OwnerModule;
+
+  let owner, user;
+
+  before('identify signers', async () => {
+    [owner, user] = await ethers.getSigners();
+  });
+
+  before('identify modules', async () => {
+    const proxyAddress = getProxyAddress();
+
+    OwnerModule = await ethers.getContractAt('OwnerModule', proxyAddress);
+  });
+
+  describe('before an owner is set', () => {
+    it('shows that no owner is set', async () => {
+      assert.equal(
+        await OwnerModule.getOwner(),
+        '0x0000000000000000000000000000000000000000'
+      );
+    });
+  });
+
+  describe('when an address is nominated', () => {
+    before('nominate ownership', async () => {
+      const tx = await OwnerModule.connect(owner).nominateOwner(owner.address);
+      await tx.wait();
+    });
+
+    it('shows that the address is nominated', async () => {
+      assert.equal(
+        await OwnerModule.getNominatedOwner(),
+        owner.address
+      );
+    });
+  });
+});

--- a/packages/deployer/test/sample-project/test/SettingsModule.test.js
+++ b/packages/deployer/test/sample-project/test/SettingsModule.test.js
@@ -13,7 +13,8 @@ describe('SettingsModule', () => {
   });
 
   before('identify modules', async () => {
-    const proxyAddress = getProxyAddress(config);
+    const proxyAddress = getProxyAddress();
+
     SettingsModule = await ethers.getContractAt('SettingsModule', proxyAddress);
   });
 

--- a/packages/deployer/test/sample-project/test/SettingsModule.test.js
+++ b/packages/deployer/test/sample-project/test/SettingsModule.test.js
@@ -1,6 +1,6 @@
 const hre = require('hardhat');
 const assert = require('assert');
-const { config, ethers } = hre;
+const { ethers } = hre;
 const { getProxyAddress } = require('../../../utils/deployments');
 const { assertRevert } = require('@synthetixio/core-js/utils/assertions');
 const { bootstrap, initializeSystem } = require('./helpers/initializer');
@@ -28,10 +28,7 @@ describe('SettingsModule', () => {
 
   describe('when a regular user tries to set a value', () => {
     it('reverts', async () => {
-      await assertRevert(
-        SettingsModule.connect(user).setASettingValue(1),
-        'Only owner allowed'
-      );
+      await assertRevert(SettingsModule.connect(user).setASettingValue(1), 'Only owner allowed');
     });
   });
 

--- a/packages/deployer/test/sample-project/test/SettingsModule.test.js
+++ b/packages/deployer/test/sample-project/test/SettingsModule.test.js
@@ -3,9 +3,11 @@ const assert = require('assert');
 const { config, ethers } = hre;
 const { getProxyAddress } = require('../../../utils/deployments');
 const { assertRevert } = require('@synthetixio/core-js/utils/assertions');
-const { initializeSystem } = require('./helpers/initializer');
+const { bootstrap, initializeSystem } = require('./helpers/initializer');
 
 describe('SettingsModule', () => {
+  bootstrap();
+
   let SettingsModule;
 
   let owner, user;

--- a/packages/deployer/test/sample-project/test/SomeModule.test.js
+++ b/packages/deployer/test/sample-project/test/SomeModule.test.js
@@ -1,8 +1,7 @@
 const hre = require('hardhat');
 const assert = require('assert');
-const { config, ethers } = hre;
+const { ethers } = hre;
 const { getProxyAddress } = require('../../../utils/deployments');
-const { assertRevert } = require('@synthetixio/core-js/utils/assertions');
 const { bootstrap, initializeSystem } = require('./helpers/initializer');
 
 describe('SomeModule', () => {

--- a/packages/deployer/test/sample-project/test/SomeModule.test.js
+++ b/packages/deployer/test/sample-project/test/SomeModule.test.js
@@ -1,0 +1,50 @@
+const hre = require('hardhat');
+const assert = require('assert');
+const { config, ethers } = hre;
+const { getProxyAddress } = require('../../../utils/deployments');
+const { assertRevert } = require('@synthetixio/core-js/utils/assertions');
+const { bootstrap, initializeSystem } = require('./helpers/initializer');
+
+describe('SomeModule', () => {
+  bootstrap();
+
+  let SomeModule;
+
+  let owner;
+
+  before('identify signers', async () => {
+    [owner] = await ethers.getSigners();
+  });
+
+  before('initialize the system', async () => {
+    await initializeSystem({ owner });
+  });
+
+  before('identify modules', async () => {
+    const proxyAddress = getProxyAddress();
+
+    SomeModule = await ethers.getContractAt('SomeModule', proxyAddress);
+  });
+
+  describe('when the owner sets the value', () => {
+    before('set value', async () => {
+      const tx = await SomeModule.connect(owner).setValue(42);
+      await tx.wait();
+    });
+
+    it('shows that the value was set', async () => {
+      assert.equal(await SomeModule.getValue(), 42);
+    });
+  });
+
+  describe('when the owner sets some value', () => {
+    before('set some value', async () => {
+      const tx = await SomeModule.connect(owner).setSomeValue(1337);
+      await tx.wait();
+    });
+
+    it('shows that the value was set', async () => {
+      assert.equal(await SomeModule.getSomeValue(), 1337);
+    });
+  });
+});

--- a/packages/deployer/test/sample-project/test/UpgradeModule.test.js
+++ b/packages/deployer/test/sample-project/test/UpgradeModule.test.js
@@ -1,0 +1,82 @@
+const hre = require('hardhat');
+const assert = require('assert');
+const { ethers } = hre;
+const { getProxyAddress, getRouterAddress, getDeployment } = require('../../../utils/deployments');
+const { assertRevert } = require('@synthetixio/core-js/utils/assertions');
+const { bootstrap, initializeSystem } = require('./helpers/initializer');
+
+describe('UpgradeModule', () => {
+  bootstrap();
+
+  let UpgradeModule;
+
+  let owner, user;
+  let routerAddress;
+
+  before('identify signers', async () => {
+    [owner, user] = await ethers.getSigners();
+  });
+
+  before('initialize the system', async () => {
+    await initializeSystem({ owner });
+  });
+
+  before('identify modules', async () => {
+    routerAddress = getRouterAddress();
+    const proxyAddress = getProxyAddress();
+
+    UpgradeModule = await ethers.getContractAt('UpgradeModule', proxyAddress);
+  });
+
+  describe('when the system is deployed', () => {
+    it('shows that the current implementation is correct', async () => {
+      assert.equal(await UpgradeModule.getImplementation(), routerAddress);
+    });
+  });
+
+  describe('when a regular user attempts to upgrade the system', () => {
+    it('reverts', async () => {
+      await assertRevert(UpgradeModule.connect(user).upgradeTo(user.address), 'Only owner allowed');
+    });
+  });
+
+  describe('when the owner attempts to upgrade to an EOA', () => {
+    it('reverts', async () => {
+      await assertRevert(
+        UpgradeModule.connect(owner).upgradeTo(owner.address),
+        'Invalid: not a contract'
+      );
+    });
+  });
+
+  describe('when the owner attempts to upgrade to a sterile implementation', () => {
+    it('reverts', async () => {
+      const deployment = getDeployment();
+      const someSterileContractAddress = deployment.contracts.SomeModule.deployedAddress;
+
+      await assertRevert(
+        UpgradeModule.connect(owner).upgradeTo(someSterileContractAddress),
+        'brick upgrade'
+      );
+    });
+  });
+
+  describe('when the owner upgrades to a non-sterile implementation', () => {
+    let receipt;
+
+    before('upgrade', async () => {
+      const tx = await UpgradeModule.connect(owner).upgradeTo(routerAddress);
+      receipt = await tx.wait();
+    });
+
+    it('emitted an Upgraded event', async () => {
+      const event = receipt.events.find((e) => e.event === 'Upgraded');
+
+      assert.equal(event.args.implementation, routerAddress);
+    });
+
+    it('shows that the current implementation is correct', async () => {
+      assert.equal(await UpgradeModule.getImplementation(), routerAddress);
+    });
+  });
+});

--- a/packages/deployer/test/sample-project/test/helpers/initializer.js
+++ b/packages/deployer/test/sample-project/test/helpers/initializer.js
@@ -15,6 +15,12 @@ function bootstrap() {
         await deploySystem();
       } else {
         proxyAddress = getProxyAddress();
+
+        const proxyCode = await ethers.provider.getCode(proxyAddress);
+
+        if (proxyCode === '0x') {
+          await deploySystem();
+        }
       }
     }
   });

--- a/packages/deployer/test/sample-project/test/helpers/initializer.js
+++ b/packages/deployer/test/sample-project/test/helpers/initializer.js
@@ -8,21 +8,7 @@ let proxyAddress;
 
 function bootstrap() {
   before('deploy system only once if needed', async () => {
-    if (!proxyAddress) {
-      const deployment = getDeployment();
-
-      if (!deployment) {
-        await deploySystem();
-      } else {
-        proxyAddress = getProxyAddress();
-
-        const proxyCode = await ethers.provider.getCode(proxyAddress);
-
-        if (proxyCode === '0x') {
-          await deploySystem();
-        }
-      }
-    }
+    await deploySystemIfNeeded();
   });
 
   before('take a snapshot', async () => {
@@ -32,6 +18,24 @@ function bootstrap() {
   after('restore the snapshot', async () => {
     await restoreSnapshot(snapshotId, ethers.provider);
   });
+}
+
+async function deploySystemIfNeeded() {
+  if (!proxyAddress) {
+    const deployment = getDeployment();
+
+    if (!deployment) {
+      await deploySystem();
+    } else {
+      proxyAddress = getProxyAddress();
+
+      const proxyCode = await ethers.provider.getCode(proxyAddress);
+
+      if (proxyCode === '0x') {
+        await deploySystem();
+      }
+    }
+  }
 }
 
 async function deploySystem() {
@@ -64,6 +68,7 @@ async function initializeOwner({ owner }) {
 module.exports = {
   bootstrap,
   deploySystem,
+  deploySystemIfNeeded,
   initializeSystem,
   initializeOwner,
 };

--- a/packages/deployer/test/sample-project/test/helpers/initializer.js
+++ b/packages/deployer/test/sample-project/test/helpers/initializer.js
@@ -1,0 +1,25 @@
+const hre = require('hardhat');
+const { ethers } = hre;
+const { getProxyAddress } = require('../../../../utils/deployments');
+
+async function initializeSystem({ owner }) {
+  const proxyAddress = getProxyAddress();
+
+  await _setFirstOwner({ owner, proxyAddress });
+}
+
+async function _setFirstOwner({ owner, proxyAddress }) {
+  let tx;
+
+  const OwnerModule = await ethers.getContractAt('OwnerModule', proxyAddress);
+
+  tx = await OwnerModule.connect(owner).nominateOwner(owner.address);
+  await tx.wait();
+
+  tx = await OwnerModule.connect(owner).acceptOwnership();
+  await tx.wait();
+}
+
+module.exports = {
+  initializeSystem,
+};

--- a/packages/deployer/utils/deployments.js
+++ b/packages/deployer/utils/deployments.js
@@ -25,7 +25,7 @@ const DeploymentInfo = {
  * @returns {address} The address of the proxy
  */
 function getProxyAddress(info) {
-  info = _populateDetauls(info);
+  info = _populateDefaults(info);
 
   const deployment = getDeployment(info);
 
@@ -38,7 +38,7 @@ function getProxyAddress(info) {
  * @returns {address} The address of the router
  */
 function getRouterAddress(info) {
-  info = _populateDetauls(info);
+  info = _populateDefaults(info);
 
   const deployment = getDeployment(info);
 
@@ -51,7 +51,7 @@ function getRouterAddress(info) {
  * @returns {Object} An object with deployment schema
  */
 function getDeployment(info) {
-  info = _populateDetauls(info);
+  info = _populateDefaults(info);
 
   const file = getDeploymentFile(info);
 
@@ -68,7 +68,7 @@ function getDeployment(info) {
  * @returns {string} The path of the file
  */
 function getDeploymentFile(info) {
-  info = _populateDetauls(info);
+  info = _populateDefaults(info);
 
   const deployments = getAllDeploymentFiles(info);
 
@@ -81,7 +81,7 @@ function getDeploymentFile(info) {
  * @returns {array} An array of paths for the files
  */
 function getAllDeploymentFiles(info) {
-  info = _populateDetauls(info);
+  info = _populateDefaults(info);
 
   const instanceFolder = getDeploymentFolder(info);
 
@@ -97,12 +97,12 @@ function getAllDeploymentFiles(info) {
  * @returns {string} The path of the folder
  */
 function getDeploymentFolder(info) {
-  info = _populateDetauls(info);
+  info = _populateDefaults(info);
 
   return path.join(info.folder, info.network, info.instance);
 }
 
-function _populateDetauls(info) {
+function _populateDefaults(info) {
   return { ...info, ...DeploymentInfo };
 }
 

--- a/packages/deployer/utils/deployments.js
+++ b/packages/deployer/utils/deployments.js
@@ -7,45 +7,62 @@ const { defaults } = require('../extensions/config');
 // Regex for deployment file formats, e.g.: 2021-08-31-00-sirius.json
 const DEPLOYMENT_FILE_FORMAT = /^[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2,}(?:-[a-z0-9]+)?\.json$/;
 
-function getProxyAddress({
-  network = 'local',
-  instance = 'official',
-  deploymentsFolder = defaults.paths.deployments,
-} = {}) {
-  const data = getCurrentDeploymentDataForInstance({ network, instance, deploymentsFolder });
-  return data.contracts['Proxy'].deployedAddress;
+/**
+ * @param {Object} info An object describing which deployment to retrieve
+ * @param {string} info.network The network of the target deployment
+ * @param {string} info.instance The instance name of the target deployment
+ * @param {string} info.folder The path to the folder where deployment files are stored
+ */
+const DeploymentInfo = {
+  network: 'local',
+  instance: 'official',
+  folder: defaults.paths.deployments,
+};
+
+/**
+ * Retrieves the address of the target instance's deployed proxy
+ * @param {DeploymentInfo} info See DeploymentInfo above
+ * @returns {address} The address of the proxy
+ */
+function getProxyAddress(info = DeploymentInfo) {
+  const deployment = getDeployment(info);
+
+  return deployment.contracts.Proxy.deployedAddress;
 }
 
-function getCurrentDeploymentDataForInstance({
-  network = 'local',
-  instance = 'official',
-  deploymentsFolder = defaults.paths.deployments,
-} = {}) {
-  const file = getCurrentDeploymentFileForInstance({ network, instance, deploymentsFolder });
+/**
+ * Retrieves an object with the latest deployment json data for an instance
+ * @param {DeploymentInfo} info See DeploymentInfo above
+ * @returns {Object} An object with deployment schema
+ */
+function getDeployment(info = DeploymentInfo) {
+  const file = getDeploymentFile(info);
 
   if (!file) {
-    throw new Error(`No deployment file found on "${deploymentsFolder}".`);
+    throw new Error(`No deployment file found on "${info.folder}".`);
   }
 
   return JSON.parse(fs.readFileSync(file, 'utf8'));
 }
 
-function getCurrentDeploymentFileForInstance({
-  network = 'local',
-  instance = 'official',
-  deploymentsFolder = defaults.paths.deployments,
-} = {}) {
-  const deployments = getAllDeploymentsFilesForInstance({ network, instance, deploymentsFolder });
+/**
+ * Retrieves the file with the latest deployment data for an instance
+ * @param {DeploymentInfo} info See DeploymentInfo above
+ * @returns {string} The path of the file
+ */
+function getDeploymentFile(info = DeploymentInfo) {
+  const deployments = getAllDeploymentFiles(info);
 
   return deployments.length > 0 ? deployments[deployments.length - 1] : null;
 }
 
-function getAllDeploymentsFilesForInstance({
-  network = 'local',
-  instance = 'official',
-  deploymentsFolder = defaults.paths.deployments,
-} = {}) {
-  const instanceFolder = getDeploymentFolderForInstance({ network, instance, deploymentsFolder });
+/**
+ * Retrieves all deployment files for an instance, including past deployments
+ * @param {DeploymentInfo} info See DeploymentInfo above
+ * @returns {array} An array of paths for the files
+ */
+function getAllDeploymentFiles(info = DeploymentInfo) {
+  const instanceFolder = getDeploymentFolder(info);
 
   return glob
     .sync(`${instanceFolder}/*.json`)
@@ -53,17 +70,19 @@ function getAllDeploymentsFilesForInstance({
     .sort(naturalCompare);
 }
 
-function getDeploymentFolderForInstance({
-  network = 'local',
-  instance = 'official',
-  deploymentsFolder = defaults.paths.deployments,
-} = {}) {
-  return path.join(deploymentsFolder, network, instance);
+/**
+ * Retrieves the deployemnt folder path for an instance
+ * @param {DeploymentInfo} info See DeploymentInfo above
+ * @returns {string} The path of the folder
+ */
+function getDeploymentFolder(info = DeploymentInfo) {
+  return path.join(info.folder, info.network, info.instance);
 }
 
 module.exports = {
-  getAllDeploymentsFilesForInstance,
-  getCurrentDeploymentFileForInstance,
-  getCurrentDeploymentDataForInstance,
   getProxyAddress,
+  getDeployment,
+  getDeploymentFile,
+  getAllDeploymentFiles,
+  getDeploymentFolder,
 };

--- a/packages/deployer/utils/deployments.js
+++ b/packages/deployer/utils/deployments.js
@@ -24,7 +24,9 @@ const DeploymentInfo = {
  * @param {DeploymentInfo} info See DeploymentInfo above
  * @returns {address} The address of the proxy
  */
-function getProxyAddress(info = DeploymentInfo) {
+function getProxyAddress(info) {
+  info = _populateDetauls(info);
+
   const deployment = getDeployment(info);
 
   return deployment.contracts.Proxy.deployedAddress;
@@ -35,11 +37,13 @@ function getProxyAddress(info = DeploymentInfo) {
  * @param {DeploymentInfo} info See DeploymentInfo above
  * @returns {Object} An object with deployment schema
  */
-function getDeployment(info = DeploymentInfo) {
+function getDeployment(info) {
+  info = _populateDetauls(info);
+
   const file = getDeploymentFile(info);
 
   if (!file) {
-    throw new Error(`No deployment file found on "${info.folder}".`);
+    return null;
   }
 
   return JSON.parse(fs.readFileSync(file, 'utf8'));
@@ -50,7 +54,9 @@ function getDeployment(info = DeploymentInfo) {
  * @param {DeploymentInfo} info See DeploymentInfo above
  * @returns {string} The path of the file
  */
-function getDeploymentFile(info = DeploymentInfo) {
+function getDeploymentFile(info) {
+  info = _populateDetauls(info);
+
   const deployments = getAllDeploymentFiles(info);
 
   return deployments.length > 0 ? deployments[deployments.length - 1] : null;
@@ -61,7 +67,9 @@ function getDeploymentFile(info = DeploymentInfo) {
  * @param {DeploymentInfo} info See DeploymentInfo above
  * @returns {array} An array of paths for the files
  */
-function getAllDeploymentFiles(info = DeploymentInfo) {
+function getAllDeploymentFiles(info) {
+  info = _populateDetauls(info);
+
   const instanceFolder = getDeploymentFolder(info);
 
   return glob
@@ -75,8 +83,14 @@ function getAllDeploymentFiles(info = DeploymentInfo) {
  * @param {DeploymentInfo} info See DeploymentInfo above
  * @returns {string} The path of the folder
  */
-function getDeploymentFolder(info = DeploymentInfo) {
+function getDeploymentFolder(info) {
+  info = _populateDetauls(info);
+
   return path.join(info.folder, info.network, info.instance);
+}
+
+function _populateDetauls(info) {
+  return { ...info, ...DeploymentInfo };
 }
 
 module.exports = {

--- a/packages/deployer/utils/deployments.js
+++ b/packages/deployer/utils/deployments.js
@@ -33,6 +33,19 @@ function getProxyAddress(info) {
 }
 
 /**
+ * Retrieves the address of the target instance's deployed router
+ * @param {DeploymentInfo} info See DeploymentInfo above
+ * @returns {address} The address of the router
+ */
+function getRouterAddress(info) {
+  info = _populateDetauls(info);
+
+  const deployment = getDeployment(info);
+
+  return deployment.contracts.Router.deployedAddress;
+}
+
+/**
  * Retrieves an object with the latest deployment json data for an instance
  * @param {DeploymentInfo} info See DeploymentInfo above
  * @returns {Object} An object with deployment schema
@@ -95,6 +108,7 @@ function _populateDetauls(info) {
 
 module.exports = {
   getProxyAddress,
+  getRouterAddress,
   getDeployment,
   getDeploymentFile,
   getAllDeploymentFiles,


### PR DESCRIPTION
Fix #51

Usage:
`cd packages/deployer/test/sample-project`
`npx hardhat node`
`npx hardhat test`

Changes:
* Adds tests for all modules in `deployer/sample-project/test`
* Adds a few utilities to the core-js package (still not categorized into folders) that are useful in tests: rpc utils to take snapshots, reversion assertion, etc
* Adds a `--quiet` option to the deploy task so that tests can use the deploy task programmatically without dirtying output.
* Simplifies and documents `deployer/utils/deployments.js` interface.
* Adds an initializer helper to the sample-project's tests which can deploy the system, initialize it, etc.