### PR TITLE
Do not exit pipeline, plus clean up messaging

### DIFF
--- a/packages/deployer/internal/ast/router-ast-validator.js
+++ b/packages/deployer/internal/ast/router-ast-validator.js
@@ -31,12 +31,14 @@ async function findMissingSelectorsInAST(contracts) {
 }
 
 async function findUnreachableSelectorsInAST() {
-  logger.info('  Unreachable selectors not checked yet in compiled router');
+  logger.info('Unreachable selectors not checked yet in compiled router');
+
   return [];
 }
 
 async function findDuplicateSelectorsInAST() {
-  logger.info('  Duplicated selectors not checked yet in compiled router');
+  logger.info('Duplicated selectors not checked yet in compiled router');
+
   return [];
 }
 

--- a/packages/deployer/internal/ast/storage-validator.js
+++ b/packages/deployer/internal/ast/storage-validator.js
@@ -66,7 +66,7 @@ function findUnsafeStorageUsageInModules(contracts) {
 
 function findInvalidMutationsOnNamespaces() {
   logger.info(
-    'Append is the only update enabled on Namespaces. BE AWARE THIS IS NOT NOT AUTOMATICALLY VERIFIED AT THE MOMENT'
+    'Unsafe storage namespace mutations are not yet validated in modules. Please only append to storage namespace structs.'
   );
 
   return [];

--- a/packages/deployer/subtasks/deploy-modules.js
+++ b/packages/deployer/subtasks/deploy-modules.js
@@ -5,7 +5,6 @@ const filterValues = require('filter-values');
 const {
   SUBTASK_DEPLOY_CONTRACTS,
   SUBTASK_DEPLOY_MODULES,
-  SUBTASK_CANCEL_DEPLOYMENT,
 } = require('../task-names');
 
 subtask(SUBTASK_DEPLOY_MODULES).setAction(async (_, hre) => {
@@ -18,7 +17,6 @@ subtask(SUBTASK_DEPLOY_MODULES).setAction(async (_, hre) => {
   });
 
   if (!deployedSomething) {
-    logger.info('No modules need to be deployed, cancelling execution...');
-    return await hre.run(SUBTASK_CANCEL_DEPLOYMENT);
+    logger.checked('No modules need to be deployed');
   }
 });

--- a/packages/deployer/subtasks/deploy-modules.js
+++ b/packages/deployer/subtasks/deploy-modules.js
@@ -2,10 +2,7 @@ const { subtask } = require('hardhat/config');
 
 const logger = require('@synthetixio/core-js/utils/logger');
 const filterValues = require('filter-values');
-const {
-  SUBTASK_DEPLOY_CONTRACTS,
-  SUBTASK_DEPLOY_MODULES,
-} = require('../task-names');
+const { SUBTASK_DEPLOY_CONTRACTS, SUBTASK_DEPLOY_MODULES } = require('../task-names');
 
 subtask(SUBTASK_DEPLOY_MODULES).setAction(async (_, hre) => {
   logger.subtitle('Deploying modules');

--- a/packages/deployer/subtasks/deploy-router.js
+++ b/packages/deployer/subtasks/deploy-router.js
@@ -10,5 +10,10 @@ subtask(SUBTASK_DEPLOY_ROUTER).setAction(async (_, hre) => {
   const contractName = 'Router';
 
   await initContractData(contractName);
-  await hre.run(SUBTASK_DEPLOY_CONTRACT, { contractName });
+
+  const deployedSomething = await hre.run(SUBTASK_DEPLOY_CONTRACT, { contractName });
+
+  if (!deployedSomething) {
+    logger.checked('The router does not need to be deployed');
+  }
 });

--- a/packages/deployer/subtasks/generate-router.js
+++ b/packages/deployer/subtasks/generate-router.js
@@ -23,7 +23,7 @@ subtask(
   );
 
   logger.subtitle('Generating router source');
-  logger.info(`location: ${routerPath}`);
+  logger.debug(`location: ${routerPath}`);
 
   const modules = filterValues(hre.deployer.deployment.general.contracts, (c) => c.isModule);
   const modulesNames = Object.keys(modules);
@@ -31,7 +31,7 @@ subtask(
 
   const selectors = await getAllSelectors(modulesNames);
   logger.debug(`selectors: ${JSON.stringify(selectors, null, 2)}`);
-  logger.info(`Found ${modulesNames.length} modules with ${selectors.length} selectors in total`);
+  logger.debug(`Found ${modulesNames.length} modules with ${selectors.length} selectors in total`);
 
   const binaryData = _buildBinaryData({ selectors });
 
@@ -49,7 +49,7 @@ subtask(
 
   logger.debug(`Generated source: ${generatedSource}`);
 
-  const currentSource = fs.existsSync(routerPath) ? fs.readFileSync(routerPath) : '';
+  const currentSource = fs.existsSync(routerPath) ? fs.readFileSync(routerPath, 'utf8') : '';
   if (currentSource !== generatedSource) {
     fs.writeFileSync(routerPath, generatedSource);
     logger.success(`Router code generated and written to ${routerPath}`);

--- a/packages/deployer/subtasks/sync-sources.js
+++ b/packages/deployer/subtasks/sync-sources.js
@@ -64,8 +64,11 @@ async function _addNewSources({ sources, previousDeployment }) {
     }
   }
 
-  logger.notice('The following modules are going to be deployed for the first time:');
-  toAdd.forEach((source) => logger.notice(`  ${source}`));
+  if (toAdd.length > 0) {
+    logger.notice('The following modules are going to be deployed for the first time:');
+
+    toAdd.forEach((source) => logger.notice(`  ${source}`));
+  }
 
   return toAdd.length > 0;
 }

--- a/packages/deployer/subtasks/upgrade-proxy.js
+++ b/packages/deployer/subtasks/upgrade-proxy.js
@@ -72,7 +72,7 @@ async function _deployProxy({ proxyName, routerAddress, hre }) {
 }
 
 async function _upgradeProxy({ proxyAddress, routerAddress, hre }) {
-  const signer = (await ethers.getSigners())[0];
+  const signer = (await hre.ethers.getSigners())[0];
 
   const upgradeable = await hre.ethers.getContractAt(UPGRADE_ABI, proxyAddress, signer);
   const activeImplementationAddress = await upgradeable.getImplementation();

--- a/packages/deployer/subtasks/validate-router.js
+++ b/packages/deployer/subtasks/validate-router.js
@@ -25,7 +25,7 @@ subtask(
   let sourceErrorsFound = [];
   let astErrorsFound = [];
   // Source Code checking
-  logger.info('Validating Router source code');
+  logger.debug('Validating Router source code');
   sourceErrorsFound.push(...(await findMissingSelectorsInSource()));
   sourceErrorsFound.push(...(await findRepeatedSelectorsInSource()));
   sourceErrorsFound.push(...(await findWrongSelectorsInSource()));
@@ -36,7 +36,7 @@ subtask(
   }
 
   // AST checking
-  logger.info('Validating Router compiled code');
+  logger.debug('Validating Router compiled code');
   astErrorsFound.push(...(await findMissingSelectorsInAST(contracts)));
   astErrorsFound.push(...(await findUnreachableSelectorsInAST(contracts)));
   astErrorsFound.push(...(await findDuplicateSelectorsInAST(contracts)));


### PR DESCRIPTION
Fix #148

Avoids exiting anywhere in the pipeline when it becomes evident that the system will not change. The pipeline just continues with no-ops so that the user can see deployment info, validations, etc.

Also reviews messaging so that it is more consistent.