### PR TITLE
Add artifacts files on extended folder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "synthetix-v3",
       "version": "3.0.0",
       "license": "MIT",
       "workspaces": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -958,6 +958,38 @@
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
       "dev": true
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@sentry/core": {
       "version": "5.30.0",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.30.0.tgz",
@@ -1201,6 +1233,18 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1336,7 +1380,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1678,6 +1721,14 @@
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/cli-cursor": {
@@ -2055,6 +2106,27 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/del": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
+      "integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
+      "dependencies": {
+        "globby": "^11.0.1",
+        "graceful-fs": "^4.2.4",
+        "is-glob": "^4.0.1",
+        "is-path-cwd": "^2.2.0",
+        "is-path-inside": "^3.0.2",
+        "p-map": "^4.0.0",
+        "rimraf": "^3.0.2",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -2069,6 +2141,17 @@
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/doctrine": {
@@ -2738,6 +2821,33 @@
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
+    "node_modules/fast-glob": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fast-glob/node_modules/micromatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "dependencies": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2749,6 +2859,14 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "node_modules/fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/figlet": {
       "version": "1.5.2",
@@ -3088,6 +3206,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/ignore": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/graceful-fs": {
@@ -3435,6 +3580,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -3889,6 +4042,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-path-cwd": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-posix-bracket": {
@@ -4401,6 +4570,14 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/merkle-patricia-tree": {
       "version": "4.2.1",
@@ -5118,6 +5295,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
@@ -5219,6 +5410,14 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/pbkdf2": {
       "version": "3.1.2",
@@ -5561,6 +5760,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/randomatic": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
@@ -5770,6 +5988,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -5810,6 +6037,28 @@
       "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/rustbn.js": {
@@ -7500,12 +7749,12 @@
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
+        "del": "6.0.0",
         "figlet": "1.5.2",
         "filter-values": "0.4.1",
         "glob": "7.1.7",
         "mkdirp": "1.0.4",
         "mustache": "4.2.0",
-        "rimraf": "3.0.2",
         "string-natural-compare": "3.0.1",
         "use-strict": "1.0.1"
       },
@@ -8132,6 +8381,29 @@
       "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
       "dev": true
     },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
     "@sentry/core": {
       "version": "5.30.0",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.30.0.tgz",
@@ -8302,12 +8574,12 @@
       "version": "file:packages/deployer",
       "requires": {
         "chalk": "4.1.2",
+        "del": "*",
         "figlet": "1.5.2",
         "filter-values": "0.4.1",
         "glob": "7.1.7",
         "mkdirp": "1.0.4",
         "mustache": "4.2.0",
-        "rimraf": "3.0.2",
         "string-natural-compare": "3.0.1",
         "use-strict": "1.0.1"
       },
@@ -8430,6 +8702,15 @@
         "debug": "4"
       }
     },
+    "aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      }
+    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -8526,8 +8807,7 @@
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
     },
     "array-unique": {
       "version": "0.2.1",
@@ -8796,6 +9076,11 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
     },
     "cli-cursor": {
       "version": "2.1.0",
@@ -9101,6 +9386,21 @@
         "object-keys": "^1.0.12"
       }
     },
+    "del": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
+      "integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
+      "requires": {
+        "globby": "^11.0.1",
+        "graceful-fs": "^4.2.4",
+        "is-glob": "^4.0.1",
+        "is-path-cwd": "^2.2.0",
+        "is-path-inside": "^3.0.2",
+        "p-map": "^4.0.0",
+        "rimraf": "^3.0.2",
+        "slash": "^3.0.0"
+      }
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -9110,6 +9410,14 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "requires": {
+        "path-type": "^4.0.0"
+      }
     },
     "doctrine": {
       "version": "3.0.0",
@@ -9654,6 +9962,29 @@
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
+    "fast-glob": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "dependencies": {
+        "micromatch": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+          "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.2.3"
+          }
+        }
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -9665,6 +9996,14 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "requires": {
+        "reusify": "^1.0.4"
+      }
     },
     "figlet": {
       "version": "1.5.2",
@@ -9906,6 +10245,26 @@
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
+      }
+    },
+    "globby": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "requires": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
+        }
       }
     },
     "graceful-fs": {
@@ -10164,6 +10523,11 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -10483,6 +10847,16 @@
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
+    },
+    "is-path-cwd": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ=="
+    },
+    "is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="
     },
     "is-posix-bracket": {
       "version": "0.1.1",
@@ -10888,6 +11262,11 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
+    },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
     },
     "merkle-patricia-tree": {
       "version": "4.2.1",
@@ -11427,6 +11806,14 @@
         "p-limit": "^1.1.0"
       }
     },
+    "p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "requires": {
+        "aggregate-error": "^3.0.0"
+      }
+    },
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
@@ -11503,6 +11890,11 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
     },
     "pbkdf2": {
       "version": "3.1.2",
@@ -11760,6 +12152,11 @@
         "side-channel": "^1.0.4"
       }
     },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+    },
     "randomatic": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
@@ -11913,6 +12310,11 @@
         }
       }
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -11942,6 +12344,14 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
       "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "rustbn.js": {
       "version": "0.2.0",

