### PR TITLE
Use proxies in CLI

### DIFF
--- a/packages/cli/subtasks/execute-call.js
+++ b/packages/cli/subtasks/execute-call.js
@@ -20,11 +20,7 @@ subtask(SUBTASK_EXECUTE_CALL, 'Execute the current tx').setAction(async (taskArg
 });
 
 async function executeReadTransaction(address, abi) {
-  const contract = new hre.ethers.Contract(
-    address,
-    abi,
-    hre.ethers.provider
-  );
+  const contract = new hre.ethers.Contract(address, abi, hre.ethers.provider);
 
   const result = await contract[hre.cli.functionName](...hre.cli.functionParameters);
 
@@ -37,11 +33,7 @@ async function executeWriteTransaction(address, abi) {
   const signer = (await hre.ethers.getSigners())[0];
   logger.info(`Signer to use: ${signer.address}`);
 
-  const contract = new hre.ethers.Contract(
-    address,
-    abi,
-    signer
-  );
+  const contract = new hre.ethers.Contract(address, abi, signer);
 
   let tx;
   try {

--- a/packages/cli/subtasks/execute-call.js
+++ b/packages/cli/subtasks/execute-call.js
@@ -8,17 +8,20 @@ subtask(SUBTASK_EXECUTE_CALL, 'Execute the current tx').setAction(async (taskArg
   const abi = hre.deployer.deployment.abis[hre.cli.contractName];
   const functionAbi = abi.find((abiItem) => abiItem.name === hre.cli.functionName);
 
+  const target = hre.deployer.deployment.general.contracts[hre.cli.contractName];
+  const address = target.proxyAddress || target.deployedAddress;
+
   const readOnly = functionAbi.stateMutability === 'view';
   if (readOnly) {
-    await executeReadTransaction(abi);
+    await executeReadTransaction(address, abi);
   } else {
-    await executeWriteTransaction(abi);
+    await executeWriteTransaction(address, abi);
   }
 });
 
-async function executeReadTransaction(abi) {
+async function executeReadTransaction(address, abi) {
   const contract = new hre.ethers.Contract(
-    hre.deployer.deployment.general.contracts[hre.cli.contractName].deployedAddress,
+    address,
     abi,
     hre.ethers.provider
   );
@@ -28,14 +31,14 @@ async function executeReadTransaction(abi) {
   logger.checked(`Result: ${result}`);
 }
 
-async function executeWriteTransaction(abi) {
+async function executeWriteTransaction(address, abi) {
   logger.warn('This is a write transaction');
 
   const signer = (await hre.ethers.getSigners())[0];
   logger.info(`Signer to use: ${signer.address}`);
 
   const contract = new hre.ethers.Contract(
-    hre.deployer.deployment.general.contracts[hre.cli.contractName].deployedAddress,
+    address,
     abi,
     signer
   );

--- a/packages/core-modules/hardhat.config.js
+++ b/packages/core-modules/hardhat.config.js
@@ -1,6 +1,7 @@
 require('solidity-coverage');
 require('@nomiclabs/hardhat-ethers');
 require('@synthetixio/deployer');
+require('@synthetixio/cli');
 
 module.exports = {
   solidity: {

--- a/packages/deployer/internal/abis.js
+++ b/packages/deployer/internal/abis.js
@@ -1,0 +1,32 @@
+const UPGRADE_ABI = [
+  {
+    inputs: [],
+    name: 'getImplementation',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'newImplementation',
+        type: 'address',
+      },
+    ],
+    name: 'upgradeTo',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+];
+
+module.exports = {
+  UPGRADE_ABI,
+};

--- a/packages/deployer/subtasks/deploy-proxy.js
+++ b/packages/deployer/subtasks/deploy-proxy.js
@@ -8,10 +8,26 @@ subtask(SUBTASK_DEPLOY_PROXY, 'Deploys the main proxy if needed').setAction(asyn
   const routerName = 'Router';
   const proxyName = hre.config.deployer.proxyContract;
 
+  await _deployProxy(proxyName, routerName, hre);
+
+  _setProxyOnModules(proxyName, hre);
+});
+
+async function _deployProxy(proxyName, routerName, hre) {
   const routerAddress = hre.deployer.deployment.general.contracts[routerName].deployedAddress;
 
   await hre.run(SUBTASK_DEPLOY_CONTRACT, {
     contractName: proxyName,
     constructorArgs: [routerAddress],
   });
-});
+}
+
+function _setProxyOnModules(proxyName, hre) {
+  const proxy = hre.deployer.deployment.general.contracts[proxyName];
+
+  Object.values(hre.deployer.deployment.general.contracts).map((contract) => {
+    if (contract.isModule) {
+      contract.proxyAddress = proxy.deployedAddress;
+    }
+  });
+}

--- a/packages/deployer/subtasks/deploy-proxy.js
+++ b/packages/deployer/subtasks/deploy-proxy.js
@@ -1,0 +1,17 @@
+const logger = require('@synthetixio/core-js/utils/logger');
+const { subtask } = require('hardhat/config');
+const { SUBTASK_DEPLOY_PROXY, SUBTASK_DEPLOY_CONTRACT } = require('../task-names');
+
+subtask(SUBTASK_DEPLOY_PROXY, 'Deploys the main proxy if needed').setAction(async (_, hre) => {
+  logger.subtitle('Deploying main proxy');
+
+  const routerName = 'Router';
+  const proxyName = hre.config.deployer.proxyContract;
+
+  const routerAddress = hre.deployer.deployment.general.contracts[routerName].deployedAddress;
+
+  await hre.run(SUBTASK_DEPLOY_CONTRACT, {
+    contractName: proxyName,
+    constructorArgs: [routerAddress],
+  });
+});

--- a/packages/deployer/subtasks/upgrade-proxy.js
+++ b/packages/deployer/subtasks/upgrade-proxy.js
@@ -33,7 +33,7 @@ subtask(SUBTASK_UPGRADE_PROXY, 'Upgrades the main proxy if needed').setAction(as
     logger.notice(`Upgrading main proxy to ${routerAddress}`);
 
     try {
-      const signer = (await hre.ethers.getSigners())[0];
+      const [signer] = await hre.ethers.getSigners();
 
       ProxyContract = ProxyContract.connect(signer);
 

--- a/packages/deployer/task-names.js
+++ b/packages/deployer/task-names.js
@@ -11,6 +11,7 @@ module.exports = {
   SUBTASK_PRINT_INFO: 'deployer-print-info',
   SUBTASK_SYNC_PROXY: 'deployer-sync-proxy',
   SUBTASK_SYNC_SOURCES: 'deployer-sync-sources',
+  SUBTASK_DEPLOY_PROXY: 'deployer-deploy-proxy',
   SUBTASK_UPGRADE_PROXY: 'deployer-upgrade-proxy',
   SUBTASK_VALIDATE_MODULES: 'deployer-validate-modules',
   SUBTASK_VALIDATE_STORAGE: 'deployer-validate-storage',

--- a/packages/deployer/tasks/deploy.js
+++ b/packages/deployer/tasks/deploy.js
@@ -13,6 +13,7 @@ const {
   SUBTASK_PRINT_INFO,
   SUBTASK_SYNC_PROXY,
   SUBTASK_SYNC_SOURCES,
+  SUBTASK_DEPLOY_PROXY,
   SUBTASK_UPGRADE_PROXY,
   SUBTASK_VALIDATE_MODULES,
   SUBTASK_VALIDATE_ROUTER,
@@ -62,6 +63,7 @@ task(TASK_DEPLOY, 'Deploys all system modules')
       await _compile(hre, quiet);
       await hre.run(SUBTASK_VALIDATE_ROUTER);
       await hre.run(SUBTASK_DEPLOY_ROUTER);
+      await hre.run(SUBTASK_DEPLOY_PROXY);
       await hre.run(SUBTASK_UPGRADE_PROXY);
       await hre.run(SUBTASK_FINALIZE_DEPLOYMENT);
     } catch (err) {


### PR DESCRIPTION
Fix #539

This PR makes the following changes associated with proxies in the deployer and cli packages:
1) Extracts some of the code in `upgrade-proxy` into a new file `deploy-proxy`.
2) Whenever a proxy is deployed, its address is stored in all contracts that will be behind this proxy, in this case all modules in a new `proxyAddress` field.
3) The CLI will now try to use this `proxyAddress` field instead of the `deployedAddress` field if found.

Note that I could have just used `.isModule` from the CLI, but I decided to go this way because the CLI may eventually target other types of proxies apart from the router proxy. With this implementation, the CLI doesn't care which type of proxy it is, it just knows that its a proxy.