### PR TITLE
Adds interfaces for all public facing contracts

### DIFF
--- a/packages/core-contracts/contracts/interfaces/IOwnable.sol
+++ b/packages/core-contracts/contracts/interfaces/IOwnable.sol
@@ -1,0 +1,22 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IOwnable {
+    error NotNominated(address addr);
+    error InvalidNomination(address addr);
+    error NoNomination();
+
+    event OwnerNominated(address newOwner);
+
+    event OwnerChanged(address oldOwner, address newOwner);
+
+    function acceptOwnership() external;
+
+    function nominateNewOwner(address newNominatedOwner) external;
+
+    function renounceNomination() external;
+
+    function owner() external view returns (address);
+
+    function nominatedOwner() external view returns (address);
+}

--- a/packages/core-contracts/contracts/interfaces/IUUPSImplementation.sol
+++ b/packages/core-contracts/contracts/interfaces/IUUPSImplementation.sol
@@ -1,0 +1,15 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IUUPSImplementation {
+    error SterileImplementation(address implementation);
+    error SimulatedUpgradeFailed();
+
+    event Upgraded(address implementation);
+
+    function upgradeTo(address newImplementation) external;
+
+    function simulateUpgradeTo(address newImplementation) external;
+
+    function getImplementation() external view returns (address);
+}

--- a/packages/core-contracts/contracts/ownership/Ownable.sol
+++ b/packages/core-contracts/contracts/ownership/Ownable.sol
@@ -45,11 +45,11 @@ contract Ownable is IOwnable, OwnableMixin, CommonErrors {
         store.nominatedOwner = address(0);
     }
 
