### PR TITLE
Fix proxy storage validation

### DIFF
--- a/packages/deployer/subtasks/sync-proxy.js
+++ b/packages/deployer/subtasks/sync-proxy.js
@@ -1,0 +1,38 @@
+const { subtask } = require('hardhat/config');
+const logger = require('@synthetixio/core-js/utils/logger');
+const { initContractData } = require('../internal/process-contracts');
+const { ContractValidationError } = require('../internal/errors');
+const { SUBTASK_SYNC_PROXY } = require('../task-names');
+
+/**
+ * Compiles the Proxy's source, saves it to the deployments file, and checks
+ * that it does not have changes if it's already deployed.
+ */
+subtask(SUBTASK_SYNC_PROXY, 'Compile and sync the source from the Proxy.').setAction(
+  async (_, hre) => {
+    logger.subtitle('Syncing and compiling source from the Proxy');
+
+    const proxyName = hre.config.deployer.proxyContract;
+
+    await initContractData(proxyName);
+
+    const currentBytecode =
+      hre.deployer.deployment.general.contracts[proxyName].deployedBytecodeHash;
+    const previousBytecode =
+      hre.deployer.previousDeployment?.general.contracts[proxyName]?.deployedBytecodeHash;
+
+    if (hre.deployer.previousDeployment && !previousBytecode) {
+      throw new ContractValidationError(
+        'Proxy contract cannot be deleted or have its name changed'
+      );
+    }
+
+    if (previousBytecode && previousBytecode !== currentBytecode) {
+      throw new ContractValidationError(
+        `The ${proxyName} contract cannot be changed after first deployment`
+      );
+    }
+
+    logger.checked('Proxy deployment data is in sync with sources');
+  }
+);

