### PR TITLE
Implement basic version of ERC20Votes

### DIFF
--- a/packages/core-contracts/contracts/mocks/token/ERC20VotesMock.sol
+++ b/packages/core-contracts/contracts/mocks/token/ERC20VotesMock.sol
@@ -1,0 +1,22 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../../token/ERC20Votes.sol";
+
+contract ERC20VotesMock is ERC20Votes {
+    function initialize(
+        string memory tokenName,
+        string memory tokenSymbol,
+        uint8 tokenDecimals
+    ) public {
+        _initialize(tokenName, tokenSymbol, tokenDecimals);
+    }
+
+    function mint(uint256 amount) external {
+        _mint(msg.sender, amount);
+    }
+
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
+}

--- a/packages/core-contracts/contracts/token/ERC20Votes.sol
+++ b/packages/core-contracts/contracts/token/ERC20Votes.sol
@@ -1,0 +1,10 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./ERC20.sol";
+
+contract ERC20Votes is ERC20 {
+    function getVotes(address account) public view virtual returns (uint256) {
+        return balanceOf(account);
+    }
+}

--- a/packages/core-contracts/test/contracts/token/ERC20Votes.js
+++ b/packages/core-contracts/test/contracts/token/ERC20Votes.js
@@ -1,0 +1,73 @@
+const { ethers } = hre;
+const assertBn = require('@synthetixio/core-js/utils/assert-bignumber');
+
+describe('ERC20Votes', () => {
+  let ERC20;
+
+  let user1, user2;
+
+  before('identify signers', async () => {
+    [user1, user2] = await ethers.getSigners();
+  });
+
+  before('deploy the contract', async () => {
+    const factory = await ethers.getContractFactory('ERC20VotesMock');
+    ERC20 = await factory.deploy();
+    const tx = await ERC20.initialize('Synthetix Network Token', 'snx', 18);
+    await tx.wait();
+  });
+
+  describe('when tokens are minted', () => {
+    const totalSupply = ethers.BigNumber.from('1000000');
+
+    before('mint', async () => {
+      const tx = await ERC20.connect(user1).mint(totalSupply);
+      await tx.wait();
+    });
+
+    it('updates the voting power', async () => {
+      assertBn.eq(await ERC20.getVotes(user1.address), totalSupply);
+    });
+
+    describe('when tokens are burned', () => {
+      const tokensToBurn = ethers.BigNumber.from('1000');
+      const newSupply = totalSupply.sub(tokensToBurn);
+
+      before('burn', async () => {
+        const tx = await ERC20.connect(user1).burn(tokensToBurn);
+        await tx.wait();
+      });
+
+      it('reduces the user voting power', async () => {
+        assertBn.eq(await ERC20.getVotes(user1.address), newSupply);
+      });
+    });
+
+    describe('transfer()', () => {
+      const transferAmount = ethers.BigNumber.from('10');
+      let currentSupply, user1Votes, user2Votes;
+
+      before('record votes and supply', async () => {
+        currentSupply = await ERC20.totalSupply();
+        user1Votes = await ERC20.getVotes(user1.address);
+        user2Votes = await ERC20.getVotes(user2.address);
+      });
+
+      describe('when having enough balance', () => {
+        before('transfer', async () => {
+          const tx = await ERC20.connect(user1).transfer(user2.address, transferAmount);
+          await tx.wait();
+        });
+
+        it('does not alter the total supply', async () => {
+          assertBn.eq(await ERC20.totalSupply(), currentSupply);
+        });
+
+        it('reduces the sender votes and increases the receiver votes', async () => {
+          assertBn.eq(await ERC20.getVotes(user1.address), user1Votes.sub(transferAmount));
+          assertBn.eq(await ERC20.getVotes(user2.address), user2Votes.add(transferAmount));
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fix #458

Implementation of Basic ERC20Votes.

It doesn't include support for:
- Snapshots
- Delegation
- Sign to Delegate

