### PR TITLE
Allow namespace removals

### DIFF
--- a/packages/deployer/internal/storage-ast-validator.js
+++ b/packages/deployer/internal/storage-ast-validator.js
@@ -83,13 +83,13 @@ class ModuleStorageASTValidator {
       const current = namespaces.find((v) => v.contractName === previous.contractName);
       if (!current) {
         errors.push({
-          msg: `Removed namespaces slot! ${previous.contractName} slot ${previous.slot} not found`,
+          msg: `Storage namespace removed! ${previous.contractName} slot ${previous.slot} not found`,
         });
         continue;
       }
       if (current.slot !== previous.slot) {
         errors.push({
-          msg: `Changed namespaces slot! ${previous.contractName} slot ${previous.slot} changed to ${current.slot}`,
+          msg: `Storage namespace hash changed! ${previous.contractName} slot ${previous.slot} changed to ${current.slot}`,
         });
       }
     }
@@ -139,15 +139,17 @@ class ModuleStorageASTValidator {
     const previousStructsMap = await buildContractsStructMap(this.previousAsts);
     const currentStructsMap = await buildContractsStructMap(this.asts);
 
-    const { modifications, removals } = compareStorageStructs({
+    let { modifications, removals } = compareStorageStructs({
       previousStructsMap,
       currentStructsMap,
     });
 
+    removals = removals.filter((removal) => removal.completeStruct === false);
+
     modifications.forEach((m) => {
       if (!errors.some((e) => e.contract === m.contract && e.struct === m.struct)) {
         errors.push({
-          msg: `Invalid mutation found in namespace ${m.contract}.${m.struct}`,
+          msg: `Invalid modification mutation found in namespace ${m.contract}.${m.struct}`,
           contract: m.contract,
           struct: m.struct,
         });
@@ -157,7 +159,7 @@ class ModuleStorageASTValidator {
     removals.forEach((m) => {
       if (!errors.some((e) => e.contract === m.contract && e.struct === m.struct)) {
         errors.push({
-          msg: `Invalid mutation found in namespace ${m.contract}.${m.struct}`,
+          msg: `Invalid removal mutation found in namespace ${m.contract}.${m.struct}`,
           contract: m.contract,
           struct: m.struct,
         });

--- a/packages/deployer/subtasks/validate-storage.js
+++ b/packages/deployer/subtasks/validate-storage.js
@@ -39,7 +39,9 @@ subtask(SUBTASK_VALIDATE_STORAGE).setAction(async (_, hre) => {
       errorsFound.map((err) => console.log(JSON.stringify(err, null, 2)));
     }
 
-    throw new ContractValidationError(`Invalid storage usage: ${errorsFound.map((err) => err.msg)}`);
+    throw new ContractValidationError(
+      `Invalid storage usage: ${errorsFound.map((err) => err.msg)}`
+    );
   }
 
   logger.checked('Storage layout is valid');

--- a/packages/deployer/subtasks/validate-storage.js
+++ b/packages/deployer/subtasks/validate-storage.js
@@ -1,6 +1,7 @@
 const { subtask } = require('hardhat/config');
 const mapValues = require('just-map-values');
 const logger = require('@synthetixio/core-js/utils/logger');
+const prompter = require('@synthetixio/core-js/utils/prompter');
 const ModuleStorageASTValidator = require('../internal/storage-ast-validator');
 const { ContractValidationError } = require('../internal/errors');
 const { SUBTASK_VALIDATE_STORAGE } = require('../task-names');
@@ -17,16 +18,28 @@ subtask(SUBTASK_VALIDATE_STORAGE).setAction(async (_, hre) => {
 
   let errorsFound = [];
   errorsFound.push(...validator.findNamespaceCollisions());
-  errorsFound.push(...validator.findNamespaceSlotChanges());
   errorsFound.push(...validator.findRegularVariableDeclarations());
   errorsFound.push(...(await validator.findInvalidNamespaceMutations()));
+
+  let warningsFound = [];
+  warningsFound.push(...validator.findNamespaceSlotChanges());
+
+  if (warningsFound.length > 0) {
+    for (let warning of warningsFound) {
+      await prompter.ask(`Warning: ${warning.msg}. Do you wish to continue anyway?`);
+    }
+  }
 
   if (errorsFound.length > 0) {
     errorsFound.forEach((error) => {
       logger.error(error.msg);
     });
 
-    throw new ContractValidationError('Invalid storage usage');
+    if (logger.debug) {
+      errorsFound.map((err) => console.log(JSON.stringify(err, null, 2)));
+    }
+
+    throw new ContractValidationError(`Invalid storage usage: ${errorsFound.map((err) => err.msg)}`);
   }
 
   logger.checked('Storage layout is valid');

--- a/packages/deployer/test/integration/sample-project.test.js
+++ b/packages/deployer/test/integration/sample-project.test.js
@@ -44,19 +44,21 @@ describe('sample-project', function () {
 
     const SomeModuleOriginal = await readFile(path.join(MODULES, 'SomeModule.sol'));
     const AnotherModuleOriginal = await readFile(path.join(MODULES, 'AnotherModule.sol'));
+    const SettingsModuleOriginal = await readFile(path.join(MODULES, 'SettingsModule.sol'));
 
     try {
       // Make some file changes before deploying
       await Promise.all([
         // Create new module
         copyFile(path.join(CONTRACTS, 'NewModule.sol'), path.join(MODULES, 'NewModule.sol')),
-        // Modify a existing module
+        // Modify existing modules
         copyFile(
           path.join(CONTRACTS, 'SomeModule.modified.sol'),
           path.join(MODULES, 'SomeModule.sol')
         ),
-        // Delete a existing module
+        // Delete existing modules
         unlink(path.join(MODULES, 'AnotherModule.sol')),
+        unlink(path.join(MODULES, 'SettingsModule.sol')),
       ]);
 
       await deployOnEnvironment(hre, {
@@ -68,6 +70,7 @@ describe('sample-project', function () {
         unlink(path.join(MODULES, 'NewModule.sol')),
         writeFile(path.join(MODULES, 'SomeModule.sol'), SomeModuleOriginal),
         writeFile(path.join(MODULES, 'AnotherModule.sol'), AnotherModuleOriginal),
+        writeFile(path.join(MODULES, 'SettingsModule.sol'), SettingsModuleOriginal),
       ]);
     }
   });


### PR DESCRIPTION
Fix #474

Atm, if you remove a module, the storage validator will throw an error because you're not allowed to remove storage slots (or change them).

This PR allows it, but as suggested by @leomassazza, the checks are not removed; the user is warned and prompted to continue instead.