### PR TITLE
Update contract licenses 

### DIFF
--- a/packages/core-contracts/contracts/common/CommonErrors.sol
+++ b/packages/core-contracts/contracts/common/CommonErrors.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: UNLICENSED
+//SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface CommonErrors {

--- a/packages/core-contracts/contracts/interfaces/IERC20.sol
+++ b/packages/core-contracts/contracts/interfaces/IERC20.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: UNLICENSED
+//SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface IERC20 {

--- a/packages/core-contracts/contracts/mocks/ownership/OwnableMock.sol
+++ b/packages/core-contracts/contracts/mocks/ownership/OwnableMock.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: UNLICENSED
+//SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "../../ownership/Ownable.sol";

--- a/packages/core-contracts/contracts/mocks/proxy/Bricker.sol
+++ b/packages/core-contracts/contracts/mocks/proxy/Bricker.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+//SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "../../proxy/UniversalProxyImplementation.sol";

--- a/packages/core-contracts/contracts/mocks/proxy/Destroyer.sol
+++ b/packages/core-contracts/contracts/mocks/proxy/Destroyer.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+//SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 contract Destroyer {

--- a/packages/core-contracts/contracts/mocks/proxy/ForwardingProxyMock.sol
+++ b/packages/core-contracts/contracts/mocks/proxy/ForwardingProxyMock.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: UNLICENSED
+//SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "../../proxy/ForwardingProxy.sol";

--- a/packages/core-contracts/contracts/mocks/proxy/ImplementationMockA.sol
+++ b/packages/core-contracts/contracts/mocks/proxy/ImplementationMockA.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: UNLICENSED
+//SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 contract ImplementationMockA {

--- a/packages/core-contracts/contracts/mocks/proxy/ImplementationMockB.sol
+++ b/packages/core-contracts/contracts/mocks/proxy/ImplementationMockB.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: UNLICENSED
+//SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 contract ImplementationMockB {

--- a/packages/core-contracts/contracts/mocks/proxy/UniversalProxyImplementationMockA.sol
+++ b/packages/core-contracts/contracts/mocks/proxy/UniversalProxyImplementationMockA.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+//SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "../../proxy/UniversalProxyImplementation.sol";

--- a/packages/core-contracts/contracts/mocks/proxy/UniversalProxyImplementationMockB.sol
+++ b/packages/core-contracts/contracts/mocks/proxy/UniversalProxyImplementationMockB.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+//SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "../../proxy/UniversalProxyImplementation.sol";

--- a/packages/core-contracts/contracts/mocks/token/ERC20Mock.sol
+++ b/packages/core-contracts/contracts/mocks/token/ERC20Mock.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+//SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "../../token/ERC20.sol";

--- a/packages/core-contracts/contracts/mocks/utils/ContractUtilMock.sol
+++ b/packages/core-contracts/contracts/mocks/utils/ContractUtilMock.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: UNLICENSED
+//SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "../../utils/ContractUtil.sol";

--- a/packages/core-contracts/contracts/ownership/Ownable.sol
+++ b/packages/core-contracts/contracts/ownership/Ownable.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: UNLICENSED
+//SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "./OwnableMixin.sol";

--- a/packages/core-contracts/contracts/ownership/OwnableMixin.sol
+++ b/packages/core-contracts/contracts/ownership/OwnableMixin.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: UNLICENSED
+//SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 abstract contract OwnableMixin {

--- a/packages/core-contracts/contracts/proxy/ForwardingProxy.sol
+++ b/packages/core-contracts/contracts/proxy/ForwardingProxy.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: UNLICENSED
+//SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 abstract contract ForwardingProxy {

--- a/packages/core-contracts/contracts/proxy/UniversalProxyImplementation.sol
+++ b/packages/core-contracts/contracts/proxy/UniversalProxyImplementation.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+//SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "../utils/ContractUtil.sol";

--- a/packages/core-contracts/contracts/token/ERC20.sol
+++ b/packages/core-contracts/contracts/token/ERC20.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: UNLICENSED
+//SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "../interfaces/IERC20.sol";

--- a/packages/core-contracts/contracts/utils/ContractUtil.sol
+++ b/packages/core-contracts/contracts/utils/ContractUtil.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: UNLICENSED
+//SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 contract ContractUtil {

--- a/packages/core-contracts/contracts/utils/TransformUtil.sol
+++ b/packages/core-contracts/contracts/utils/TransformUtil.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: UNLICENSED
+//SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 contract TransformUtil {


### PR DESCRIPTION
There was an incosistency in the contract license declaration `UNLICENSED` Vs `Unlicense` (also typo) that I wanted to fix. But since we are including in our packages the MIT license file it is safe to assume we are going to use it for the contracts too.