### PR TITLE
Refactor call to cancel-deployment subtask

### DIFF
--- a/packages/deployer/internal/errors.js
+++ b/packages/deployer/internal/errors.js
@@ -1,0 +1,3 @@
+class ContractValidationError extends Error {}
+
+module.exports = { ContractValidationError };

--- a/packages/deployer/subtasks/cancel-deployment.js
+++ b/packages/deployer/subtasks/cancel-deployment.js
@@ -20,5 +20,4 @@ subtask(
   await del(toDelete);
 
   logger.info('Exiting...');
-  process.exit(0);
 });

--- a/packages/deployer/subtasks/validate-modules.js
+++ b/packages/deployer/subtasks/validate-modules.js
@@ -2,7 +2,8 @@ const { subtask } = require('hardhat/config');
 const logger = require('@synthetixio/core-js/utils/logger');
 const filterValues = require('filter-values');
 const { getAllSelectors, findDuplicateSelectors } = require('../internal/contract-helper');
-const { SUBTASK_VALIDATE_MODULES, SUBTASK_CANCEL_DEPLOYMENT } = require('../task-names');
+const { ContractValidationError } = require('../internal/errors');
+const { SUBTASK_VALIDATE_MODULES } = require('../task-names');
 
 subtask(SUBTASK_VALIDATE_MODULES).setAction(async (_, hre) => {
   logger.subtitle('Validating modules');
@@ -18,7 +19,8 @@ subtask(SUBTASK_VALIDATE_MODULES).setAction(async (_, hre) => {
     );
 
     logger.error(`Duplicate selectors found!\n${details.join('\n')}`);
-    return await hre.run(SUBTASK_CANCEL_DEPLOYMENT);
+
+    throw new ContractValidationError('Found duplicate selectors on modules');
   }
 
   logger.checked('Modules are valid');

--- a/packages/deployer/subtasks/validate-router.js
+++ b/packages/deployer/subtasks/validate-router.js
@@ -4,12 +4,13 @@ const mapValues = require('just-map-values');
 const { initContractData } = require('../internal/process-contracts');
 const RouterSourceValidator = require('../internal/router-source-validator');
 const RouterASTValidator = require('../internal/router-ast-validator');
-const { SUBTASK_VALIDATE_ROUTER, SUBTASK_CANCEL_DEPLOYMENT } = require('../task-names');
+const { ContractValidationError } = require('../internal/errors');
+const { SUBTASK_VALIDATE_ROUTER } = require('../task-names');
 
 subtask(
   SUBTASK_VALIDATE_ROUTER,
   'Runs a series of validations against a generated router source.'
-).setAction(async (_, hre) => {
+).setAction(async () => {
   logger.subtitle('Validating router');
 
   await initContractData('Router');
@@ -18,9 +19,7 @@ subtask(
   const astErrorsFound = await _runASTValidations();
 
   if (sourceErrorsFound.length > 0 || astErrorsFound.length > 0) {
-    logger.error('Router is not valid');
-
-    return await hre.run(SUBTASK_CANCEL_DEPLOYMENT);
+    throw new ContractValidationError('Router is not valid');
   }
 
   logger.checked('Router is valid');

--- a/packages/deployer/subtasks/validate-storage.js
+++ b/packages/deployer/subtasks/validate-storage.js
@@ -2,7 +2,8 @@ const { subtask } = require('hardhat/config');
 const mapValues = require('just-map-values');
 const logger = require('@synthetixio/core-js/utils/logger');
 const ModuleStorageASTValidator = require('../internal/storage-ast-validator');
-const { SUBTASK_VALIDATE_STORAGE, SUBTASK_CANCEL_DEPLOYMENT } = require('../task-names');
+const { ContractValidationError } = require('../internal/errors');
+const { SUBTASK_VALIDATE_STORAGE } = require('../task-names');
 
 subtask(SUBTASK_VALIDATE_STORAGE).setAction(async (_, hre) => {
   logger.subtitle('Validating module storage usage');
@@ -25,7 +26,7 @@ subtask(SUBTASK_VALIDATE_STORAGE).setAction(async (_, hre) => {
       logger.error(error.msg);
     });
 
-    return await hre.run(SUBTASK_CANCEL_DEPLOYMENT);
+    throw new ContractValidationError('Invalid storage usage');
   }
 
   logger.checked('Storage layout is valid');


### PR DESCRIPTION
Closes #275 

This PR removes the `process.exit(0)` from the `cancel-deployment` subtask. Avoiding the shutdown of the current process on fail, and also throws an exit code `1` when there is a error.