-    function owner() external override view returns (address) {
+    function owner() external view override returns (address) {
         return _ownableStore().owner;
     }
 
-    function nominatedOwner() external override view returns (address) {
+    function nominatedOwner() external view override returns (address) {
         return _ownableStore().nominatedOwner;
     }
 }

--- a/packages/core-contracts/contracts/ownership/Ownable.sol
+++ b/packages/core-contracts/contracts/ownership/Ownable.sol
@@ -2,18 +2,11 @@
 pragma solidity ^0.8.0;
 
 import "./OwnableMixin.sol";
+import "../interfaces/IOwnable.sol";
 import "../common/CommonErrors.sol";
 
-contract Ownable is OwnableMixin, CommonErrors {
-    error NotNominated(address addr);
-    error InvalidNomination(address addr);
-    error NoNomination();
-
-    event OwnerNominated(address newOwner);
-
-    event OwnerChanged(address oldOwner, address newOwner);
-
-    function acceptOwnership() external {
+contract Ownable is IOwnable, OwnableMixin, CommonErrors {
+    function acceptOwnership() external override {
         OwnableStore storage store = _ownableStore();
 
         address currentNominatedOwner = store.nominatedOwner;
@@ -27,7 +20,7 @@ contract Ownable is OwnableMixin, CommonErrors {
         store.nominatedOwner = address(0);
     }
 
-    function nominateNewOwner(address newNominatedOwner) external onlyOwnerIfSet {
+    function nominateNewOwner(address newNominatedOwner) external override onlyOwnerIfSet {
         OwnableStore storage store = _ownableStore();
 
         if (newNominatedOwner == address(0)) {
@@ -42,7 +35,7 @@ contract Ownable is OwnableMixin, CommonErrors {
         emit OwnerNominated(newNominatedOwner);
     }
 
-    function renounceNomination() external onlyOwner {
+    function renounceNomination() external override onlyOwner {
         OwnableStore storage store = _ownableStore();
 
         if (store.nominatedOwner == address(0)) {
@@ -52,11 +45,11 @@ contract Ownable is OwnableMixin, CommonErrors {
         store.nominatedOwner = address(0);
     }
 
-    function owner() external view returns (address) {
+    function owner() external override view returns (address) {
         return _ownableStore().owner;
     }
 
-    function nominatedOwner() external view returns (address) {
+    function nominatedOwner() external override view returns (address) {
         return _ownableStore().nominatedOwner;
     }
 }

--- a/packages/core-contracts/contracts/proxy/UUPSImplementation.sol
+++ b/packages/core-contracts/contracts/proxy/UUPSImplementation.sol
@@ -59,7 +59,7 @@ abstract contract UUPSImplementation is IUUPSImplementation, ProxyStorage, Contr
         revert();
     }
 
-    function getImplementation() external override view returns (address) {
+    function getImplementation() external view override returns (address) {
         return _proxyStore().implementation;
     }
 }

--- a/packages/core-contracts/contracts/proxy/UUPSImplementation.sol
+++ b/packages/core-contracts/contracts/proxy/UUPSImplementation.sol
@@ -1,18 +1,12 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import "../interfaces/IUUPSImplementation.sol";
 import "../utils/ContractUtil.sol";
 import "../common/CommonErrors.sol";
 import "./ProxyStorage.sol";
 
-abstract contract UUPSImplementation is ProxyStorage, ContractUtil, CommonErrors {
-    error SterileImplementation(address implementation);
-    error SimulatedUpgradeFailed();
-
-    event Upgraded(address implementation);
-
-    function upgradeTo(address newImplementation) public virtual;
-
+abstract contract UUPSImplementation is IUUPSImplementation, ProxyStorage, ContractUtil, CommonErrors {
     function _upgradeTo(address newImplementation) internal virtual {
         if (newImplementation == address(0)) {
             revert InvalidAddress(newImplementation);
@@ -43,7 +37,7 @@ abstract contract UUPSImplementation is ProxyStorage, ContractUtil, CommonErrors
             keccak256(abi.encodePacked(simulationResponse)) == keccak256(abi.encodePacked(SimulatedUpgradeFailed.selector));
     }
 
-    function simulateUpgradeTo(address newImplementation) public {
+    function simulateUpgradeTo(address newImplementation) public override {
         ProxyStore storage store = _proxyStore();
 
         store.simulatingUpgrade = true;
@@ -65,7 +59,7 @@ abstract contract UUPSImplementation is ProxyStorage, ContractUtil, CommonErrors
         revert();
     }
 
-    function getImplementation() external view returns (address) {
+    function getImplementation() external override view returns (address) {
         return _proxyStore().implementation;
     }
 }

--- a/packages/core-modules/contracts/interfaces/IElectionModule.sol
+++ b/packages/core-modules/contracts/interfaces/IElectionModule.sol
@@ -1,0 +1,14 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IElectionModule {
+    error MemberTokenAlreadyCreated();
+
+    event MemberTokenCreated(address memberTokenAddress);
+
+    function createMemberToken(string memory tokenName, string memory tokenSymbol) external;
+
+    function upgradeMemberTokenImplementation(address newMemberTokenImplementation) external;
+
+    function getMemberTokenAddress() external view returns (address);
+}

--- a/packages/core-modules/contracts/modules/CoreElectionModule.sol
+++ b/packages/core-modules/contracts/modules/CoreElectionModule.sol
@@ -3,15 +3,12 @@ pragma solidity ^0.8.0;
 
 import "@synthetixio/core-contracts/contracts/ownership/OwnableMixin.sol";
 import "@synthetixio/core-contracts/contracts/proxy/UUPSProxy.sol";
+import "../interfaces/IElectionModule.sol";
 import "../token/MemberToken.sol";
 import "../storage/ElectionStorage.sol";
 
-contract CoreElectionModule is ElectionStorage, OwnableMixin {
-    error MemberTokenAlreadyCreated();
-
-    event MemberTokenCreated(address memberTokenAddress);
-
-    function createMemberToken(string memory tokenName, string memory tokenSymbol) public onlyOwner {
+contract CoreElectionModule is IElectionModule, ElectionStorage, OwnableMixin {
+    function createMemberToken(string memory tokenName, string memory tokenSymbol) external override onlyOwner {
         ElectionStore storage store = _electionStore();
 
         if (store.memberTokenAddress != address(0)) {
@@ -33,11 +30,11 @@ contract CoreElectionModule is ElectionStorage, OwnableMixin {
         emit MemberTokenCreated(memberTokenProxyAddress);
     }
 
-    function upgradeMemberTokenImplementation(address newMemberTokenImplementation) public onlyOwner {
+    function upgradeMemberTokenImplementation(address newMemberTokenImplementation) external override onlyOwner {
         MemberToken(getMemberTokenAddress()).upgradeTo(newMemberTokenImplementation);
     }
 
-    function getMemberTokenAddress() public view returns (address) {
+    function getMemberTokenAddress() public override view returns (address) {
         return _electionStore().memberTokenAddress;
     }
 }

--- a/packages/core-modules/contracts/modules/CoreElectionModule.sol
+++ b/packages/core-modules/contracts/modules/CoreElectionModule.sol
@@ -34,7 +34,7 @@ contract CoreElectionModule is IElectionModule, ElectionStorage, OwnableMixin {
         MemberToken(getMemberTokenAddress()).upgradeTo(newMemberTokenImplementation);
     }
 
-    function getMemberTokenAddress() public override view returns (address) {
+    function getMemberTokenAddress() public view override returns (address) {
         return _electionStore().memberTokenAddress;
     }
 }

--- a/packages/synthetix-main/contracts/interfaces/ISNXTokenModule.sol
+++ b/packages/synthetix-main/contracts/interfaces/ISNXTokenModule.sol
@@ -6,7 +6,7 @@ interface SNXTokenModule {
 
     event SNXTokenCreated(address snxAddress);
 
-    function createSNX() external {
+    function createSNX() external;
 
     function upgradeSNXImplementation(address newSNXTokenImplementation) external;
 

--- a/packages/synthetix-main/contracts/interfaces/ISNXTokenModule.sol
+++ b/packages/synthetix-main/contracts/interfaces/ISNXTokenModule.sol
@@ -1,7 +1,7 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-interface SNXTokenModule {
+interface ISNXTokenModule {
     error SNXAlreadyCreated();
 
     event SNXTokenCreated(address snxAddress);

--- a/packages/synthetix-main/contracts/interfaces/ISNXTokenModule.sol
+++ b/packages/synthetix-main/contracts/interfaces/ISNXTokenModule.sol
@@ -1,0 +1,14 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface SNXTokenModule {
+    error SNXAlreadyCreated();
+
+    event SNXTokenCreated(address snxAddress);
+
+    function createSNX() external {
+
+    function upgradeSNXImplementation(address newSNXTokenImplementation) external;
+
+    function getSNXTokenAddress() external view returns (address);
+}

--- a/packages/synthetix-main/contracts/interfaces/ISynthsModule.sol
+++ b/packages/synthetix-main/contracts/interfaces/ISynthsModule.sol
@@ -1,0 +1,29 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface ISynthsModule {
+    error BeaconAlreadyCreated();
+    error BeaconNotCreated();
+    error ImplementationNotSet();
+    error SynthAlreadyCreated();
+
+    event BeaconCreated(address beacon);
+    event SynthCreated(bytes32 synth, address synthAddress);
+
+    function createBeacon() external;
+
+    function createSynth(
+        bytes32 synth,
+        string memory synthName,
+        string memory synthSymbol,
+        uint8 synthDecimals
+    ) external;
+
+    function upgradeSynthImplementation(address newSynthsImplementation) external;
+
+    function getBeacon() external view returns (address);
+
+    function getSynthImplementation() external view returns (address);
+
+    function getSynth(bytes32 synth) external view returns (address);
+}

--- a/packages/synthetix-main/contracts/modules/SNXTokenModule.sol
+++ b/packages/synthetix-main/contracts/modules/SNXTokenModule.sol
@@ -35,7 +35,7 @@ contract SNXTokenModule is ISNXTokenModule, OwnableMixin, SNXTokenStorage {
         SNXToken(getSNXTokenAddress()).upgradeTo(newSNXTokenImplementation);
     }
 
-    function getSNXTokenAddress() public override view returns (address) {
+    function getSNXTokenAddress() public view override returns (address) {
         return _snxTokenStore().snxTokenAddress;
     }
 }

--- a/packages/synthetix-main/contracts/modules/SNXTokenModule.sol
+++ b/packages/synthetix-main/contracts/modules/SNXTokenModule.sol
@@ -3,15 +3,12 @@ pragma solidity ^0.8.0;
 
 import "@synthetixio/core-contracts/contracts/ownership/OwnableMixin.sol";
 import "@synthetixio/core-contracts/contracts/proxy/UUPSProxy.sol";
+import "../interfaces/ISNXTokenModule.sol";
 import "../storage/SNXTokenStorage.sol";
 import "../token/SNXToken.sol";
 
-contract SNXTokenModule is OwnableMixin, SNXTokenStorage {
-    error SNXAlreadyCreated();
-
-    event SNXTokenCreated(address snxAddress);
-
-    function createSNX() public onlyOwner {
+contract SNXTokenModule is ISNXTokenModule, OwnableMixin, SNXTokenStorage {
+    function createSNX() external override onlyOwner {
         SNXTokenStore storage store = _snxTokenStore();
 
         if (store.snxTokenAddress != address(0)) {
@@ -34,11 +31,11 @@ contract SNXTokenModule is OwnableMixin, SNXTokenStorage {
         emit SNXTokenCreated(snxTokenProxyAddress);
     }
 
-    function upgradeSNXImplementation(address newSNXTokenImplementation) public onlyOwner {
+    function upgradeSNXImplementation(address newSNXTokenImplementation) external override onlyOwner {
         SNXToken(getSNXTokenAddress()).upgradeTo(newSNXTokenImplementation);
     }
 
-    function getSNXTokenAddress() public view returns (address) {
+    function getSNXTokenAddress() public override view returns (address) {
         return _snxTokenStore().snxTokenAddress;
     }
 }

--- a/packages/synthetix-main/contracts/modules/SynthsModule.sol
+++ b/packages/synthetix-main/contracts/modules/SynthsModule.sol
@@ -53,15 +53,15 @@ contract SynthsModule is ISynthsModule, OwnableMixin, SynthsStorage {
         Beacon(beaconAddress).upgradeTo(newSynthsImplementation);
     }
 
-    function getBeacon() external override view returns (address) {
+    function getBeacon() external view override returns (address) {
         return _synthsStore().beacon;
     }
 
-    function getSynthImplementation() external override view returns (address) {
+    function getSynthImplementation() external view override returns (address) {
         return Beacon(_synthsStore().beacon).getImplementation();
     }
 
-    function getSynth(bytes32 synth) external override view returns (address) {
+    function getSynth(bytes32 synth) external view override returns (address) {
         return _synthsStore().synths[synth];
     }
 }

--- a/packages/synthetix-main/contracts/modules/SynthsModule.sol
+++ b/packages/synthetix-main/contracts/modules/SynthsModule.sol
@@ -4,19 +4,12 @@ pragma solidity ^0.8.0;
 import "@synthetixio/core-contracts/contracts/proxy/Beacon.sol";
 import "@synthetixio/core-contracts/contracts/ownership/OwnableMixin.sol";
 import "@synthetixio/core-contracts/contracts/proxy/BeaconProxy.sol";
+import "../interfaces/ISynthsModule.sol";
 import "../interfaces/ISynth.sol";
 import "../storage/SynthsStorage.sol";
 
-contract SynthsModule is OwnableMixin, SynthsStorage {
-    error BeaconAlreadyCreated();
-    error BeaconNotCreated();
-    error ImplementationNotSet();
-    error SynthAlreadyCreated();
-
-    event BeaconCreated(address beacon);
-    event SynthCreated(bytes32 synth, address synthAddress);
-
-    function createBeacon() external onlyOwner {
+contract SynthsModule is ISynthsModule, OwnableMixin, SynthsStorage {
+    function createBeacon() external override onlyOwner {
         SynthsStore storage store = _synthsStore();
         if (store.beacon != address(0)) {
             revert BeaconAlreadyCreated();
@@ -31,7 +24,7 @@ contract SynthsModule is OwnableMixin, SynthsStorage {
         string memory synthName,
         string memory synthSymbol,
         uint8 synthDecimals
-    ) external onlyOwner {
+    ) external override onlyOwner {
         if (_synthsStore().synths[synth] != address(0x0)) {
             revert SynthAlreadyCreated();
         }
@@ -52,7 +45,7 @@ contract SynthsModule is OwnableMixin, SynthsStorage {
         ISynth(synthAddress).initialize(synthName, synthSymbol, synthDecimals);
     }
 
-    function upgradeSynthImplementation(address newSynthsImplementation) external onlyOwner {
+    function upgradeSynthImplementation(address newSynthsImplementation) external override onlyOwner {
         address beaconAddress = _synthsStore().beacon;
         if (beaconAddress == address(0)) {
             revert BeaconNotCreated();
@@ -60,15 +53,15 @@ contract SynthsModule is OwnableMixin, SynthsStorage {
         Beacon(beaconAddress).upgradeTo(newSynthsImplementation);
     }
 
-    function getBeacon() external view returns (address) {
+    function getBeacon() external override view returns (address) {
         return _synthsStore().beacon;
     }
 
-    function getSynthImplementation() external view returns (address) {
+    function getSynthImplementation() external override view returns (address) {
         return Beacon(_synthsStore().beacon).getImplementation();
     }
 
-    function getSynth(bytes32 synth) external view returns (address) {
+    function getSynth(bytes32 synth) external override view returns (address) {
         return _synthsStore().synths[synth];
     }
 }


### PR DESCRIPTION
Fix #486

This PR should cover all the interfaces needed so far in the repo.

Note that not all contracts have interfaces, but only those supposed to be outward facing, i.e. that we can expect other protocols to reach into, as well as subgraphs.