### PR TITLE
Add linter rule for line length

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,5 +18,6 @@ module.exports = {
     quotes: ['error', 'single'],
     semi: ['error', 'always'],
     'no-inner-declarations': 'off',
+    'max-len': ['error', { code: 160, comments: 100 }],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "synthetix-v3",
       "version": "3.0.0",
       "license": "MIT",
       "workspaces": [
@@ -8574,7 +8573,7 @@
       "version": "file:packages/deployer",
       "requires": {
         "chalk": "4.1.2",
-        "del": "*",
+        "del": "6.0.0",
         "figlet": "1.5.2",
         "filter-values": "0.4.1",
         "glob": "7.1.7",


### PR DESCRIPTION
Adds a linter rule to limit line lengths to 160 characters, and 100 characters on comments.