### PR TITLE
Created README.md with codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # synthetix-v3
 [![codecov](https://codecov.io/gh/Synthetixio/synthetix-v3/branch/main/graph/badge.svg)](https://codecov.io/gh/Synthetixio/synthetix-v3)
+
+| core-js | [![codecov](https://codecov.io/gh/Synthetixio/synthetix-v3/branch/main/graph/badge.svg?flag=core-js)](https://codecov.io/gh/Synthetixio/synthetix-v3) |
+| core-contracts | [![codecov](https://codecov.io/gh/Synthetixio/synthetix-v3/branch/main/graph/badge.svg?flag=core-contracts)](https://codecov.io/gh/Synthetixio/synthetix-v3) |
+| deployer | [![codecov](https://codecov.io/gh/Synthetixio/synthetix-v3/branch/main/graph/badge.svg?flag=deployer)](https://codecov.io/gh/Synthetixio/synthetix-v3) |
+| synthetix-modules | [![codecov](https://codecov.io/gh/Synthetixio/synthetix-v3/branch/main/graph/badge.svg?flag=synthetix-modules)](https://codecov.io/gh/Synthetixio/synthetix-v3) |
+| synthetix-main | [![codecov](https://codecov.io/gh/Synthetixio/synthetix-v3/branch/main/graph/badge.svg?flag=synthetix-main)](https://codecov.io/gh/Synthetixio/synthetix-v3) |


### PR DESCRIPTION
Fix #261  Adds a simple (almost empty) README.md to include codecov badge  (https://codecov.io/gh/Synthetixio/synthetix-v3/branch/main/graph/badge.svg)