### PR TITLE
find selectors in dependencies

### DIFF
--- a/packages/core-js/utils/ast/finders.js
+++ b/packages/core-js/utils/ast/finders.js
@@ -1,13 +1,13 @@
 const { findAll } = require('solidity-ast/utils');
 
-function findContractNodeWithId(contractId, asts) {
-  return Array.from(findAll('ContractDefinition', asts)).find(
+function findContractNodeWithId(contractId, ast) {
+  return Array.from(findAll('ContractDefinition', ast)).find(
     (contractDefiniton) => contractDefiniton.id === contractId
   );
 }
 
-function findContractNodeWithName(contractName, asts) {
-  return Array.from(findAll('ContractDefinition', asts)).find(
+function findContractNodeWithName(contractName, ast) {
+  return Array.from(findAll('ContractDefinition', ast)).find(
     (contractDefiniton) => contractDefiniton.name === contractName
   );
 }
@@ -34,9 +34,11 @@ function findContractDependencies(contractName, asts) {
   let dependencyContractNodes = [];
 
   contractNode.linearizedBaseContracts.forEach((baseContractId) => {
-    const dependency = findContractNodeWithId(baseContractId, asts);
-    if (dependency) {
-      dependencyContractNodes.push(dependency);
+    for (var [, ast] of Object.entries(asts)) {
+      const dependency = findContractNodeWithId(baseContractId, ast);
+      if (dependency) {
+        dependencyContractNodes.push(dependency);
+      }
     }
   });
 
@@ -82,19 +84,30 @@ function findYulCaseValues(contractName, ast) {
   return items;
 }
 
-function findFunctionSelectors(contractName, asts) {
+function _findFunctionSelectors(contractNode) {
   const selectors = [];
-  const contractNode = asts[contractName];
-  if (!contractNode) {
-    return selectors;
-  }
 
   for (const functionDefinition of findAll('FunctionDefinition', contractNode)) {
-    selectors.push({ selector: '0x' + functionDefinition.functionSelector });
+    if (functionDefinition.functionSelector) {
+      selectors.push({ selector: '0x' + functionDefinition.functionSelector });
+    }
   }
 
   return selectors;
 }
+
+function findFunctionSelectors(contractName, asts) {
+  const selectors = [];
+  for (const contractNode of findContractDependencies(contractName, asts)) {
+    const currentSelectors = _findFunctionSelectors(contractNode);
+    if (currentSelectors.length > 0) {
+      selectors.push(...currentSelectors);
+    }
+  }
+
+  return selectors;
+}
+
 module.exports = {
   findYulCaseValues,
   findYulStorageSlotAssignments,


### PR DESCRIPTION
Fix #210 
This small PR fixes a bug that prevented the Router AST validator to correctly find selectors in dependencies.