### PR TITLE
Add codecov.yml config file to be able to set coverage precision

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  range: "90...100"
+  status:
+    project:
+      default:
+        threshold: 0.1%


### PR DESCRIPTION
This configuration will make codecov stop showing an error if the coverage drops less than `0.1%`, e.g.: https://github.com/Synthetixio/synthetix-v3/pull/341