### PR TITLE
Add updater for storage slots

### DIFF
--- a/bin/update-storage-slots.js
+++ b/bin/update-storage-slots.js
@@ -1,5 +1,33 @@
 #!/usr/bin/env node
 
+/**
+
+Helper script for searching all the storage files that define a hash slot and update
+it if necessary using the label on the comment.
+
+Usage:
+  npm run update-storage-slots
+
+This script will find all the contracts that have something like this defined:
+
+```
+        assembly {
+            // bytes32(uint(keccak256("io.synthetix.proxy")) - 1)
+            store.slot := 0x0000000000000000000000000000000000000000000000000000000000000000
+        }
+```
+
+And replace it with the correct calculated hash from the label:
+
+```
+        assembly {
+            // bytes32(uint(keccak256("io.synthetix.proxy")) - 1)
+            store.slot := 0x9dbde58b6f7305fccdc5abd7ea1096e84de3f9ee47d83d8c3efc3e5557ac9c74
+        }
+```
+
+*/
+
 const path = require('path');
 const fs = require('fs/promises');
 const { promisify } = require('util');

--- a/bin/update-storage-slots.js
+++ b/bin/update-storage-slots.js
@@ -46,8 +46,10 @@ function toEip1967Hash(label) {
 
 async function main() {
   const contracts = await glob(
-    path.join(__dirname, '..', '**', 'contracts', 'storage', '**', '*.sol'),
-    { ignore: ['**/node_modules/**', '**/artifacts/**'] }
+    path.join(__dirname, '..', 'packages', '**', 'contracts', '**', '*.sol'),
+    {
+      ignore: ['**/node_modules/**', '**/artifacts/**'],
+    }
   );
 
   for (const contractPath of contracts) {

--- a/bin/update-storage-slots.js
+++ b/bin/update-storage-slots.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const fs = require('fs/promises');
+const { promisify } = require('util');
+const { ethers } = require('ethers');
+
+const glob = promisify(require('glob'));
+
+const LabelRegex = /\/\/ bytes32\(uint\(keccak256\("([^"]+)"\)\) - 1\)/;
+const HashRegex = /store\.slot := (0x[0-9A-Fa-f]{64})/;
+
+function toEip1967Hash(label) {
+  const hash = ethers.utils.id(label);
+  const offsetedHash = ethers.BigNumber.from(hash).sub(1);
+  return offsetedHash.toHexString(32);
+}
+
+async function main() {
+  const contracts = await glob(
+    path.join(__dirname, '..', '**', 'contracts', 'storage', '**', '*.sol'),
+    { ignore: ['**/node_modules/**', '**/artifacts/**'] }
+  );
+
+  for (const contractPath of contracts) {
+    const source = await fs.readFile(contractPath).then((buff) => buff.toString());
+    const labelMatch = source.match(LabelRegex);
+    const oldHashMatch = source.match(HashRegex);
+
+    if (!labelMatch || !oldHashMatch) continue;
+
+    const [, label] = labelMatch;
+    const [, oldHash] = oldHashMatch;
+
+    const newHash = toEip1967Hash(label);
+
+    if (newHash !== oldHash) {
+      console.log(
+        `Updating label "${label}" on "${path.relative(
+          path.resolve(__dirname, '..'),
+          contractPath
+        )}"`
+      );
+
+      const result = source.replace(oldHash, newHash);
+      await fs.writeFile(contractPath, result);
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       ],
       "devDependencies": {
         "eslint": "7.32.0",
+        "glob": "7.2.0",
         "hardhat": "2.6.6",
         "pre-commit": "1.2.2",
         "prettier": "2.3.2",
@@ -5854,8 +5855,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.1.7",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -17656,25 +17658,6 @@
         "testrpc-sc": "index.js"
       }
     },
-    "packages/core-contracts/node_modules/glob": {
-      "version": "7.2.0",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "packages/core-contracts/node_modules/glob-parent": {
       "version": "5.1.2",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
@@ -22275,6 +22258,26 @@
         "flat": "cli.js"
       }
     },
+    "packages/core-js/node_modules/glob": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "packages/core-js/node_modules/inquirer": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.2.tgz",
@@ -22812,6 +22815,25 @@
       "dev": true,
       "bin": {
         "flat": "cli.js"
+      }
+    },
+    "packages/deployer/node_modules/glob": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/deployer/node_modules/js-yaml": {
@@ -27677,19 +27699,6 @@
             "node-emoji": "^1.10.0"
           }
         },
-        "glob": {
-          "version": "7.2.0",
-          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
         "glob-parent": {
           "version": "5.1.2",
           "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
@@ -31270,6 +31279,20 @@
           "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
           "dev": true
         },
+        "glob": {
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "inquirer": {
           "version": "8.1.2",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.1.2.tgz",
@@ -31669,6 +31692,19 @@
           "version": "5.0.2",
           "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
           "dev": true
+        },
+        "glob": {
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         },
         "js-yaml": {
           "version": "4.1.0",
@@ -35257,8 +35293,9 @@
       }
     },
     "glob": {
-      "version": "7.1.7",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "lint:quick": "pretty-quick --check --staged --pattern '**/*.(js|sol)'",
     "lint:fix": "npm run lint:js:fix && npm run lint:sol:fix",
     "lint": "npm run lint:js && npm run lint:sol",
-    "check-packages": "bin/check-packages"
+    "check-packages": "bin/check-packages",
+    "update-storage-slots": "bin/update-storage-slots.js"
   },
   "pre-commit": [
     "lint:quick",
@@ -39,6 +40,7 @@
   },
   "devDependencies": {
     "eslint": "7.32.0",
+    "glob": "7.2.0",
     "hardhat": "2.6.6",
     "pre-commit": "1.2.2",
     "prettier": "2.3.2",


### PR DESCRIPTION
Closes #268

This PR adds a simple script for searching all the storage files that define a hash slot and update it if necessary using the label on the comment.

Usage:
```javascript
npm run update-storage-slots
```

This script will find all the contracts that have something like this defined:
```
        assembly {
            // bytes32(uint(keccak256("io.synthetix.proxy")) - 1)
            store.slot := 0x0000000000000000000000000000000000000000000000000000000000000000
        }
```

And replace it with the correct calculated hash from the label:
```
        assembly {
            // bytes32(uint(keccak256("io.synthetix.proxy")) - 1)
            store.slot := 0x9dbde58b6f7305fccdc5abd7ea1096e84de3f9ee47d83d8c3efc3e5557ac9c74
        }
```