### PR TITLE
(DON'T MERGE) Change router and test project to test STATIC CALL costs on view/pure function 

### DIFF
--- a/packages/deployer/subtasks/generate-router.js
+++ b/packages/deployer/subtasks/generate-router.js
@@ -121,7 +121,9 @@ function _renderModuleNames(modules) {
   return Object.entries(modules)
     .reduce((lines, [moduleName]) => {
       lines.push(
-        `${TAB}bytes32 private constant ${_toPrivateConstantCase(moduleName+'Name')} = "${moduleName}";`
+        `${TAB}bytes32 private constant ${_toPrivateConstantCase(
+          moduleName + 'Name'
+        )} = "${moduleName}";`
       );
       return lines;
     }, [])
@@ -133,7 +135,9 @@ function _renderResolver(modules) {
   return Object.entries(modules)
     .reduce((lines, [moduleName]) => {
       lines.push(
-        `${TAB}${TAB}if (name == ${_toPrivateConstantCase(moduleName+'Name')} ) return ${_toPrivateConstantCase(moduleName)};`
+        `${TAB}${TAB}if (name == ${_toPrivateConstantCase(
+          moduleName + 'Name'
+        )} ) return ${_toPrivateConstantCase(moduleName)};`
       );
       return lines;
     }, [])

--- a/packages/deployer/subtasks/generate-router.js
+++ b/packages/deployer/subtasks/generate-router.js
@@ -45,6 +45,8 @@ subtask(
     moduleName: routerName,
     modules: _renderModules(modules),
     selectors: _renderSelectors({ binaryData }),
+    moduleNames: _renderModuleNames(modules),
+    resolver: _renderResolver(modules),
   });
 
   logger.debug(`Generated source: ${generatedSource}`);
@@ -108,6 +110,30 @@ function _renderModules(modules) {
       const { deployedAddress } = moduleData;
       lines.push(
         `${TAB}address private constant ${_toPrivateConstantCase(moduleName)} = ${deployedAddress};`
+      );
+      return lines;
+    }, [])
+    .join('\n')
+    .trim();
+}
+
+function _renderModuleNames(modules) {
+  return Object.entries(modules)
+    .reduce((lines, [moduleName]) => {
+      lines.push(
+        `${TAB}bytes32 private constant ${_toPrivateConstantCase(moduleName+'Name')} = "${moduleName}";`
+      );
+      return lines;
+    }, [])
+    .join('\n')
+    .trim();
+}
+
+function _renderResolver(modules) {
+  return Object.entries(modules)
+    .reduce((lines, [moduleName]) => {
+      lines.push(
+        `${TAB}${TAB}if (name == ${_toPrivateConstantCase(moduleName+'Name')} ) return ${_toPrivateConstantCase(moduleName)};`
       );
       return lines;
     }, [])

--- a/packages/deployer/templates/Router.sol.mustache
+++ b/packages/deployer/templates/Router.sol.mustache
@@ -13,9 +13,18 @@ pragma solidity ^0.8.0;
 // GENERATED CODE - do not edit manually!!
 // --------------------------------------------------------------------------------
 // --------------------------------------------------------------------------------
+import "./IRouter.sol"; 
 
-contract {{{moduleName}}} {
+contract {{{moduleName}}} is IRouter{
     {{{modules}}}
+
+    {{{moduleNames}}}
+
+    function getModuleAddress(bytes32 name) external override pure returns (address) {
+        {{{resolver}}}
+
+        revert("Unknown ID");
+    }
 
     fallback() external payable {
         // Lookup table: Function selector => implementation contract

--- a/packages/deployer/test/sample-project/contracts/IRouter.sol
+++ b/packages/deployer/test/sample-project/contracts/IRouter.sol
@@ -1,0 +1,6 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity >0.8.0;
+
+interface IRouter {
+    function getModuleAddress(bytes32 name) external pure returns (address);
+}

--- a/packages/deployer/test/sample-project/contracts/modules/AnotherModule.sol
+++ b/packages/deployer/test/sample-project/contracts/modules/AnotherModule.sol
@@ -31,19 +31,21 @@ contract AnotherModule is CommsMixin {
     function _bytesToAddress(bytes memory bytesAddress) private pure returns (address addr) {
         assembly {
             addr := mload(add(bytesAddress, 32))
-        } 
+        }
     }
 
     function _getModuleAddress() private view returns (address addr) {
-        (,bytes memory data) =
-                address(this).staticcall(abi.encodeWithSelector(IRouter.getModuleAddress.selector, _SOME_MODULE_NAME));
+        (, bytes memory data) = address(this).staticcall(
+            abi.encodeWithSelector(IRouter.getModuleAddress.selector, _SOME_MODULE_NAME)
+        );
 
         addr = _bytesToAddress(data);
     }
 
     function setSomeValueOnSomeModule(uint newValue) public {
-
-        (bool success,) = _getModuleAddress().delegatecall(abi.encodeWithSelector(SomeModule.setSomeValue.selector, newValue));
+        (bool success, ) = _getModuleAddress().delegatecall(
+            abi.encodeWithSelector(SomeModule.setSomeValue.selector, newValue)
+        );
 
         require(success, "Intermodule call failed");
     }


### PR DESCRIPTION
fix #110  This PR is there just to keep the research documented. It's not intended to be merged.

---

As expected, using STATIC CALL to call a view/pure function doesn't make any difference in the gas usage since the compiler will use static call when the called function has the non-mutative functions.

In order to do the test I updated the router generator and AnotherModule.sol to change the behavior. The changes were:
1- adding a "resolver" function called GetModuleAddress to the router populated with router generator.
2- update AnotherModule.setSomeValueOnSomeModule function to use Router.GetModuleAddress with a normal call
3- update AnotherModule.setSomeValueOnSomeModule function to use Router.GetModuleAddress with a static call

I made some measurements before step 1 (to have a baseline), after 1, after 2 and after 3.

The results are the following:

### Baseline
AnotherModule
when writing to GlobalNamespace.someValue
✓ directly via SomeModule (36202 gas) (39ms)
✓ indirectly via AnotherModule (40826 gas) (54ms)

### After Step 1: Router with GetModuleAddress function, not used to verify the gas increment because the selector added to the router.
AnotherModule
when writing to GlobalNamespace.someValue
✓ directly via SomeModule (36269 gas) (41ms)
✓ indirectly via AnotherModule (40960 gas) (102ms)

### After Step 2: Router with GetModuleAddress function and using it with a normal call
AnotherModule
when writing to GlobalNamespace.someValue
✓ directly via SomeModule (36269 gas) (43ms)
✓ indirectly via AnotherModule (42081 gas) (54ms)

### After Step 3: Router with GetModuleAddress function and using it with a STATIC CALL
AnotherModule
when writing to GlobalNamespace.someValue
✓ directly via SomeModule (36269 gas) (39ms)
✓ indirectly via AnotherModule (42382 gas) (63ms)