### PR TITLE
Remove NoChange()

### DIFF
--- a/packages/core-contracts/contracts/proxy/BeaconProxy.sol
+++ b/packages/core-contracts/contracts/proxy/BeaconProxy.sol
@@ -8,8 +8,6 @@ import "../interfaces/IBeacon.sol";
 import "../utils/ContractUtil.sol";
 
 contract BeaconProxy is AbstractProxy, BeaconStorage, CommonErrors, ContractUtil {
-    error NoChange();
-
     event BeaconSet(address beacon);
 
     constructor(address firstBeacon) {
@@ -21,16 +19,12 @@ contract BeaconProxy is AbstractProxy, BeaconStorage, CommonErrors, ContractUtil
     }
 
     function _setBeacon(address newBeacon) internal virtual {
-        if (newBeacon == address(0)) {
+        if (newBeacon == address(0) || newBeacon == _beaconStore().beacon) {
             revert InvalidAddress(newBeacon);
         }
 
         if (!_isContract(newBeacon)) {
             revert InvalidContract(newBeacon);
-        }
-
-        if (newBeacon == _beaconStore().beacon) {
-            revert NoChange();
         }
 
         _beaconStore().beacon = newBeacon;

--- a/packages/core-contracts/test/contracts/proxy/BeaconProxy.test.js
+++ b/packages/core-contracts/test/contracts/proxy/BeaconProxy.test.js
@@ -117,7 +117,10 @@ describe('BeaconProxy', () => {
 
       describe('when trying to set it to the same beacon', () => {
         it('reverts', async () => {
-          await assertRevert(BeaconProxy.setBeacon(Beacon.address), 'NoChange()');
+          await assertRevert(
+            BeaconProxy.setBeacon(Beacon.address),
+            `InvalidAddress("${Beacon.address}")`
+          );
         });
       });
 


### PR DESCRIPTION
FIX #386 
Instead of moving `NoChange()`  error to the `CommonErrros` contract and naming it to something specific, it was cleaner to use the existing `InvalidAddress()` one, till we decide on how explicit and precise we want to be with errors.