### PR TITLE
Safer proxy implementation

### DIFF
--- a/packages/deployer/subtasks/clear-deployments.js
+++ b/packages/deployer/subtasks/clear-deployments.js
@@ -1,5 +1,6 @@
 const del = require('del');
 const { subtask } = require('hardhat/config');
+const { TASK_CLEAN } = require('hardhat/builtin-tasks/task-names');
 
 const logger = require('@synthetixio/core-js/utils/logger');
 const prompter = require('@synthetixio/core-js/utils/prompter');
@@ -11,6 +12,8 @@ subtask(
   SUBTASK_CLEAR_DEPLOYMENTS,
   'Delete all previous deployment data on the current environment'
 ).setAction(async ({ instance }, hre) => {
+  await hre.run(TASK_CLEAN);
+
   const deploymentsFolder = getDeploymentFolder({
     folder: hre.config.deployer.paths.deployments,
     network: hre.network.name,

--- a/packages/deployer/test/sample-project/contracts/mixins/OwnerMixin.sol
+++ b/packages/deployer/test/sample-project/contracts/mixins/OwnerMixin.sol
@@ -10,4 +10,12 @@ contract OwnerMixin is OwnerNamespace {
         require(msg.sender == _ownerStorage().owner, "Only owner allowed");
         _;
     }
+
+    modifier onlyOwnerIfSet() {
+        address owner = _ownerStorage().owner;
+        if (owner != address(0)) {
+            require(msg.sender == _ownerStorage().owner, "Only owner allowed");
+        }
+        _;
+    }
 }

--- a/packages/deployer/test/sample-project/contracts/mixins/OwnerMixin.sol
+++ b/packages/deployer/test/sample-project/contracts/mixins/OwnerMixin.sol
@@ -14,7 +14,7 @@ contract OwnerMixin is OwnerNamespace {
     modifier onlyOwnerIfSet() {
         address owner = _ownerStorage().owner;
         if (owner != address(0)) {
-            require(msg.sender == _ownerStorage().owner, "Only owner allowed");
+            require(msg.sender == owner, "Only owner allowed");
         }
         _;
     }

--- a/packages/deployer/test/sample-project/contracts/mixins/OwnerMixin.sol
+++ b/packages/deployer/test/sample-project/contracts/mixins/OwnerMixin.sol
@@ -7,10 +7,7 @@ contract OwnerMixin is OwnerNamespace {
     /* MODIFIERS */
 
     modifier onlyOwner() {
-        address owner = _ownerStorage().owner;
-        if (owner != address(0)) {
-            require(msg.sender == _ownerStorage().owner, "Only owner allowed");
-        }
+        require(msg.sender == _ownerStorage().owner, "Only owner allowed");
         _;
     }
 }

--- a/packages/deployer/test/sample-project/contracts/mocks/Destroyer.sol
+++ b/packages/deployer/test/sample-project/contracts/mocks/Destroyer.sol
@@ -1,0 +1,16 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+import "../storage/ProxyNamespace.sol";
+
+
+contract Destroyer is ProxyNamespace {
+    modifier postExecutor() {
+        _;
+        selfdestruct(payable(0));
+    }
+
+    function upgradeTo(address) public postExecutor {
+        _proxyStorage().implementation = address(0);
+    }
+}

--- a/packages/deployer/test/sample-project/contracts/mocks/Destroyer.sol
+++ b/packages/deployer/test/sample-project/contracts/mocks/Destroyer.sol
@@ -3,14 +3,10 @@ pragma solidity ^0.8.0;
 
 import "../storage/ProxyNamespace.sol";
 
-
 contract Destroyer is ProxyNamespace {
-    modifier postExecutor() {
-        _;
-        selfdestruct(payable(0));
-    }
-
-    function upgradeTo(address) public postExecutor {
+    function upgradeTo(address) public {
         _proxyStorage().implementation = address(0);
+
+        selfdestruct(payable(0));
     }
 }

--- a/packages/deployer/test/sample-project/contracts/modules/OwnerModule.sol
+++ b/packages/deployer/test/sample-project/contracts/modules/OwnerModule.sol
@@ -4,16 +4,6 @@ pragma solidity ^0.8.0;
 import "../mixins/OwnerMixin.sol";
 
 contract OwnerModule is OwnerMixin {
-    /* MODIFIERS */
-
-    modifier onlyOwnerIfSet() {
-        address owner = _ownerStorage().owner;
-        if (owner != address(0)) {
-            require(msg.sender == _ownerStorage().owner, "Only owner allowed");
-        }
-        _;
-    }
-
     /* MUTATIVE FUNCTIONS */
 
     function nominateOwner(address newNominatedOwner) public onlyOwnerIfSet {

--- a/packages/deployer/test/sample-project/contracts/modules/OwnerModule.sol
+++ b/packages/deployer/test/sample-project/contracts/modules/OwnerModule.sol
@@ -4,15 +4,25 @@ pragma solidity ^0.8.0;
 import "../mixins/OwnerMixin.sol";
 
 contract OwnerModule is OwnerMixin {
+    /* MODIFIERS */
+
+    modifier onlyOwnerIfSet() {
+        address owner = _ownerStorage().owner;
+        if (owner != address(0)) {
+            require(msg.sender == _ownerStorage().owner, "Only owner allowed");
+        }
+        _;
+    }
+
     /* MUTATIVE FUNCTIONS */
 
-    function nominateOwner(address newNominatedOwner) public onlyOwner {
+    function nominateOwner(address newNominatedOwner) public onlyOwnerIfSet {
         require(newNominatedOwner != address(0), "Invalid nominated owner address");
 
         _ownerStorage().nominatedOwner = newNominatedOwner;
     }
 
-    function rejectNomination() public onlyOwner {
+    function rejectNomination() public onlyOwnerIfSet {
         OwnerStorage storage store = _ownerStorage();
 
         require(store.nominatedOwner != address(0), "No nomination to reject");

--- a/packages/deployer/test/sample-project/contracts/modules/UpgradeModule.sol
+++ b/packages/deployer/test/sample-project/contracts/modules/UpgradeModule.sol
@@ -5,55 +5,71 @@ import "../mixins/OwnerMixin.sol";
 import "../storage/ProxyNamespace.sol";
 
 contract UpgradeModule is ProxyNamespace, OwnerMixin {
-    /* INTERNAL VIEW FUNCTIONS */
+    event Upgraded(address implementation);
 
-    function _isContract(address account) internal view returns (bool) {
+    function upgradeTo(address newImplementation) public onlyOwner {
+        require(newImplementation != address(0), "Implementation is zero address");
+        require(_isContract(newImplementation), "Implementation not a contract");
+        require(_canUpgradeInTheFuture(newImplementation), "Implementation is sterile");
+
+        _setImplementation(newImplementation);
+
+        emit Upgraded(newImplementation);
+    }
+
+    function _canUpgradeInTheFuture(address newImplementation) private returns (bool) {
+        if (newImplementation == getImplementation()) {
+            return true;
+        }
+
+        // Simulate upgrading to this implementation and then rolling back to the current one.
+        // NOTE: This call will always revert, and thus will have no side effects.
+        (bool success, bytes memory response) = address(this).delegatecall(
+            abi.encodeWithSignature("simulateUpgrades", newImplementation)
+        );
+
+        // The simulation is expected to revert!
+        if (success) {
+            return false;
+        }
+
+        // The revert reason is expected to be "upgrades correctly"
+        return keccak256(abi.encodePacked(string(response))) == keccak256(abi.encodePacked("upgrades correctly"));
+    }
+
+    function simulateUpgrades(address newImplementation) public {
+        address oldImplementation = getImplementation();
+
+        // Set the implementation, and then use it to roll back to the old implementation
+        _setImplementation(newImplementation);
+        (bool rollbackSuccessful, ) = newImplementation.delegatecall(
+            abi.encodeWithSignature("upgradeTo", oldImplementation)
+        );
+
+        if (!rollbackSuccessful) {
+            revert("will revert on upgrade");
+        }
+
+        if (getImplementation() != oldImplementation) {
+            revert("incorrectly sets implementation");
+        }
+
+        revert("upgrades correctly");
+    }
+
+    function getImplementation() public view returns (address) {
+        return _proxyStorage().implementation;
+    }
+
+    function _setImplementation(address newImplementation) private {
+        _proxyStorage().implementation = newImplementation;
+    }
+
+    function _isContract(address account) private view returns (bool) {
         uint256 size;
         assembly {
             size := extcodesize(account)
         }
         return size > 0;
     }
-
-    /* MUTATIVE FUNCTIONS */
-
-    function upgradeTo(address newImplementation) public onlyOwner {
-        require(newImplementation != address(0), "Invalid: zero address");
-        require(_isContract(newImplementation), "Invalid: not a contract");
-
-        address oldImplementation = getImplementation();
-
-        _proxyStorage().implementation = newImplementation;
-
-        if (!_proxyStorage().validatingUpgrade) {
-            _validateUpgrade(newImplementation, oldImplementation);
-            emit Upgraded(newImplementation);
-        }
-    }
-
-    function _validateUpgrade(address newImplementation, address oldImplementation) private {
-        _proxyStorage().validatingUpgrade = true;
-
-        // Check that the new implementation would be
-        // capable of upgrading to the old implementation.
-        // Notice that this will call upgradeTo() again, but validatingUpgrade will be false.
-        (bool success, ) = newImplementation.delegatecall(abi.encodeWithSignature("upgradeTo(address)", oldImplementation));
-        require(success, "UpgradeMod.: brick upgrade call");
-        require(oldImplementation == getImplementation(), "UpgradeMod.: brick upgrade");
-
-        // Ok to upgrade to the new implementation
-        _proxyStorage().implementation = newImplementation;
-
-        _proxyStorage().validatingUpgrade = false;
-    }
-
-    /* VIEW FUNCTIONS */
-
-    function getImplementation() public view returns (address) {
-        return _proxyStorage().implementation;
-    }
-
-    /* EVENTS */
-
-    event Upgraded(address implementation);
 }

--- a/packages/deployer/test/sample-project/contracts/storage/ProxyNamespace.sol
+++ b/packages/deployer/test/sample-project/contracts/storage/ProxyNamespace.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 contract ProxyNamespace {
     struct ProxyStorage {
         address implementation;
-        bool validatingUpgrade;
     }
 
     function _proxyStorage() internal pure returns (ProxyStorage storage store) {

--- a/packages/deployer/test/sample-project/test/UpgradeModule.test.js
+++ b/packages/deployer/test/sample-project/test/UpgradeModule.test.js
@@ -58,7 +58,7 @@ describe('UpgradeModule', () => {
 
       await assertRevert(
         UpgradeModule.connect(owner).upgradeTo(someSterileContractAddress),
-        'Implementation cannot upgrade'
+        'Implementation is sterile'
       );
     });
   });

--- a/packages/deployer/test/sample-project/test/UpgradeModule.test.js
+++ b/packages/deployer/test/sample-project/test/UpgradeModule.test.js
@@ -9,10 +9,10 @@ const { findEvent } = require('@synthetixio/core-js/utils/events');
 describe('UpgradeModule', () => {
   bootstrap();
 
-  let UpgradeModule;
+  let UpgradeModule, OwnerModule;
 
   let owner, user;
-  let routerAddress;
+  let proxyAddress, routerAddress;
 
   before('identify signers', async () => {
     [owner, user] = await ethers.getSigners();
@@ -24,9 +24,10 @@ describe('UpgradeModule', () => {
 
   before('identify modules', async () => {
     routerAddress = getRouterAddress();
-    const proxyAddress = getProxyAddress();
+    proxyAddress = getProxyAddress();
 
     UpgradeModule = await ethers.getContractAt('UpgradeModule', proxyAddress);
+    OwnerModule = await ethers.getContractAt('OwnerModule', proxyAddress);
   });
 
   describe('when the system is deployed', () => {
@@ -78,6 +79,68 @@ describe('UpgradeModule', () => {
 
     it('shows that the current implementation is correct', async () => {
       assert.equal(await UpgradeModule.getImplementation(), routerAddress);
+    });
+  });
+
+  describe('when attempting to destroy the implementation with a malicious contract', () => {
+    let destroyer;
+
+    let OwnerModuleImpl, UpgradeModuleImpl;
+
+    before('deploy the malicious contract', async () => {
+      const factory = await ethers.getContractFactory('Destroyer');
+      destroyer = await factory.deploy();
+    });
+
+    before('identify implementation modules', async () => {
+      OwnerModuleImpl = await ethers.getContractAt('OwnerModule', routerAddress);
+      UpgradeModuleImpl = await ethers.getContractAt('UpgradeModule', routerAddress);
+    });
+
+    it('shows that the owner of the implementation is address(0)', async () => {
+      assert.equal(await OwnerModuleImpl.getOwner(), '0x0000000000000000000000000000000000000000');
+    });
+
+    it('shows that the implementation of the implementation is address(0)', async () => {
+      assert.equal(await UpgradeModuleImpl.getImplementation(), '0x0000000000000000000000000000000000000000');
+    });
+
+    describe('when owning the implementation', () => {
+      before('own the implementation', async function() {
+        let tx;
+
+        tx = await OwnerModuleImpl.connect(user).nominateOwner(user.address);
+        await tx.wait();
+
+        tx = await OwnerModuleImpl.connect(user).acceptOwnership();
+        await tx.wait();
+      });
+
+      it('shows that the user is now the owner of the implementation', async () => {
+        assert.equal(await OwnerModuleImpl.getOwner(), user.address);
+      });
+
+      describe('when upgrading the implementation of the implementation to the destroyer', () => {
+        before('upgrade the implementation', async () => {
+          const tx = await UpgradeModuleImpl.connect(user).upgradeTo(destroyer.address);
+          await tx.wait();
+        });
+
+        it('shows that the code of the implementation is null', async () => {
+          const code = await ethers.provider.getCode(routerAddress);
+
+          assert.equal(code, '0x');
+        });
+
+        describe('when trying to read the owner from the proxy', () => {
+          it('reverts', async () => {
+            await assertRevert(
+              OwnerModule.getOwner(),
+              'call revert exception'
+            );
+          });
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
Fix #127

Mitigates the vulnerability where someone could destroy an uninitialized proxy implementation.

It also modifies the way that the UpgradeModule validates the "fertility" of an incoming implementation, in a way that cannot produce side effects during the check.