--- a/packages/deployer/subtasks/upgrade-proxy.js
+++ b/packages/deployer/subtasks/upgrade-proxy.js
@@ -47,10 +47,9 @@ subtask(
 
   logger.debug(`Target implementation: ${routerAddress}`);
 
-  const wasProxyDeployed = await _deployProxy({
-    proxyName,
-    routerAddress,
-    hre,
+  const wasProxyDeployed = await hre.run(SUBTASK_DEPLOY_CONTRACT, {
+    contractName: proxyName,
+    constructorArgs: [routerAddress],
   });
 
   if (!wasProxyDeployed) {
@@ -61,14 +60,6 @@ subtask(
 
 function _getDeployedAddress(contractName, hre) {
   return hre.deployer.deployment.general.contracts[contractName].deployedAddress;
-}
-
-async function _deployProxy({ proxyName, routerAddress, hre }) {
-  await initContractData(proxyName);
-  return await hre.run(SUBTASK_DEPLOY_CONTRACT, {
-    contractName: proxyName,
-    constructorArgs: [routerAddress],
-  });
 }
 
 async function _upgradeProxy({ proxyAddress, routerAddress, hre }) {

--- a/packages/deployer/subtasks/upgrade-proxy.js
+++ b/packages/deployer/subtasks/upgrade-proxy.js
@@ -1,7 +1,6 @@
 const logger = require('@synthetixio/core-js/utils/logger');
 const prompter = require('@synthetixio/core-js/utils/prompter');
 const { subtask } = require('hardhat/config');
-const { initContractData } = require('../internal/process-contracts');
 const { processTransaction, processReceipt } = require('../internal/process-transactions');
 const { SUBTASK_UPGRADE_PROXY, SUBTASK_DEPLOY_CONTRACT } = require('../task-names');
 

--- a/packages/deployer/task-names.js
+++ b/packages/deployer/task-names.js
@@ -8,6 +8,7 @@ module.exports = {
   SUBTASK_GENERATE_ROUTER_SOURCE: 'generate-router-source',
   SUBTASK_PREPARE_DEPLOYMENT: 'prepare-deployment',
   SUBTASK_PRINT_INFO: 'print-info',
+  SUBTASK_SYNC_PROXY: 'sync-proxy',
   SUBTASK_SYNC_SOURCES: 'sync-sources',
   SUBTASK_UPGRADE_PROXY: 'upgrade-proxy',
   SUBTASK_VALIDATE_MODULES: 'validate-modules',

--- a/packages/deployer/tasks/deploy.js
+++ b/packages/deployer/tasks/deploy.js
@@ -10,6 +10,7 @@ const {
   SUBTASK_GENERATE_ROUTER_SOURCE,
   SUBTASK_PREPARE_DEPLOYMENT,
   SUBTASK_PRINT_INFO,
+  SUBTASK_SYNC_PROXY,
   SUBTASK_SYNC_SOURCES,
   SUBTASK_UPGRADE_PROXY,
   SUBTASK_VALIDATE_MODULES,
@@ -51,6 +52,7 @@ task(TASK_DEPLOY, 'Deploys all system modules')
       await hre.run(SUBTASK_PRINT_INFO, taskArguments);
       await _compile(hre, quiet);
       await hre.run(SUBTASK_SYNC_SOURCES);
+      await hre.run(SUBTASK_SYNC_PROXY);
       await hre.run(SUBTASK_VALIDATE_STORAGE);
       await hre.run(SUBTASK_VALIDATE_MODULES);
       await hre.run(SUBTASK_DEPLOY_MODULES);

--- a/packages/deployer/test/fixture-projects/custom-proxy/.gitignore
+++ b/packages/deployer/test/fixture-projects/custom-proxy/.gitignore
@@ -1,0 +1,1 @@
+contracts/Proxy.sol

--- a/packages/deployer/test/fixture-projects/custom-proxy/Proxy.edited.sol
+++ b/packages/deployer/test/fixture-projects/custom-proxy/Proxy.edited.sol
@@ -1,0 +1,9 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+import "@synthetixio/core-contracts/contracts/proxy/UUPSProxy.sol";
+
+// solhint-disable-next-line no-empty-blocks
+contract Proxy is UUPSProxy(0x0000000000000000000000000000000000000001) {
+
+}

--- a/packages/deployer/test/fixture-projects/custom-proxy/Proxy.original.sol
+++ b/packages/deployer/test/fixture-projects/custom-proxy/Proxy.original.sol
@@ -1,0 +1,9 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+import "@synthetixio/core-contracts/contracts/proxy/UUPSProxy.sol";
+
+contract Proxy is UUPSProxy {
+    // solhint-disable-next-line no-empty-blocks
+    constructor(address firstImplementation) UUPSProxy(firstImplementation) {}
+}

--- a/packages/deployer/test/fixture-projects/custom-proxy/contracts/AlternativeProxy.sol
+++ b/packages/deployer/test/fixture-projects/custom-proxy/contracts/AlternativeProxy.sol
@@ -1,0 +1,9 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+import "@synthetixio/core-contracts/contracts/proxy/UUPSProxy.sol";
+
+contract AlternativeProxy is UUPSProxy {
+    // solhint-disable-next-line no-empty-blocks
+    constructor(address firstImplementation) UUPSProxy(firstImplementation) {}
+}

--- a/packages/deployer/test/fixture-projects/custom-proxy/contracts/modules/UpgradeModule.sol
+++ b/packages/deployer/test/fixture-projects/custom-proxy/contracts/modules/UpgradeModule.sol
@@ -1,0 +1,9 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@synthetixio/core-modules/contracts/modules/CoreUpgradeModule.sol";
+
+// solhint-disable-next-line no-empty-blocks
+contract UpgradeModule is CoreUpgradeModule {
+
+}

--- a/packages/deployer/test/src/tasks/deploy.test.js
+++ b/packages/deployer/test/src/tasks/deploy.test.js
@@ -99,9 +99,9 @@ describe('tasks/deploy.js', function () {
         clear: true,
       });
 
-      // await this.deploySystem({
-      //   alias: 'second',
-      // });
+      await this.deploySystem({
+        alias: 'second',
+      });
     });
 
     it('throws an error when changing the proxy name', async function () {

--- a/packages/deployer/test/src/tasks/deploy.test.js
+++ b/packages/deployer/test/src/tasks/deploy.test.js
@@ -100,13 +100,10 @@ describe('tasks/deploy.js', function () {
         clear: true,
       });
 
-      // TODO: Uncomment this test when this fixed:
-      //   https://github.com/Synthetixio/synthetix-v3/issues/428
-      // await this.deploySystem({
-      //   alias: 'second',
-      //   clear: false,
-      //   quiet: false,
-      // });
+      // Second deployment, without any changes
+      await this.deploySystem({
+        alias: 'second',
+      });
     });
   });
 });

--- a/packages/deployer/test/src/tasks/deploy.test.js
+++ b/packages/deployer/test/src/tasks/deploy.test.js
@@ -129,28 +129,24 @@ describe('tasks/deploy.js', function () {
 
       const { root, sources } = this.hre.config.paths;
 
-      try {
-        // Create the Proxy
-        await copyFile(path.join(root, 'Proxy.original.sol'), path.join(sources, 'Proxy.sol'));
+      // Create the Proxy
+      await copyFile(path.join(root, 'Proxy.original.sol'), path.join(sources, 'Proxy.sol'));
 
-        // Deploy for the first time
+      // Deploy for the first time
+      await this.deploySystem({
+        alias: 'first',
+        clear: true,
+      });
+
+      // Edit the Proxy
+      await copyFile(path.join(root, 'Proxy.edited.sol'), path.join(sources, 'Proxy.sol'));
+
+      // Try to re-deploy with a changed Proxy
+      await rejects(async () => {
         await this.deploySystem({
-          alias: 'first',
-          clear: true,
+          alias: 'second',
         });
-
-        // Edit the Proxy
-        await copyFile(path.join(root, 'Proxy.edited.sol'), path.join(sources, 'Proxy.sol'));
-
-        // Try to re-deploy with a changed Proxy
-        await rejects(async () => {
-          await this.deploySystem({
-            alias: 'second',
-          });
-        }, ContractValidationError);
-      } finally {
-        await unlink(path.join(sources, 'Proxy.sol'));
-      }
+      }, ContractValidationError);
     });
   });
 });


### PR DESCRIPTION
Closes #428

This PR fixes a bug where we were validating Storage usage on the Proxy (comparing it with the previous deployment) before compiling, which caused to throw an error because the deployer thought that it was deleted.

So, the solution implemented here breaks up the `upgrade-proxy` subtask into `sync-proxy`, and the latter is executed before running any validations, so we make sure that all the `Proxy.sol` data is loaded on the current deployments json files.