### PR TITLE
Add contracts ast to sources deployment extended info

### DIFF
--- a/packages/deployer/internal/ast/ast-sources.js
+++ b/packages/deployer/internal/ast/ast-sources.js
@@ -1,20 +1,24 @@
+async function getContractAST({ sourceName, contractName }) {
+  const { output } = await hre.artifacts.getBuildInfo(`${sourceName}:${contractName}`);
+  // Hardhat includes the contract name in the object if any .sol file has more than one contract.
+  return output.sources[sourceName][contractName]
+    ? output.sources[sourceName][contractName].ast
+    : output.sources[sourceName].ast;
+}
+
 async function getSourcesAST(hre) {
   const fqns = await hre.artifacts.getAllFullyQualifiedNames();
 
   const contracts = {};
   for (const fqn of fqns) {
-    const bi = await hre.artifacts.getBuildInfo(fqn);
-    const split = fqn.split(':');
-    const solPath = split[0];
-    const contractName = split[1];
-    // Hardhat includes the contract name in the object if any .sol file has more than one contract.
-    contracts[contractName] = bi.output.sources[solPath][contractName]
-      ? bi.output.sources[solPath][contractName].ast
-      : bi.output.sources[solPath].ast;
+    const [sourceName, contractName] = fqn.split(':');
+    contracts[contractName] = await getContractAST({ sourceName, contractName });
   }
+
   return { contracts };
 }
 
 module.exports = {
+  getContractAST,
   getSourcesAST,
 };

--- a/packages/deployer/internal/process-contracts.js
+++ b/packages/deployer/internal/process-contracts.js
@@ -1,6 +1,8 @@
 const fs = require('fs/promises');
 const path = require('path');
 
+const { getContractAST } = require('./ast/ast-sources');
+
 /**
  * Initialize contract metadata on hre.deployer.deployment.*
  * @param {string} contractName
@@ -15,6 +17,7 @@ async function initContractData(contractName, general = {}) {
   const sourceCode = (
     await fs.readFile(path.resolve(hre.config.paths.root, sourceName))
   ).toString();
+  const ast = await getContractAST({ sourceName, contractName });
 
   const previousData = previousDeployment?.general.contracts[contractName] || {};
 
@@ -33,6 +36,7 @@ async function initContractData(contractName, general = {}) {
     bytecode,
     deployedBytecode,
     sourceCode,
+    ast,
   };
 }
 

--- a/packages/deployer/tasks/deploy.js
+++ b/packages/deployer/tasks/deploy.js
@@ -50,8 +50,8 @@ task(TASK_DEPLOY, 'Deploys all system modules')
 
     await hre.run(SUBTASK_PREPARE_DEPLOYMENT, taskArguments);
     await hre.run(SUBTASK_PRINT_INFO, taskArguments);
-    await hre.run(SUBTASK_SYNC_SOURCES);
     await hre.run(TASK_COMPILE, { force: false, quiet: true });
+    await hre.run(SUBTASK_SYNC_SOURCES);
     await hre.run(SUBTASK_VALIDATE_STORAGE);
     await hre.run(SUBTASK_VALIDATE_MODULES);
     await hre.run(SUBTASK_DEPLOY_MODULES);


### PR DESCRIPTION
Closes #122 

This PR adds the ASTs to the `hre.deployer.deployment.sources[contractName].ast` object, which means that is also saving it to the deployments files.

---

As a follow up, I created issue #136 so we stop getting the list of Contracts from 2 different sources (manually using `glob('contracts/*')` or `hre.artifacts.get*`).