### PR TITLE
Set eslint max-params rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,5 +19,6 @@ module.exports = {
     semi: ['error', 'always'],
     'no-inner-declarations': 'off',
     'max-len': ['error', { code: 160, comments: 100 }],
+    'max-params': ['error', 3], // If a function requires more than 3 parameters, please compact them using objects: { param1, param2, param3 }
   },
 };


### PR DESCRIPTION
Fix #138

Note: I tried limiting to 2 params, but a lot of vanilla js functions like `filter` _can_ use 3 params, so that would imply adding a lot of disabling exception comments.

Feel free to reject this PR if you know of more sophisticated ways of doing this.