--- a/packages/core-js/utils/get-date.js
+++ b/packages/core-js/utils/get-date.js
@@ -1,0 +1,11 @@
+/**
+ * Get the date in format `YYYY-MM-DD`
+ * @param {Date} [date=new Date()]
+ * @returns {string}
+ */
+module.exports = function getDate(date = new Date()) {
+  const year = `${date.getUTCFullYear()}`;
+  const month = `${date.getUTCMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getUTCDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};

--- a/packages/deployer/extensions/environment.js
+++ b/packages/deployer/extensions/environment.js
@@ -9,6 +9,9 @@ extendEnvironment((hre) => {
   hre.deployer = {
     paths: {
       routerTemplate: path.resolve(__dirname, '../templates/Router.sol.mustache'),
+      deployment: null,
+      sources: null,
+      abis: null,
     },
     deployment: null,
     previousDeployment: null,
@@ -17,4 +20,5 @@ extendEnvironment((hre) => {
   // Prevent any properties being added to hre.deployer
   // other than those defined above.
   Object.preventExtensions(hre.deployer);
+  Object.preventExtensions(hre.deployer.paths);
 });

--- a/packages/deployer/internal/autosave-object.js
+++ b/packages/deployer/internal/autosave-object.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const logger = require('@synthetixio/core-js/utils/logger');
-const relativePath = require('@synthetixio/core-js//utils/relative-path');
+const relativePath = require('@synthetixio/core-js/utils/relative-path');
 
 const write = (file, data) => fs.writeFileSync(file, JSON.stringify(data, null, 2));
 

--- a/packages/deployer/internal/contract-helper.js
+++ b/packages/deployer/internal/contract-helper.js
@@ -1,3 +1,5 @@
+const fs = require('fs/promises');
+const path = require('path');
 const { deployedContractHasBytescode } = require('@synthetixio/core-js/utils/contracts');
 const { getSelectors } = require('@synthetixio/core-js/utils/contracts');
 
@@ -51,8 +53,21 @@ function findDuplicateSelectors(selectors) {
   return ocurrences.length > 0 ? ocurrences : null;
 }
 
+async function getContractMetadata(contractName) {
+  const { sourceName, abi, bytecode, deployedBytecode } = await hre.artifacts.readArtifact(
+    contractName
+  );
+
+  const sourceCode = (
+    await fs.readFile(path.resolve(hre.config.paths.root, sourceName))
+  ).toString();
+
+  return { abi, bytecode, deployedBytecode, sourceCode };
+}
+
 module.exports = {
   isAlreadyDeployed,
   getAllSelectors,
   findDuplicateSelectors,
+  getContractMetadata,
 };

--- a/packages/deployer/internal/contract-helper.js
+++ b/packages/deployer/internal/contract-helper.js
@@ -1,5 +1,3 @@
-const fs = require('fs/promises');
-const path = require('path');
 const { deployedContractHasBytescode } = require('@synthetixio/core-js/utils/contracts');
 const { getSelectors } = require('@synthetixio/core-js/utils/contracts');
 
@@ -53,21 +51,8 @@ function findDuplicateSelectors(selectors) {
   return ocurrences.length > 0 ? ocurrences : null;
 }
 
-async function getContractMetadata(contractName) {
-  const { sourceName, abi, bytecode, deployedBytecode } = await hre.artifacts.readArtifact(
-    contractName
-  );
-
-  const sourceCode = (
-    await fs.readFile(path.resolve(hre.config.paths.root, sourceName))
-  ).toString();
-
-  return { abi, bytecode, deployedBytecode, sourceCode };
-}
-
 module.exports = {
   isAlreadyDeployed,
   getAllSelectors,
   findDuplicateSelectors,
-  getContractMetadata,
 };

--- a/packages/deployer/internal/process-contracts.js
+++ b/packages/deployer/internal/process-contracts.js
@@ -4,9 +4,9 @@ const path = require('path');
 /**
  * Initialize contract metadata on hre.deployer.deployment.*
  * @param {string} contractName
- * @param {object} [data={}] initial contract metadata, e.g.: { isModule: true }
+ * @param {object} [general={}] initial contract metadata, e.g.: { isModule: true }
  */
-async function initContractData(contractName, data = {}) {
+async function initContractData(contractName, general = {}) {
   const { deployment, previousDeployment } = hre.deployer;
   const { sourceName, abi, bytecode, deployedBytecode } = await hre.artifacts.readArtifact(
     contractName
@@ -16,14 +16,14 @@ async function initContractData(contractName, data = {}) {
     await fs.readFile(path.resolve(hre.config.paths.root, sourceName))
   ).toString();
 
-  const previousData = previousDeployment?.data.contracts[contractName] || {};
+  const previousData = previousDeployment?.general.contracts[contractName] || {};
 
-  deployment.data.contracts[contractName] = {
+  deployment.general.contracts[contractName] = {
     deployedAddress: '',
     deployTransaction: '',
     bytecodeHash: '',
     ...previousData,
-    ...data,
+    ...general,
     sourceName,
   };
 

--- a/packages/deployer/internal/process-contracts.js
+++ b/packages/deployer/internal/process-contracts.js
@@ -1,6 +1,11 @@
 const fs = require('fs/promises');
 const path = require('path');
 
+/**
+ * Initialize contract metadata on hre.deployer.deployment.*
+ * @param {string} contractName
+ * @param {object} [data={}] initial contract metadata, e.g.: { isModule: true }
+ */
 async function initContractData(contractName, data = {}) {
   const { deployment } = hre.deployer;
   const { sourceName, abi, bytecode, deployedBytecode } = await hre.artifacts.readArtifact(

--- a/packages/deployer/internal/process-contracts.js
+++ b/packages/deployer/internal/process-contracts.js
@@ -7,7 +7,7 @@ const path = require('path');
  * @param {object} [data={}] initial contract metadata, e.g.: { isModule: true }
  */
 async function initContractData(contractName, data = {}) {
-  const { deployment } = hre.deployer;
+  const { deployment, previousDeployment } = hre.deployer;
   const { sourceName, abi, bytecode, deployedBytecode } = await hre.artifacts.readArtifact(
     contractName
   );
@@ -16,10 +16,13 @@ async function initContractData(contractName, data = {}) {
     await fs.readFile(path.resolve(hre.config.paths.root, sourceName))
   ).toString();
 
+  const previousData = previousDeployment?.data.contracts[contractName] || {};
+
   deployment.data.contracts[contractName] = {
     deployedAddress: '',
     deployTransaction: '',
     bytecodeHash: '',
+    ...previousData,
     ...data,
     sourceName,
   };

--- a/packages/deployer/internal/process-contracts.js
+++ b/packages/deployer/internal/process-contracts.js
@@ -1,0 +1,33 @@
+const fs = require('fs/promises');
+const path = require('path');
+
+async function initContractData(contractName, data = {}) {
+  const { deployment } = hre.deployer;
+  const { sourceName, abi, bytecode, deployedBytecode } = await hre.artifacts.readArtifact(
+    contractName
+  );
+
+  const sourceCode = (
+    await fs.readFile(path.resolve(hre.config.paths.root, sourceName))
+  ).toString();
+
+  deployment.data.contracts[contractName] = {
+    deployedAddress: '',
+    deployTransaction: '',
+    bytecodeHash: '',
+    ...data,
+    sourceName,
+  };
+
+  deployment.abis[contractName] = abi;
+
+  deployment.sources[contractName] = {
+    bytecode,
+    deployedBytecode,
+    sourceCode,
+  };
+}
+
+module.exports = {
+  initContractData,
+};

--- a/packages/deployer/internal/process-transactions.js
+++ b/packages/deployer/internal/process-transactions.js
@@ -1,5 +1,5 @@
 function processTransaction(transaction, hre) {
-  hre.deployer.deployment.transactions[transaction.hash] = { status: 'pending' };
+  hre.deployer.deployment.data.transactions[transaction.hash] = { status: 'pending' };
 }
 
 function processReceipt(receipt, hre) {
@@ -7,13 +7,15 @@ function processReceipt(receipt, hre) {
   const { gasUsed } = receipt;
   const status = receipt.status === 1 ? 'confirmed' : 'failed';
 
-  hre.deployer.deployment.transactions[receipt.transactionHash].status = status;
+  hre.deployer.deployment.data.transactions[receipt.transactionHash].status = status;
 
-  const totalGasUsed = hre.ethers.BigNumber.from(hre.deployer.deployment.properties.totalGasUsed)
+  const totalGasUsed = hre.ethers.BigNumber.from(
+    hre.deployer.deployment.data.properties.totalGasUsed
+  )
     .add(gasUsed)
     .toString();
 
-  hre.deployer.deployment.properties.totalGasUsed = totalGasUsed;
+  hre.deployer.deployment.data.properties.totalGasUsed = totalGasUsed;
 
   return { status, gasUsed };
 }

--- a/packages/deployer/internal/process-transactions.js
+++ b/packages/deployer/internal/process-transactions.js
@@ -1,5 +1,5 @@
 function processTransaction(transaction, hre) {
-  hre.deployer.deployment.data.transactions[transaction.hash] = { status: 'pending' };
+  hre.deployer.deployment.general.transactions[transaction.hash] = { status: 'pending' };
 }
 
 function processReceipt(receipt, hre) {
@@ -7,15 +7,15 @@ function processReceipt(receipt, hre) {
   const { gasUsed } = receipt;
   const status = receipt.status === 1 ? 'confirmed' : 'failed';
 
-  hre.deployer.deployment.data.transactions[receipt.transactionHash].status = status;
+  hre.deployer.deployment.general.transactions[receipt.transactionHash].status = status;
 
   const totalGasUsed = hre.ethers.BigNumber.from(
-    hre.deployer.deployment.data.properties.totalGasUsed
+    hre.deployer.deployment.general.properties.totalGasUsed
   )
     .add(gasUsed)
     .toString();
 
-  hre.deployer.deployment.data.properties.totalGasUsed = totalGasUsed;
+  hre.deployer.deployment.general.properties.totalGasUsed = totalGasUsed;
 
   return { status, gasUsed };
 }

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -14,12 +14,12 @@
   },
   "dependencies": {
     "chalk": "4.1.2",
+    "del": "6.0.0",
     "figlet": "1.5.2",
     "filter-values": "0.4.1",
     "glob": "7.1.7",
     "mkdirp": "1.0.4",
     "mustache": "4.2.0",
-    "rimraf": "3.0.2",
     "string-natural-compare": "3.0.1",
     "use-strict": "1.0.1"
   }

--- a/packages/deployer/subtasks/cancel-deployment.js
+++ b/packages/deployer/subtasks/cancel-deployment.js
@@ -1,0 +1,24 @@
+const del = require('del');
+const { subtask } = require('hardhat/config');
+const logger = require('@synthetixio/core-js/utils/logger');
+const relativePath = require('@synthetixio/core-js/utils/relative-path');
+const { SUBTASK_CANCEL_DEPLOYMENT } = require('../task-names');
+
+subtask(
+  SUBTASK_CANCEL_DEPLOYMENT,
+  'Stop current deployment execution and delete created data files'
+).setAction(async (_, hre) => {
+  const toDelete = [
+    hre.deployer.paths.deployment,
+    hre.deployer.paths.sources,
+    hre.deployer.paths.abis,
+  ];
+
+  logger.info('Deleting generated files:');
+  toDelete.forEach((file) => logger.info(`  ${relativePath(file)}`));
+
+  await del(toDelete);
+
+  logger.info('Extiting...');
+  process.exit(0);
+});

--- a/packages/deployer/subtasks/clear-deployments.js
+++ b/packages/deployer/subtasks/clear-deployments.js
@@ -1,9 +1,9 @@
-const path = require('path');
-const rimraf = require('rimraf');
+const del = require('del');
 const { subtask } = require('hardhat/config');
 
 const logger = require('@synthetixio/core-js/utils/logger');
 const prompter = require('@synthetixio/core-js/utils/prompter');
+const { getDeploymentFolder } = require('../utils/deployments');
 const { getGeneratedContractPaths } = require('../internal/generate-contracts');
 const { SUBTASK_CLEAR_DEPLOYMENTS } = require('../task-names');
 
@@ -11,11 +11,11 @@ subtask(
   SUBTASK_CLEAR_DEPLOYMENTS,
   'Delete all previous deployment data on the current environment'
 ).setAction(async ({ instance }, hre) => {
-  const deploymentsFolder = path.join(
-    hre.config.deployer.paths.deployments,
-    hre.network.name,
-    instance
-  );
+  const deploymentsFolder = getDeploymentFolder({
+    folder: hre.config.deployer.paths.deployments,
+    network: hre.network.name,
+    instance,
+  });
 
   const generatedContracts = getGeneratedContractPaths(hre.config);
 
@@ -27,5 +27,5 @@ subtask(
 
   await prompter.confirmAction('Are you sure you want to delete all?');
 
-  toDelete.forEach((pathname) => rimraf.sync(pathname));
+  await del(toDelete);
 });

--- a/packages/deployer/subtasks/deploy-contract.js
+++ b/packages/deployer/subtasks/deploy-contract.js
@@ -8,7 +8,13 @@ const { SUBTASK_DEPLOY_CONTRACT } = require('../task-names');
 subtask(
   SUBTASK_DEPLOY_CONTRACT,
   'Deploys the given contract and update the contractData object.'
-).setAction(async ({ contractName, contractData, constructorArgs = [] }) => {
+).setAction(async ({ contractName, constructorArgs = [] }) => {
+  const contractData = hre.deployer.deployment.data.contracts[contractName];
+
+  if (!contractData) {
+    throw new Error(`Cotract ${contractName} cannot be deployed because is not initialized.`);
+  }
+
   if (await isAlreadyDeployed(contractName, contractData)) {
     return false;
   }

--- a/packages/deployer/subtasks/deploy-contract.js
+++ b/packages/deployer/subtasks/deploy-contract.js
@@ -9,7 +9,7 @@ subtask(
   SUBTASK_DEPLOY_CONTRACT,
   'Deploys the given contract and update the contractData object.'
 ).setAction(async ({ contractName, constructorArgs = [] }) => {
-  const contractData = hre.deployer.deployment.data.contracts[contractName];
+  const contractData = hre.deployer.deployment.general.contracts[contractName];
 
   if (!contractData) {
     throw new Error(`Cotract ${contractName} cannot be deployed because is not initialized.`);

--- a/packages/deployer/subtasks/deploy-contracts.js
+++ b/packages/deployer/subtasks/deploy-contracts.js
@@ -18,10 +18,9 @@ subtask(
   }
 
   // Update & create the contracts
-  for (const [contractName, contractData] of [...toUpdate, ...toCreate]) {
+  for (const contractName of [...toUpdate, ...toCreate]) {
     await hre.run(SUBTASK_DEPLOY_CONTRACT, {
       contractName,
-      contractData,
     });
   }
 
@@ -34,19 +33,19 @@ subtask(
 async function _confirmDeployments({ toSkip, toUpdate, toCreate }) {
   if (toSkip.length > 0) {
     logger.info(`There are ${toSkip.length} contracts that are already up-to-date:`);
-    toSkip.forEach(([contractName]) => logger.notice(`  ${contractName}`));
+    toSkip.forEach((contractName) => logger.notice(`  ${contractName}`));
   }
 
   if (toUpdate.length > 0) {
     logger.info(`The following ${toUpdate.length} contracts are going to be updated:`);
-    toUpdate.forEach(([contractName]) => logger.notice(`  ${contractName}`));
+    toUpdate.forEach((contractName) => logger.notice(`  ${contractName}`));
   }
 
   if (toCreate.length > 0) {
     logger.info(
       `The following ${toCreate.length} contracts are going to be deployed for the first time:`
     );
-    toCreate.forEach(([contractName]) => logger.notice(`  ${contractName}`));
+    toCreate.forEach((contractName) => logger.notice(`  ${contractName}`));
   }
 
   return await prompter.ask('Are you sure you want to make these changes?');
@@ -64,12 +63,12 @@ async function _processContracts(contracts) {
 
   for (const [contractName, contractData] of Object.entries(contracts)) {
     if (hre.network.name === 'hardhat' || !contractData.deployedAddress) {
-      toCreate.push([contractName, contractData]);
+      toCreate.push(contractName);
     } else {
       if (await isAlreadyDeployed(contractName, contractData)) {
-        toSkip.push([contractName, contractData]);
+        toSkip.push(contractName);
       } else {
-        toUpdate.push([contractName, contractData]);
+        toUpdate.push(contractName);
       }
     }
   }

--- a/packages/deployer/subtasks/deploy-modules.js
+++ b/packages/deployer/subtasks/deploy-modules.js
@@ -9,7 +9,7 @@ const { SUBTASK_DEPLOY_CONTRACTS, SUBTASK_DEPLOY_MODULES } = require('../task-na
 subtask(SUBTASK_DEPLOY_MODULES).setAction(async (_, hre) => {
   logger.subtitle('Deploying modules');
 
-  const modules = filterValues(hre.deployer.deployment.contracts, (c) => c.isModule);
+  const modules = filterValues(hre.deployer.deployment.data.contracts, (c) => c.isModule);
 
   const deployedSomething = await hre.run(SUBTASK_DEPLOY_CONTRACTS, {
     contracts: modules,

--- a/packages/deployer/subtasks/deploy-modules.js
+++ b/packages/deployer/subtasks/deploy-modules.js
@@ -1,10 +1,12 @@
-const rimraf = require('rimraf');
 const { subtask } = require('hardhat/config');
 
 const logger = require('@synthetixio/core-js/utils/logger');
-const relativePath = require('@synthetixio/core-js/utils/relative-path');
 const filterValues = require('filter-values');
-const { SUBTASK_DEPLOY_CONTRACTS, SUBTASK_DEPLOY_MODULES } = require('../task-names');
+const {
+  SUBTASK_DEPLOY_CONTRACTS,
+  SUBTASK_DEPLOY_MODULES,
+  SUBTASK_CANCEL_DEPLOYMENT,
+} = require('../task-names');
 
 subtask(SUBTASK_DEPLOY_MODULES).setAction(async (_, hre) => {
   logger.subtitle('Deploying modules');
@@ -16,9 +18,7 @@ subtask(SUBTASK_DEPLOY_MODULES).setAction(async (_, hre) => {
   });
 
   if (!deployedSomething) {
-    logger.info('No modules need to be deployed, clearing generated files and exiting...');
-    logger.info(`Deleting ${relativePath(hre.deployer.paths.deployment)}`);
-    rimraf.sync(hre.deployer.paths.deployment);
-    process.exit(0);
+    logger.info('No modules need to be deployed, cancelling execution...');
+    return await hre.run(SUBTASK_CANCEL_DEPLOYMENT);
   }
 });

--- a/packages/deployer/subtasks/deploy-modules.js
+++ b/packages/deployer/subtasks/deploy-modules.js
@@ -9,7 +9,7 @@ const { SUBTASK_DEPLOY_CONTRACTS, SUBTASK_DEPLOY_MODULES } = require('../task-na
 subtask(SUBTASK_DEPLOY_MODULES).setAction(async (_, hre) => {
   logger.subtitle('Deploying modules');
 
-  const modules = filterValues(hre.deployer.deployment.data.contracts, (c) => c.isModule);
+  const modules = filterValues(hre.deployer.deployment.general.contracts, (c) => c.isModule);
 
   const deployedSomething = await hre.run(SUBTASK_DEPLOY_CONTRACTS, {
     contracts: modules,

--- a/packages/deployer/subtasks/deploy-modules.js
+++ b/packages/deployer/subtasks/deploy-modules.js
@@ -1,8 +1,8 @@
-const path = require('path');
 const rimraf = require('rimraf');
 const { subtask } = require('hardhat/config');
 
 const logger = require('@synthetixio/core-js/utils/logger');
+const relativePath = require('@synthetixio/core-js/utils/relative-path');
 const filterValues = require('filter-values');
 const { SUBTASK_DEPLOY_CONTRACTS, SUBTASK_DEPLOY_MODULES } = require('../task-names');
 
@@ -17,8 +17,8 @@ subtask(SUBTASK_DEPLOY_MODULES).setAction(async (_, hre) => {
 
   if (!deployedSomething) {
     logger.info('No modules need to be deployed, clearing generated files and exiting...');
-    logger.info(`Deleting ${hre.deployer.deployment.file}`);
-    rimraf.sync(path.resolve(hre.config.paths.root, hre.deployer.deployment.file));
+    logger.info(`Deleting ${relativePath(hre.deployer.deployment.file)}`);
+    rimraf.sync(hre.deployer.deployment.file);
     process.exit(0);
   }
 });

--- a/packages/deployer/subtasks/deploy-modules.js
+++ b/packages/deployer/subtasks/deploy-modules.js
@@ -17,8 +17,8 @@ subtask(SUBTASK_DEPLOY_MODULES).setAction(async (_, hre) => {
 
   if (!deployedSomething) {
     logger.info('No modules need to be deployed, clearing generated files and exiting...');
-    logger.info(`Deleting ${relativePath(hre.deployer.deployment.file)}`);
-    rimraf.sync(hre.deployer.deployment.file);
+    logger.info(`Deleting ${relativePath(hre.deployer.paths.deployment)}`);
+    rimraf.sync(hre.deployer.paths.deployment);
     process.exit(0);
   }
 });

--- a/packages/deployer/subtasks/deploy-router.js
+++ b/packages/deployer/subtasks/deploy-router.js
@@ -17,16 +17,16 @@ subtask(SUBTASK_DEPLOY_ROUTER).setAction(async (_, hre) => {
     `${contractName}.sol`
   );
 
-  let contractData = hre.deployer.deployment.contracts[contractName];
+  let contractData = hre.deployer.deployment.data.contracts[contractName];
 
   if (!contractData) {
-    hre.deployer.deployment.contracts[contractName] = {
+    hre.deployer.deployment.data.contracts[contractName] = {
       source: conntractPath,
       deployedAddress: '',
       deployTransaction: '',
       bytecodeHash: '',
     };
-    contractData = hre.deployer.deployment.contracts[contractName];
+    contractData = hre.deployer.deployment.data.contracts[contractName];
   }
 
   await hre.run(SUBTASK_DEPLOY_CONTRACT, {

--- a/packages/deployer/subtasks/deploy-router.js
+++ b/packages/deployer/subtasks/deploy-router.js
@@ -16,8 +16,5 @@ subtask(SUBTASK_DEPLOY_ROUTER).setAction(async (_, hre) => {
     await initContractData(contractName);
   }
 
-  await hre.run(SUBTASK_DEPLOY_CONTRACT, {
-    contractName,
-    contractData: hre.deployer.deployment.data.contracts[contractName],
-  });
+  await hre.run(SUBTASK_DEPLOY_CONTRACT, { contractName });
 });

--- a/packages/deployer/subtasks/deploy-router.js
+++ b/packages/deployer/subtasks/deploy-router.js
@@ -12,9 +12,6 @@ subtask(SUBTASK_DEPLOY_ROUTER).setAction(async (_, hre) => {
 
   const contractName = 'Router';
 
-  if (!hre.deployer.deployment.data.contracts[contractName]) {
-    await initContractData(contractName);
-  }
-
+  await initContractData(contractName);
   await hre.run(SUBTASK_DEPLOY_CONTRACT, { contractName });
 });

--- a/packages/deployer/subtasks/deploy-router.js
+++ b/packages/deployer/subtasks/deploy-router.js
@@ -1,8 +1,7 @@
 const logger = require('@synthetixio/core-js/utils/logger');
-const path = require('path');
 const { subtask } = require('hardhat/config');
 const { TASK_COMPILE } = require('hardhat/builtin-tasks/task-names');
-const relativePath = require('@synthetixio/core-js/utils/relative-path');
+const { initContractData } = require('../internal/process-contracts');
 
 const { SUBTASK_DEPLOY_CONTRACT, SUBTASK_DEPLOY_ROUTER } = require('../task-names');
 
@@ -12,25 +11,13 @@ subtask(SUBTASK_DEPLOY_ROUTER).setAction(async (_, hre) => {
   await hre.run(TASK_COMPILE, { force: false, quiet: true });
 
   const contractName = 'Router';
-  const conntractPath = path.join(
-    relativePath(hre.config.paths.sources, hre.config.paths.root),
-    `${contractName}.sol`
-  );
 
-  let contractData = hre.deployer.deployment.data.contracts[contractName];
-
-  if (!contractData) {
-    hre.deployer.deployment.data.contracts[contractName] = {
-      source: conntractPath,
-      deployedAddress: '',
-      deployTransaction: '',
-      bytecodeHash: '',
-    };
-    contractData = hre.deployer.deployment.data.contracts[contractName];
+  if (!hre.deployer.deployment.data.contracts[contractName]) {
+    await initContractData(contractName);
   }
 
   await hre.run(SUBTASK_DEPLOY_CONTRACT, {
     contractName,
-    contractData,
+    contractData: hre.deployer.deployment.data.contracts[contractName],
   });
 });

--- a/packages/deployer/subtasks/deploy-router.js
+++ b/packages/deployer/subtasks/deploy-router.js
@@ -1,14 +1,11 @@
 const logger = require('@synthetixio/core-js/utils/logger');
 const { subtask } = require('hardhat/config');
-const { TASK_COMPILE } = require('hardhat/builtin-tasks/task-names');
 const { initContractData } = require('../internal/process-contracts');
 
 const { SUBTASK_DEPLOY_CONTRACT, SUBTASK_DEPLOY_ROUTER } = require('../task-names');
 
 subtask(SUBTASK_DEPLOY_ROUTER).setAction(async (_, hre) => {
   logger.subtitle('Deploying router');
-
-  await hre.run(TASK_COMPILE, { force: false, quiet: true });
 
   const contractName = 'Router';
 

--- a/packages/deployer/subtasks/finalize-deployment.js
+++ b/packages/deployer/subtasks/finalize-deployment.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const path = require('path');
 const logger = require('@synthetixio/core-js/utils/logger');
 const { subtask } = require('hardhat/config');
 const { SUBTASK_FINALIZE_DEPLOYMENT } = require('../task-names');
@@ -13,7 +12,7 @@ subtask(SUBTASK_FINALIZE_DEPLOYMENT).setAction(async (_, hre) => {
   if (hre.deployer.deployment.data.properties.totalGasUsed === '0') {
     logger.checked('Deployment did not produce any changes, deleting temp file');
 
-    fs.unlinkSync(path.resolve(hre.config.paths.root, hre.deployer.deployment.file));
+    fs.unlinkSync(hre.deployer.deployment.file);
   } else {
     logger.complete('Deployment marked as completed');
 

--- a/packages/deployer/subtasks/finalize-deployment.js
+++ b/packages/deployer/subtasks/finalize-deployment.js
@@ -10,13 +10,13 @@ const { SUBTASK_FINALIZE_DEPLOYMENT } = require('../task-names');
 subtask(SUBTASK_FINALIZE_DEPLOYMENT).setAction(async (_, hre) => {
   logger.subtitle('Finalizing deployment');
 
-  if (hre.deployer.deployment.properties.totalGasUsed === '0') {
+  if (hre.deployer.deployment.data.properties.totalGasUsed === '0') {
     logger.checked('Deployment did not produce any changes, deleting temp file');
 
     fs.unlinkSync(path.resolve(hre.config.paths.root, hre.deployer.deployment.file));
   } else {
     logger.complete('Deployment marked as completed');
 
-    hre.deployer.deployment.properties.completed = true;
+    hre.deployer.deployment.data.properties.completed = true;
   }
 });

--- a/packages/deployer/subtasks/finalize-deployment.js
+++ b/packages/deployer/subtasks/finalize-deployment.js
@@ -9,13 +9,13 @@ const { SUBTASK_FINALIZE_DEPLOYMENT } = require('../task-names');
 subtask(SUBTASK_FINALIZE_DEPLOYMENT).setAction(async (_, hre) => {
   logger.subtitle('Finalizing deployment');
 
-  if (hre.deployer.deployment.data.properties.totalGasUsed === '0') {
+  if (hre.deployer.deployment.general.properties.totalGasUsed === '0') {
     logger.checked('Deployment did not produce any changes, deleting temp file');
 
     fs.unlinkSync(hre.deployer.paths.deployment);
   } else {
     logger.complete('Deployment marked as completed');
 
-    hre.deployer.deployment.data.properties.completed = true;
+    hre.deployer.deployment.general.properties.completed = true;
   }
 });

--- a/packages/deployer/subtasks/finalize-deployment.js
+++ b/packages/deployer/subtasks/finalize-deployment.js
@@ -12,7 +12,7 @@ subtask(SUBTASK_FINALIZE_DEPLOYMENT).setAction(async (_, hre) => {
   if (hre.deployer.deployment.data.properties.totalGasUsed === '0') {
     logger.checked('Deployment did not produce any changes, deleting temp file');
 
-    fs.unlinkSync(hre.deployer.deployment.file);
+    fs.unlinkSync(hre.deployer.paths.deployment);
   } else {
     logger.complete('Deployment marked as completed');
 

--- a/packages/deployer/subtasks/generate-router.js
+++ b/packages/deployer/subtasks/generate-router.js
@@ -25,7 +25,7 @@ subtask(
   logger.subtitle('Generating router source');
   logger.info(`location: ${routerPath}`);
 
-  const modules = filterValues(hre.deployer.deployment.data.contracts, (c) => c.isModule);
+  const modules = filterValues(hre.deployer.deployment.general.contracts, (c) => c.isModule);
   const modulesNames = Object.keys(modules);
   logger.debug(`modules: ${JSON.stringify(modulesNames, null, 2)}`);
 

--- a/packages/deployer/subtasks/generate-router.js
+++ b/packages/deployer/subtasks/generate-router.js
@@ -25,7 +25,7 @@ subtask(
   logger.subtitle('Generating router source');
   logger.info(`location: ${routerPath}`);
 
-  const modules = filterValues(hre.deployer.deployment.contracts, (c) => c.isModule);
+  const modules = filterValues(hre.deployer.deployment.data.contracts, (c) => c.isModule);
   const modulesNames = Object.keys(modules);
   logger.debug(`modules: ${JSON.stringify(modulesNames, null, 2)}`);
 

--- a/packages/deployer/subtasks/prepare-deployment.js
+++ b/packages/deployer/subtasks/prepare-deployment.js
@@ -34,15 +34,23 @@ subtask(
   // Make sure the deployments folder exists
   await mkdirp(deploymentsFolder);
 
-  const { previousFile, currentFile } = await _determineDeploymentFiles(deploymentsFolder, alias);
+  const { currentName, currentFile, previousName, previousFile } = await _determineDeploymentFiles(
+    deploymentsFolder,
+    alias
+  );
+
+  hre.deployer.paths.deployment = currentFile;
 
   hre.deployer.deployment = {
-    file: currentFile,
+    name: currentName,
     data: autosaveObject(currentFile, DEPLOYMENT_SCHEMA),
   };
 
   if (previousFile) {
-    hre.deployer.previousDeployment = JSON.parse(fs.readFileSync(previousFile));
+    hre.deployer.previousDeployment = {
+      name: previousName,
+      data: JSON.parse(fs.readFileSync(previousFile)),
+    };
   }
 });
 

--- a/packages/deployer/subtasks/prepare-deployment.js
+++ b/packages/deployer/subtasks/prepare-deployment.js
@@ -5,6 +5,7 @@ const { subtask } = require('hardhat/config');
 
 const prompter = require('@synthetixio/core-js/utils/prompter');
 const relativePath = require('@synthetixio/core-js/utils/relative-path');
+const getDate = require('@synthetixio/core-js/utils/date');
 const autosaveObject = require('../internal/autosave-object');
 const { getAllDeploymentFiles } = require('../utils/deployments');
 const { SUBTASK_PREPARE_DEPLOYMENT } = require('../task-names');
@@ -84,7 +85,7 @@ async function _determineDeploymentFiles(deploymentsFolder, alias) {
   }
 
   // Get the date with format `YYYY-mm-dd`
-  const today = _getDate();
+  const today = getDate();
 
   // Calculate the next deployment number based on the previous one
   let number = '00';
@@ -102,12 +103,4 @@ async function _determineDeploymentFiles(deploymentsFolder, alias) {
     previousFile: latestFile,
     currentFile,
   };
-}
-
-function _getDate() {
-  const now = new Date();
-  const year = `${now.getUTCFullYear()}`;
-  const month = `${now.getUTCMonth() + 1}`.padStart(2, '0');
-  const day = `${now.getUTCDate()}`.padStart(2, '0');
-  return `${year}-${month}-${day}`;
 }

--- a/packages/deployer/subtasks/prepare-deployment.js
+++ b/packages/deployer/subtasks/prepare-deployment.js
@@ -54,14 +54,14 @@ subtask(
   hre.deployer.paths.abis = abis;
 
   hre.deployer.deployment = {
-    data: autosaveObject(currentFile, DEPLOYMENT_SCHEMA),
+    general: autosaveObject(currentFile, DEPLOYMENT_SCHEMA),
     sources: autosaveObject(sources, {}),
     abis: autosaveObject(abis, {}),
   };
 
   if (previousFile) {
     hre.deployer.previousDeployment = {
-      data: JSON.parse(fs.readFileSync(previousFile)),
+      general: JSON.parse(fs.readFileSync(previousFile)),
     };
   }
 });

--- a/packages/deployer/subtasks/prepare-deployment.js
+++ b/packages/deployer/subtasks/prepare-deployment.js
@@ -5,7 +5,7 @@ const { subtask } = require('hardhat/config');
 
 const prompter = require('@synthetixio/core-js/utils/prompter');
 const relativePath = require('@synthetixio/core-js/utils/relative-path');
-const getDate = require('@synthetixio/core-js/utils/date');
+const getDate = require('@synthetixio/core-js/utils/get-date');
 const autosaveObject = require('../internal/autosave-object');
 const { getAllDeploymentFiles } = require('../utils/deployments');
 const { SUBTASK_PREPARE_DEPLOYMENT } = require('../task-names');

--- a/packages/deployer/subtasks/prepare-deployment.js
+++ b/packages/deployer/subtasks/prepare-deployment.js
@@ -37,7 +37,7 @@ subtask(
   const { previousFile, currentFile } = await _determineDeploymentFiles(deploymentsFolder, alias);
 
   hre.deployer.deployment = {
-    file: relativePath(currentFile, hre.config.paths.root),
+    file: currentFile,
     data: autosaveObject(currentFile, DEPLOYMENT_SCHEMA),
   };
 

--- a/packages/deployer/subtasks/prepare-deployment.js
+++ b/packages/deployer/subtasks/prepare-deployment.js
@@ -71,7 +71,6 @@ subtask(
 async function _determineDeploymentFiles(deploymentsFolder, alias) {
   const deployments = getAllDeploymentFiles({ folder: deploymentsFolder });
   const latestFile = deployments.length > 0 ? deployments[deployments.length - 1] : null;
-  const latestFileName = latestFile && path.basename(latestFile, '.json');
 
   // Check if there is an unfinished deployment and prompt the user if we should
   // continue with it, instead of creating a new one.
@@ -109,6 +108,7 @@ async function _determineDeploymentFiles(deploymentsFolder, alias) {
 
   // Calculate the next deployment number based on the previous one
   let number = '00';
+  const latestFileName = latestFile && path.basename(latestFile);
   if (latestFileName && latestFileName.startsWith(today)) {
     const previousNumber = latestFileName.slice(11, 13);
     number = `${Number.parseInt(previousNumber) + 1}`.padStart(2, '0');

--- a/packages/deployer/subtasks/prepare-deployment.js
+++ b/packages/deployer/subtasks/prepare-deployment.js
@@ -30,7 +30,7 @@ subtask(
   const { instance, alias } = taskArguments;
 
   const info = {
-    folder: path.resolve(hre.config.paths.root, hre.config.deployer.paths.deployments),
+    folder: hre.config.deployer.paths.deployments,
     network: hre.network.name,
     instance,
   };

--- a/packages/deployer/subtasks/prepare-deployment.js
+++ b/packages/deployer/subtasks/prepare-deployment.js
@@ -49,8 +49,8 @@ subtask(
 
   hre.deployer.deployment = {
     data: autosaveObject(currentFile, DEPLOYMENT_SCHEMA),
-    sources: autosaveObject(sources, []),
-    abis: autosaveObject(abis, []),
+    sources: autosaveObject(sources, {}),
+    abis: autosaveObject(abis, {}),
     txs: autosaveObject(txs, []),
   };
 

--- a/packages/deployer/subtasks/prepare-deployment.js
+++ b/packages/deployer/subtasks/prepare-deployment.js
@@ -7,11 +7,7 @@ const prompter = require('@synthetixio/core-js/utils/prompter');
 const relativePath = require('@synthetixio/core-js/utils/relative-path');
 const getDate = require('@synthetixio/core-js/utils/get-date');
 const autosaveObject = require('../internal/autosave-object');
-const {
-  getDeploymentName,
-  getAllDeploymentFiles,
-  getDeploymentExtendedFiles,
-} = require('../utils/deployments');
+const { getAllDeploymentFiles, getDeploymentExtendedFiles } = require('../utils/deployments');
 const { SUBTASK_PREPARE_DEPLOYMENT } = require('../task-names');
 
 const DEPLOYMENT_SCHEMA = {

--- a/packages/deployer/subtasks/prepare-deployment.js
+++ b/packages/deployer/subtasks/prepare-deployment.js
@@ -17,7 +17,6 @@ const DEPLOYMENT_SCHEMA = {
   },
   transactions: {},
   contracts: {},
-  file: null,
 };
 
 subtask(
@@ -37,8 +36,10 @@ subtask(
 
   const { previousFile, currentFile } = await _determineDeploymentFiles(deploymentsFolder, alias);
 
-  hre.deployer.deployment = autosaveObject(currentFile, DEPLOYMENT_SCHEMA);
-  hre.deployer.deployment.file = relativePath(currentFile);
+  hre.deployer.deployment = {
+    file: relativePath(currentFile, hre.config.paths.root),
+    data: autosaveObject(currentFile, DEPLOYMENT_SCHEMA),
+  };
 
   if (previousFile) {
     hre.deployer.previousDeployment = JSON.parse(fs.readFileSync(previousFile));

--- a/packages/deployer/subtasks/print-info.js
+++ b/packages/deployer/subtasks/print-info.js
@@ -5,6 +5,7 @@ const { subtask } = require('hardhat/config');
 
 const logger = require('@synthetixio/core-js/utils/logger');
 const prompter = require('@synthetixio/core-js/utils/prompter');
+const relativePath = require('@synthetixio/core-js/utils/relative-path');
 const { getCommit, getBranch } = require('@synthetixio/core-js/utils/git');
 const { readPackageJson } = require('@synthetixio/core-js/utils/package');
 const { SUBTASK_PRINT_INFO } = require('../task-names');
@@ -46,7 +47,7 @@ async function _printInfo(taskArguments) {
 
   logger.log(chalk.gray(`instance: ${taskArguments.instance}`));
   logger.log(chalk.gray(`debug: ${taskArguments.debug}`));
-  logger.log(chalk.gray(`deployment file: ${hre.deployer.deployment.file}`));
+  logger.log(chalk.gray(`deployment file: ${relativePath(hre.deployer.deployment.file)}`));
 
   const signer = (await hre.ethers.getSigners())[0];
   const balance = hre.ethers.utils.formatEther(

--- a/packages/deployer/subtasks/print-info.js
+++ b/packages/deployer/subtasks/print-info.js
@@ -47,7 +47,7 @@ async function _printInfo(taskArguments) {
 
   logger.log(chalk.gray(`instance: ${taskArguments.instance}`));
   logger.log(chalk.gray(`debug: ${taskArguments.debug}`));
-  logger.log(chalk.gray(`deployment file: ${relativePath(hre.deployer.deployment.file)}`));
+  logger.log(chalk.gray(`deployment: ${relativePath(hre.deployer.paths.deployment)}`));
 
   const signer = (await hre.ethers.getSigners())[0];
   const balance = hre.ethers.utils.formatEther(

--- a/packages/deployer/subtasks/sync-sources.js
+++ b/packages/deployer/subtasks/sync-sources.js
@@ -3,7 +3,6 @@ const filterValues = require('filter-values');
 const { subtask } = require('hardhat/config');
 const logger = require('@synthetixio/core-js/utils/logger');
 const prompter = require('@synthetixio/core-js/utils/prompter');
-const { TASK_COMPILE } = require('hardhat/builtin-tasks/task-names');
 const { getModulesPaths } = require('../internal/path-finder');
 const { initContractData } = require('../internal/process-contracts');
 const { SUBTASK_SYNC_SOURCES } = require('../task-names');
@@ -18,8 +17,6 @@ subtask(
   'Synchronizes the deployment file with the latest module sources.'
 ).setAction(async (_, hre) => {
   logger.subtitle('Syncing solidity sources with deployment data');
-
-  await hre.run(TASK_COMPILE, { force: false, quiet: true });
 
   const { previousDeployment } = hre.deployer;
   const sources = getModulesPaths(hre.config);

--- a/packages/deployer/subtasks/sync-sources.js
+++ b/packages/deployer/subtasks/sync-sources.js
@@ -65,8 +65,8 @@ async function _addNewSources({ sources, deployment, previousDeployment }) {
     const contractName = path.basename(source, '.sol');
     const previousModule = previousDeployment?.contracts[contractName];
 
-    deployment.contracts[contractName] =
-      deployment.contracts[contractName] || previousModule || _createModuleData({ source });
+    deployment.data.contracts[contractName] =
+      deployment.data.contracts[contractName] || previousModule || _createModuleData({ source });
 
     if (!previousModule) created = true;
   }

--- a/packages/deployer/subtasks/sync-sources.js
+++ b/packages/deployer/subtasks/sync-sources.js
@@ -31,7 +31,7 @@ subtask(
 async function _removeDeletedSources({ sources, previousDeployment }) {
   if (!previousDeployment) return false;
 
-  const modules = filterValues(previousDeployment.contracts, (c) => c.isModule);
+  const modules = filterValues(previousDeployment.data.contracts, (c) => c.isModule);
   const modulesPaths = Object.values(modules).map((c) => c.source);
 
   const toRemove = modulesPaths.filter(
@@ -63,7 +63,7 @@ async function _addNewSources({ sources, deployment, previousDeployment }) {
   // Initialize cotract data, using previous deployed one, or empty data.
   for (const source of sources) {
     const contractName = path.basename(source, '.sol');
-    const previousModule = previousDeployment?.contracts[contractName];
+    const previousModule = previousDeployment?.data.contracts[contractName];
 
     deployment.data.contracts[contractName] =
       deployment.data.contracts[contractName] || previousModule || _createModuleData({ source });

--- a/packages/deployer/subtasks/sync-sources.js
+++ b/packages/deployer/subtasks/sync-sources.js
@@ -54,20 +54,21 @@ async function _removeDeletedSources({ sources, previousDeployment }) {
 }
 
 async function _addNewSources({ sources, previousDeployment }) {
-  let created = false;
+  const toAdd = [];
 
   // Initialize cotract data, using previous deployed one, or empty data.
   for (const source of sources) {
     const contractName = path.basename(source, '.sol');
-    const previousData = previousDeployment?.data.contracts[contractName];
 
-    await initContractData(contractName, {
-      ...(previousData || {}),
-      isModule: true,
-    });
+    await initContractData(contractName, { isModule: true });
 
-    if (!previousData) created = true;
+    if (!previousDeployment?.data.contracts[contractName]) {
+      toAdd.push(source);
+    }
   }
 
-  return created;
+  logger.notice('The following modules are going to be deployed for the first time:');
+  toAdd.forEach((source) => logger.notice(`  ${source}`));
+
+  return toAdd.length > 0;
 }

--- a/packages/deployer/subtasks/sync-sources.js
+++ b/packages/deployer/subtasks/sync-sources.js
@@ -1,9 +1,10 @@
 const path = require('path');
+const filterValues = require('filter-values');
 const { subtask } = require('hardhat/config');
 const logger = require('@synthetixio/core-js/utils/logger');
 const prompter = require('@synthetixio/core-js/utils/prompter');
+const { TASK_COMPILE } = require('hardhat/builtin-tasks/task-names');
 const { getModulesPaths } = require('../internal/path-finder');
-const filterValues = require('filter-values');
 const { SUBTASK_SYNC_SOURCES } = require('../task-names');
 
 /**
@@ -16,6 +17,8 @@ subtask(
   'Synchronizes the deployment file with the latest module sources.'
 ).setAction(async (_, hre) => {
   logger.subtitle('Syncing solidity sources with deployment data');
+
+  await hre.run(TASK_COMPILE, { force: false, quiet: true });
 
   const { deployment, previousDeployment } = hre.deployer;
   const sources = getModulesPaths(hre.config);

--- a/packages/deployer/subtasks/sync-sources.js
+++ b/packages/deployer/subtasks/sync-sources.js
@@ -35,7 +35,7 @@ subtask(
 async function _removeDeletedSources({ sources, previousDeployment }) {
   if (!previousDeployment) return false;
 
-  const modules = filterValues(previousDeployment.data.contracts, (c) => c.isModule);
+  const modules = filterValues(previousDeployment.general.contracts, (c) => c.isModule);
   const modulesPaths = Object.values(modules).map((c) => c.sourceName);
 
   const toRemove = modulesPaths.filter(
@@ -62,7 +62,7 @@ async function _addNewSources({ sources, previousDeployment }) {
 
     await initContractData(contractName, { isModule: true });
 
-    if (!previousDeployment?.data.contracts[contractName]) {
+    if (!previousDeployment?.general.contracts[contractName]) {
       toAdd.push(source);
     }
   }

--- a/packages/deployer/subtasks/upgrade-proxy.js
+++ b/packages/deployer/subtasks/upgrade-proxy.js
@@ -1,8 +1,7 @@
 const logger = require('@synthetixio/core-js/utils/logger');
 const prompter = require('@synthetixio/core-js/utils/prompter');
-const path = require('path');
-const relativePath = require('@synthetixio/core-js/utils/relative-path');
 const { subtask } = require('hardhat/config');
+const { initContractData } = require('../internal/process-contracts');
 const { processTransaction, processReceipt } = require('../internal/process-transactions');
 const { SUBTASK_UPGRADE_PROXY, SUBTASK_DEPLOY_CONTRACT } = require('../task-names');
 
@@ -48,14 +47,8 @@ subtask(
 
   logger.info(`Target implementation: ${routerAddress}`);
 
-  const proxyPath = path.join(
-    relativePath(hre.config.paths.sources, hre.config.paths.root),
-    `${proxyName}.sol`
-  );
-
   const wasProxyDeployed = await _deployProxy({
     proxyName,
-    proxyPath,
     routerAddress,
     hre,
   });
@@ -70,22 +63,14 @@ function _getDeployedAddress(contractName, hre) {
   return hre.deployer.deployment.data.contracts[contractName].deployedAddress;
 }
 
-async function _deployProxy({ proxyName, proxyPath, routerAddress, hre }) {
-  let proxyData = hre.deployer.deployment.data.contracts[proxyName];
-
-  if (!proxyData) {
-    hre.deployer.deployment.data.contracts[proxyName] = {
-      source: proxyPath,
-      deployedAddress: '',
-      deployTransaction: '',
-      bytecodeHash: '',
-    };
-    proxyData = hre.deployer.deployment.data.contracts[proxyName];
+async function _deployProxy({ proxyName, routerAddress, hre }) {
+  if (!hre.deployer.deployment.data.contracts[proxyName]) {
+    await initContractData(proxyName);
   }
 
   return await hre.run(SUBTASK_DEPLOY_CONTRACT, {
     contractName: proxyName,
-    contractData: proxyData,
+    contractData: hre.deployer.deployment.data.contracts[proxyName],
     constructorArgs: [routerAddress],
   });
 }

--- a/packages/deployer/subtasks/upgrade-proxy.js
+++ b/packages/deployer/subtasks/upgrade-proxy.js
@@ -70,7 +70,6 @@ async function _deployProxy({ proxyName, routerAddress, hre }) {
 
   return await hre.run(SUBTASK_DEPLOY_CONTRACT, {
     contractName: proxyName,
-    contractData: hre.deployer.deployment.data.contracts[proxyName],
     constructorArgs: [routerAddress],
   });
 }

--- a/packages/deployer/subtasks/upgrade-proxy.js
+++ b/packages/deployer/subtasks/upgrade-proxy.js
@@ -67,20 +67,20 @@ subtask(
 });
 
 function _getDeployedAddress(contractName, hre) {
-  return hre.deployer.deployment.contracts[contractName].deployedAddress;
+  return hre.deployer.deployment.data.contracts[contractName].deployedAddress;
 }
 
 async function _deployProxy({ proxyName, proxyPath, routerAddress, hre }) {
-  let proxyData = hre.deployer.deployment.contracts[proxyName];
+  let proxyData = hre.deployer.deployment.data.contracts[proxyName];
 
   if (!proxyData) {
-    hre.deployer.deployment.contracts[proxyName] = {
+    hre.deployer.deployment.data.contracts[proxyName] = {
       source: proxyPath,
       deployedAddress: '',
       deployTransaction: '',
       bytecodeHash: '',
     };
-    proxyData = hre.deployer.deployment.contracts[proxyName];
+    proxyData = hre.deployer.deployment.data.contracts[proxyName];
   }
 
   return await hre.run(SUBTASK_DEPLOY_CONTRACT, {

--- a/packages/deployer/subtasks/upgrade-proxy.js
+++ b/packages/deployer/subtasks/upgrade-proxy.js
@@ -1,7 +1,7 @@
 const logger = require('@synthetixio/core-js/utils/logger');
 const prompter = require('@synthetixio/core-js/utils/prompter');
 const path = require('path');
-const relativePath = require('@synthetixio/core-js//utils/relative-path');
+const relativePath = require('@synthetixio/core-js/utils/relative-path');
 const { subtask } = require('hardhat/config');
 const { processTransaction, processReceipt } = require('../internal/process-transactions');
 const { SUBTASK_UPGRADE_PROXY, SUBTASK_DEPLOY_CONTRACT } = require('../task-names');

--- a/packages/deployer/subtasks/upgrade-proxy.js
+++ b/packages/deployer/subtasks/upgrade-proxy.js
@@ -60,7 +60,7 @@ subtask(
 });
 
 function _getDeployedAddress(contractName, hre) {
-  return hre.deployer.deployment.data.contracts[contractName].deployedAddress;
+  return hre.deployer.deployment.general.contracts[contractName].deployedAddress;
 }
 
 async function _deployProxy({ proxyName, routerAddress, hre }) {

--- a/packages/deployer/subtasks/upgrade-proxy.js
+++ b/packages/deployer/subtasks/upgrade-proxy.js
@@ -64,10 +64,7 @@ function _getDeployedAddress(contractName, hre) {
 }
 
 async function _deployProxy({ proxyName, routerAddress, hre }) {
-  if (!hre.deployer.deployment.data.contracts[proxyName]) {
-    await initContractData(proxyName);
-  }
-
+  await initContractData(proxyName);
   return await hre.run(SUBTASK_DEPLOY_CONTRACT, {
     contractName: proxyName,
     constructorArgs: [routerAddress],

--- a/packages/deployer/subtasks/validate-modules.js
+++ b/packages/deployer/subtasks/validate-modules.js
@@ -1,10 +1,8 @@
-const path = require('path');
-const rimraf = require('rimraf');
 const { subtask } = require('hardhat/config');
 const logger = require('@synthetixio/core-js/utils/logger');
 const filterValues = require('filter-values');
 const { getAllSelectors, findDuplicateSelectors } = require('../internal/contract-helper');
-const { SUBTASK_VALIDATE_MODULES } = require('../task-names');
+const { SUBTASK_VALIDATE_MODULES, SUBTASK_CANCEL_DEPLOYMENT } = require('../task-names');
 
 subtask(SUBTASK_VALIDATE_MODULES).setAction(async (_, hre) => {
   logger.subtitle('Validating modules');
@@ -20,9 +18,7 @@ subtask(SUBTASK_VALIDATE_MODULES).setAction(async (_, hre) => {
     );
 
     logger.error(`Duplicate selectors found!\n${details.join('')}`);
-    logger.info(`Deleting ${hre.deployer.deployment.file}`);
-    rimraf.sync(path.resolve(hre.config.paths.root, hre.deployer.deployment.file));
-    process.exit(0);
+    return await hre.run(SUBTASK_CANCEL_DEPLOYMENT);
   }
 
   logger.checked('Modules are valid');

--- a/packages/deployer/subtasks/validate-router.js
+++ b/packages/deployer/subtasks/validate-router.js
@@ -18,7 +18,7 @@ subtask(
     'Router.sol'
   );
 
-  const modules = filterValues(hre.deployer.deployment.contracts, (c) => c.isModule);
+  const modules = filterValues(hre.deployer.deployment.data.contracts, (c) => c.isModule);
   const modulesNames = Object.keys(modules);
 
   await _selectorsExistInSource({

--- a/packages/deployer/subtasks/validate-router.js
+++ b/packages/deployer/subtasks/validate-router.js
@@ -18,7 +18,7 @@ subtask(
     'Router.sol'
   );
 
-  const modules = filterValues(hre.deployer.deployment.data.contracts, (c) => c.isModule);
+  const modules = filterValues(hre.deployer.deployment.general.contracts, (c) => c.isModule);
   const modulesNames = Object.keys(modules);
 
   await _selectorsExistInSource({

--- a/packages/deployer/task-names.js
+++ b/packages/deployer/task-names.js
@@ -1,4 +1,5 @@
 module.exports = {
+  SUBTASK_CANCEL_DEPLOYMENT: 'cancel-deployment',
   SUBTASK_CLEAR_DEPLOYMENTS: 'clear-deployments',
   SUBTASK_DEPLOY_CONTRACT: 'deploy-contract',
   SUBTASK_DEPLOY_CONTRACTS: 'deploy-contracts',
@@ -9,7 +10,7 @@ module.exports = {
   SUBTASK_PRINT_INFO: 'print-info',
   SUBTASK_SYNC_SOURCES: 'sync-sources',
   SUBTASK_UPGRADE_PROXY: 'upgrade-proxy',
-  SUBTASK_VALIDATE_ROUTER: 'validate-router',
   SUBTASK_VALIDATE_MODULES: 'validate-modules',
+  SUBTASK_VALIDATE_ROUTER: 'validate-router',
   TASK_DEPLOY: 'deploy',
 };

--- a/packages/deployer/tasks/deploy.js
+++ b/packages/deployer/tasks/deploy.js
@@ -1,4 +1,5 @@
 const { task } = require('hardhat/config');
+const { TASK_COMPILE } = require('hardhat/builtin-tasks/task-names');
 
 const {
   SUBTASK_CLEAR_DEPLOYMENTS,
@@ -49,10 +50,12 @@ task(TASK_DEPLOY, 'Deploys all system modules')
     await hre.run(SUBTASK_PREPARE_DEPLOYMENT, taskArguments);
     await hre.run(SUBTASK_PRINT_INFO, taskArguments);
     await hre.run(SUBTASK_SYNC_SOURCES);
+    await hre.run(TASK_COMPILE, { force: false, quiet: true });
     await hre.run(SUBTASK_VALIDATE_MODULES);
     await hre.run(SUBTASK_DEPLOY_MODULES);
     await hre.run(SUBTASK_GENERATE_ROUTER_SOURCE);
     await hre.run(SUBTASK_VALIDATE_ROUTER);
+    await hre.run(TASK_COMPILE, { force: false, quiet: true });
     await hre.run(SUBTASK_DEPLOY_ROUTER);
     await hre.run(SUBTASK_UPGRADE_PROXY);
     await hre.run(SUBTASK_FINALIZE_DEPLOYMENT);

--- a/packages/deployer/tasks/deploy.js
+++ b/packages/deployer/tasks/deploy.js
@@ -1,5 +1,4 @@
 const { task } = require('hardhat/config');
-const { TASK_COMPILE } = require('hardhat/builtin-tasks/task-names');
 
 const {
   SUBTASK_CLEAR_DEPLOYMENTS,
@@ -49,7 +48,6 @@ task(TASK_DEPLOY, 'Deploys all system modules')
 
     await hre.run(SUBTASK_PREPARE_DEPLOYMENT, taskArguments);
     await hre.run(SUBTASK_PRINT_INFO, taskArguments);
-    await hre.run(TASK_COMPILE, { force: true, quiet: true });
     await hre.run(SUBTASK_SYNC_SOURCES);
     await hre.run(SUBTASK_VALIDATE_MODULES);
     await hre.run(SUBTASK_DEPLOY_MODULES);

--- a/packages/deployer/utils/deployments.js
+++ b/packages/deployer/utils/deployments.js
@@ -17,11 +17,7 @@ const DeploymentInfo = {
 };
 
 // Regex for deployment file formats, e.g.: 2021-08-31-00-sirius.json
-const DEPLOYMENT_NAME_FORMAT = /^[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2,}(?:-[a-z0-9]+)?$/;
-
-function _isValidDeploymentName(name) {
-  return DEPLOYMENT_NAME_FORMAT.test(name);
-}
+const DEPLOYMENT_FILE_FORMAT = /^[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2,}(?:-[a-z0-9]+)?\.json$/;
 
 /**
  * Get the paths to the extended files for a given deployment
@@ -106,7 +102,7 @@ function getAllDeploymentFiles(info) {
 
   return glob
     .sync(`${instanceFolder}/*.json`)
-    .filter((file) => _isValidDeploymentName(getDeploymentName(file)))
+    .filter((file) => DEPLOYMENT_FILE_FORMAT.test(file))
     .sort(naturalCompare);
 }
 

--- a/packages/deployer/utils/deployments.js
+++ b/packages/deployer/utils/deployments.js
@@ -5,7 +5,11 @@ const naturalCompare = require('string-natural-compare');
 const { defaults } = require('../extensions/config');
 
 // Regex for deployment file formats, e.g.: 2021-08-31-00-sirius.json
-const DEPLOYMENT_FILE_FORMAT = /^[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2,}(?:-[a-z0-9]+)?\.json$/;
+const DEPLOYMENT_FILE_FORMAT = /^[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2,}(?:-[a-z0-9]+)?$/;
+
+function _isValidDeploymentName(name) {
+  return DEPLOYMENT_FILE_FORMAT.test(name);
+}
 
 /**
  * @param {Object} info An object describing which deployment to retrieve
@@ -87,7 +91,7 @@ function getAllDeploymentFiles(info) {
 
   return glob
     .sync(`${instanceFolder}/*.json`)
-    .filter((file) => DEPLOYMENT_FILE_FORMAT.test(path.basename(file)))
+    .filter((file) => _isValidDeploymentName(path.basename(file, '.json')))
     .sort(naturalCompare);
 }
 

--- a/packages/deployer/utils/deployments.js
+++ b/packages/deployer/utils/deployments.js
@@ -30,7 +30,6 @@ function getDeploymentExtendedFiles(file) {
   return {
     sources: path.resolve(folder, 'extended', `${name}.sources.json`),
     abis: path.resolve(folder, 'extended', `${name}.abis.json`),
-    txs: path.resolve(folder, 'extended', `${name}.txs.json`),
   };
 }
 
@@ -66,8 +65,6 @@ function getRouterAddress(info) {
  * @returns {Object} An object with deployment schema
  */
 function getDeployment(info) {
-  info = _populateDefaults(info);
-
   const file = getDeploymentFile(info);
 
   if (!file) {
@@ -83,10 +80,7 @@ function getDeployment(info) {
  * @returns {string} The path of the file
  */
 function getDeploymentFile(info) {
-  info = _populateDefaults(info);
-
   const deployments = getAllDeploymentFiles(info);
-
   return deployments.length > 0 ? deployments[deployments.length - 1] : null;
 }
 
@@ -96,13 +90,11 @@ function getDeploymentFile(info) {
  * @returns {array} An array of paths for the files
  */
 function getAllDeploymentFiles(info) {
-  info = _populateDefaults(info);
-
   const instanceFolder = getDeploymentFolder(info);
 
   return glob
     .sync(`${instanceFolder}/*.json`)
-    .filter((file) => DEPLOYMENT_FILE_FORMAT.test(file))
+    .filter((file) => DEPLOYMENT_FILE_FORMAT.test(path.basename(file)))
     .sort(naturalCompare);
 }
 
@@ -112,13 +104,12 @@ function getAllDeploymentFiles(info) {
  * @returns {string} The path of the folder
  */
 function getDeploymentFolder(info) {
-  info = _populateDefaults(info);
-
-  return path.join(info.folder, info.network, info.instance);
+  const { folder, network, instance } = _populateDefaults(info);
+  return path.resolve(folder, network, instance);
 }
 
 function _populateDefaults(info) {
-  return { ...info, ...DeploymentInfo };
+  return { ...DeploymentInfo, ...info };
 }
 
 module.exports = {

--- a/packages/deployer/utils/deployments.js
+++ b/packages/deployer/utils/deployments.js
@@ -5,10 +5,14 @@ const naturalCompare = require('string-natural-compare');
 const { defaults } = require('../extensions/config');
 
 // Regex for deployment file formats, e.g.: 2021-08-31-00-sirius.json
-const DEPLOYMENT_FILE_FORMAT = /^[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2,}(?:-[a-z0-9]+)?$/;
+const DEPLOYMENT_NAME_FORMAT = /^[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2,}(?:-[a-z0-9]+)?$/;
 
 function _isValidDeploymentName(name) {
-  return DEPLOYMENT_FILE_FORMAT.test(name);
+  return DEPLOYMENT_NAME_FORMAT.test(name);
+}
+
+function getDeploymentName(file) {
+  return typeof file === 'string' ? path.basename(file, '.json') : null;
 }
 
 /**
@@ -91,7 +95,7 @@ function getAllDeploymentFiles(info) {
 
   return glob
     .sync(`${instanceFolder}/*.json`)
-    .filter((file) => _isValidDeploymentName(path.basename(file, '.json')))
+    .filter((file) => _isValidDeploymentName(getDeploymentName(file)))
     .sort(naturalCompare);
 }
 
@@ -111,6 +115,7 @@ function _populateDefaults(info) {
 }
 
 module.exports = {
+  getDeploymentName,
   getProxyAddress,
   getRouterAddress,
   getDeployment,

--- a/packages/deployer/utils/deployments.js
+++ b/packages/deployer/utils/deployments.js
@@ -24,21 +24,6 @@ function _isValidDeploymentName(name) {
 }
 
 /**
- * Get the deployment name from a given deployment file
- * @param {string} file
- * @returns {string} e.g.: 2021-12-23-sirius
- */
-function getDeploymentName(file) {
-  const name = typeof file === 'string' ? path.basename(file, '.json') : null;
-
-  if (!_isValidDeploymentName(name)) {
-    throw new Error(`Invalid deployment file "${file}"`);
-  }
-
-  return typeof file === 'string' ? path.basename(file, '.json') : null;
-}
-
-/**
  * Get the paths to the extended files for a given deployment
  * @param {string} file location of the deployment file
  */
@@ -142,7 +127,6 @@ function _populateDefaults(info) {
 
 module.exports = {
   getDeploymentExtendedFiles,
-  getDeploymentName,
   getProxyAddress,
   getRouterAddress,
   getDeployment,


### PR DESCRIPTION
Closes #39

This PR adds the files `extended/${name}.sources.json` & `extended/${name}.abi.json` with the corresponding metadata for each deploy.

## 
* It also includes some refactors on `contractData` passing and processing when deploying contracts.
* When possible, is not manually calculating the path to a contract (e.g.: `contracts/modules/SomeModule.sol`), but instead we're now taking it from the artifact data, to be more consistent with hardhat