### PR TITLE
Remove wrong modules source check in router

### DIFF
--- a/packages/deployer/internal/router-source-validator.js
+++ b/packages/deployer/internal/router-source-validator.js
@@ -55,32 +55,7 @@ async function findMissingSelectorsInSource() {
   return errors;
 }
 
-async function findWrongSelectorsInSource() {
-  const moduleSelectors = await getModulesSelectors();
-  const source = getRouterSource();
-
-  const errors = [];
-  moduleSelectors.forEach((moduleSelector) => {
-    const regex = `(:?\\s|^)case ${moduleSelector.selector}\\s.+`;
-    const matches = source.match(new RegExp(regex, 'gm'));
-
-    if (!matches) return;
-    if (matches.length !== 1) return;
-
-    const [match] = matches;
-    if (!match.includes(moduleSelector.contractName)) {
-      errors.push({
-        msg: `Expected to find ${moduleSelector.contractName} in the selector case: ${match}`,
-        moduleSelector,
-        missingInRouter: true,
-      });
-    }
-  });
-  return errors;
-}
-
 module.exports = {
   findMissingSelectorsInSource,
   findRepeatedSelectorsInSource,
-  findWrongSelectorsInSource,
 };

--- a/packages/deployer/subtasks/validate-router.js
+++ b/packages/deployer/subtasks/validate-router.js
@@ -9,7 +9,6 @@ const {
 const {
   findMissingSelectorsInSource,
   findRepeatedSelectorsInSource,
-  findWrongSelectorsInSource,
 } = require('../internal/router-source-validator');
 const filterValues = require('filter-values');
 
@@ -30,7 +29,6 @@ subtask(
   logger.debug('Validating Router source code');
   sourceErrorsFound.push(...(await findMissingSelectorsInSource()));
   sourceErrorsFound.push(...(await findRepeatedSelectorsInSource()));
-  sourceErrorsFound.push(...(await findWrongSelectorsInSource()));
   if (sourceErrorsFound.length > 0) {
     sourceErrorsFound.forEach((error) => {
       logger.error(error.msg);


### PR DESCRIPTION
Fix #162

This check assumes that the comment  with the module name next to a selector will be in the same line:
```
case 0x1098c085 { result := _SETTINGS_MODULE } // SettingsModule.getASettingValue()
```

However, a linter such as prettier may break the assumption:
```
case 0x1098c085 {
  result := _SETTINGS_MODULE
} // SettingsModule.getASettingValue()
```

Which makes the test fail with a false negative.

Since this kind of thing is now being tested in AST checks anyway, my suggestion is that we simply remove this check, and do not dictate anything related to code formatting.