### PR TITLE
Update coverage settings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
           cache: "npm"
       - run: npm ci
       - name: Execute tests
-        run: npm run test:coverage
+        run: npm run coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13060,9 +13060,9 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@nomiclabs/hardhat-ethers": "^2.0.2",
-        "hardhat": "^2.6.4",
-        "solidity-coverage": "^0.7.17"
+        "@nomiclabs/hardhat-ethers": "2.0.2",
+        "hardhat": "2.6.4",
+        "solidity-coverage": "0.7.17"
       }
     },
     "packages/core-contracts/node_modules/@ethereumjs/block": {
@@ -18313,9 +18313,9 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@nomiclabs/hardhat-ethers": "^2.0.2",
-        "hardhat": "^2.6.4",
-        "solidity-coverage": "^0.7.17"
+        "@nomiclabs/hardhat-ethers": "2.0.2",
+        "hardhat": "2.6.4",
+        "solidity-coverage": "0.7.17"
       }
     },
     "packages/synthetix-main/node_modules/@nomiclabs/hardhat-ethers": {
@@ -19456,9 +19456,9 @@
     "@synthetixio/core-contracts": {
       "version": "file:packages/core-contracts",
       "requires": {
-        "@nomiclabs/hardhat-ethers": "^2.0.2",
-        "hardhat": "^2.6.4",
-        "solidity-coverage": "^0.7.17"
+        "@nomiclabs/hardhat-ethers": "2.0.2",
+        "hardhat": "2.6.4",
+        "solidity-coverage": "0.7.17"
       },
       "dependencies": {
         "@ethereumjs/block": {
@@ -22591,7 +22591,7 @@
         "filter-values": "0.4.1",
         "glob": "7.1.7",
         "hardhat": "2.6.4",
-        "just-map-values": "*",
+        "just-map-values": "1.2.1",
         "mkdirp": "1.0.4",
         "mocha": "9.1.1",
         "mustache": "4.2.0",
@@ -23345,9 +23345,9 @@
     "@synthetixio/main": {
       "version": "file:packages/synthetix-main",
       "requires": {
-        "@nomiclabs/hardhat-ethers": "^2.0.2",
-        "hardhat": "^2.6.4",
-        "solidity-coverage": "^0.7.17"
+        "@nomiclabs/hardhat-ethers": "2.0.2",
+        "hardhat": "2.6.4",
+        "solidity-coverage": "0.7.17"
       },
       "dependencies": {
         "@nomiclabs/hardhat-ethers": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "homepage": "https://github.com/Synthetixio/synthetix-v3#readme",
   "scripts": {
     "test": "npm run --workspaces --if-present test",
-    "test:coverage": "npm run --workspaces --if-present test:coverage",
+    "coverage": "npm run --workspaces --if-present coverage",
     "lint:js": "prettier --check '**/*.js' && eslint '**/*.js'",
     "lint:js:fix": "prettier --write '**/*.js' && eslint --fix '**/*.js'",
     "lint:sol": "prettier --check 'packages/**/*.sol' && solhint 'packages/**/*.sol'",

--- a/packages/core-contracts/package.json
+++ b/packages/core-contracts/package.json
@@ -13,8 +13,8 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@nomiclabs/hardhat-ethers": "^2.0.2",
-    "hardhat": "^2.6.4",
-    "solidity-coverage": "^0.7.17"
+    "@nomiclabs/hardhat-ethers": "2.0.2",
+    "hardhat": "2.6.4",
+    "solidity-coverage": "0.7.17"
   }
 }

--- a/packages/core-js/.nycrc.json
+++ b/packages/core-js/.nycrc.json
@@ -1,5 +1,10 @@
 {
+  "all": true,
   "include": ["utils/**/*.js"],
   "check-coverage": true,
-  "reporter": ["lcov", "text"]
+  "reporter": ["lcov", "text"],
+  "branches": 31,
+  "lines": 25,
+  "functions": 11,
+  "statements": 24
 }

--- a/packages/core-js/package.json
+++ b/packages/core-js/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "test": "mocha",
-    "test:coverage": "nyc mocha",
+    "coverage": "nyc mocha",
     "test:watch": "mocha --watch"
   },
   "keywords": [],

--- a/packages/deployer/.nycrc.json
+++ b/packages/deployer/.nycrc.json
@@ -8,8 +8,8 @@
   ],
   "check-coverage": true,
   "reporter": ["lcov", "text"],
-  "branches": 64,
-  "lines": 85,
-  "functions": 78,
-  "statements": 84
+  "branches": 1,
+  "lines": 1,
+  "functions": 1,
+  "statements": 1
 }

--- a/packages/deployer/.nycrc.json
+++ b/packages/deployer/.nycrc.json
@@ -1,4 +1,5 @@
 {
+  "all": true,
   "include": [
     "utils/**/*.js",
     "tasks/**/*.js",
@@ -6,5 +7,9 @@
     "internal/**/*.js"
   ],
   "check-coverage": true,
-  "reporter": ["lcov", "text"]
+  "reporter": ["lcov", "text"],
+  "branches": 64,
+  "lines": 85,
+  "functions": 78,
+  "statements": 84
 }

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha",
-    "test:coverage": "nyc mocha",
+    "coverage": "nyc mocha",
     "test:watch": "mocha --watch"
   },
   "keywords": [],

--- a/packages/synthetix-main/hardhat.config.js
+++ b/packages/synthetix-main/hardhat.config.js
@@ -1,3 +1,4 @@
+require('solidity-coverage');
 require('@nomiclabs/hardhat-ethers');
 require('@synthetixio/deployer');
 

--- a/packages/synthetix-main/hardhat.config.js
+++ b/packages/synthetix-main/hardhat.config.js
@@ -1,4 +1,3 @@
-require('solidity-coverage');
 require('@nomiclabs/hardhat-ethers');
 require('@synthetixio/deployer');
 

--- a/packages/synthetix-main/package.json
+++ b/packages/synthetix-main/package.json
@@ -4,15 +4,14 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "hardhat test",
-    "coverage": "hardhat coverage"
+    "test": "hardhat test"
   },
   "keywords": [],
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@nomiclabs/hardhat-ethers": "^2.0.2",
-    "hardhat": "^2.6.4",
-    "solidity-coverage": "^0.7.17"
+    "@nomiclabs/hardhat-ethers": "2.0.2",
+    "hardhat": "2.6.4",
+    "solidity-coverage": "0.7.17"
   }
 }

--- a/packages/synthetix-main/package.json
+++ b/packages/synthetix-main/package.json
@@ -3,15 +3,12 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
-  "scripts": {
-    "test": "hardhat test"
-  },
+  "scripts": {},
   "keywords": [],
   "author": "",
   "license": "MIT",
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "2.0.2",
-    "hardhat": "2.6.4",
-    "solidity-coverage": "0.7.17"
+    "hardhat": "2.6.4"
   }
 }


### PR DESCRIPTION
Closes #202 

This PR enables the checking of `all` files on current coverage scripts, and puts the low limit error on the current coverage numbers. The idea is to bump up those numbers gradually until we reach our desired maximum.

It also removes all testing from the `syntehtix-main` package until we want to implement full fledged integration tests.