### PR TITLE
Add hardhat plugin for contract sizes

### DIFF
--- a/.github/workflows/contract-size.yml
+++ b/.github/workflows/contract-size.yml
@@ -3,7 +3,7 @@ name: Contract sizes
 on: [push]
 
 jobs:
-  test:
+  size:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/contract-size.yml
+++ b/.github/workflows/contract-size.yml
@@ -9,10 +9,6 @@ jobs:
       matrix:
         package:
           [core-contracts, core-modules, synthetix-main]
-        include:
-          - package: core-contracts
-          - package: core-modules
-          - package: synthetix-main
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/contract-size.yml
+++ b/.github/workflows/contract-size.yml
@@ -1,0 +1,27 @@
+name: Contract sizes
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package:
+          [core-contracts, core-modules, synthetix-main]
+        include:
+          - package: core-contracts
+          - package: core-modules
+          - package: synthetix-main
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16.8.0"
+          cache: "npm"
+      - run: npm ci
+      - name: Compile contracts
+        run: npm run --workspace=./packages/${{ matrix.package }} compile-contracts
+      - name: Execute size command
+        run: npm run --workspace=./packages/${{ matrix.package }} size-contracts

--- a/package-lock.json
+++ b/package-lock.json
@@ -2637,6 +2637,22 @@
         "node": ">=4"
       }
     },
+    "node_modules/cli-table3": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
+      "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
+      "dev": true,
+      "dependencies": {
+        "object-assign": "^4.1.0",
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "colors": "^1.1.2"
+      }
+    },
     "node_modules/cli-width": {
       "version": "2.2.1",
       "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
@@ -2718,6 +2734,15 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -6150,6 +6175,19 @@
       },
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/hardhat-contract-sizer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/hardhat-contract-sizer/-/hardhat-contract-sizer-2.1.1.tgz",
+      "integrity": "sha512-QgfuwdUkKT7Ugn6Zja26Eie7h6OLcBfWBewaaQtYMCzyglNafQPgUIznN2C42/iFmGrlqFPbqv4B98Iev89KSQ==",
+      "dev": true,
+      "dependencies": {
+        "cli-table3": "^0.6.0",
+        "colors": "^1.4.0"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.0.0"
       }
     },
     "node_modules/hardhat/node_modules/@solidity-parser/parser": {
@@ -12867,6 +12905,7 @@
       "devDependencies": {
         "@nomiclabs/hardhat-ethers": "2.0.2",
         "hardhat": "2.6.8",
+        "hardhat-contract-sizer": "2.1.1",
         "solidity-coverage": "0.7.17"
       }
     },
@@ -13218,6 +13257,7 @@
       "devDependencies": {
         "@nomiclabs/hardhat-ethers": "2.0.2",
         "hardhat": "2.6.8",
+        "hardhat-contract-sizer": "2.1.1",
         "solidity-coverage": "0.7.17"
       }
     },
@@ -13573,6 +13613,7 @@
       "devDependencies": {
         "@nomiclabs/hardhat-ethers": "2.0.2",
         "hardhat": "2.6.8",
+        "hardhat-contract-sizer": "2.1.1",
         "solidity-coverage": "0.7.17"
       }
     }
@@ -14626,6 +14667,7 @@
       "requires": {
         "@nomiclabs/hardhat-ethers": "2.0.2",
         "hardhat": "2.6.8",
+        "hardhat-contract-sizer": "*",
         "solidity-coverage": "0.7.17"
       }
     },
@@ -14873,6 +14915,7 @@
       "requires": {
         "@nomiclabs/hardhat-ethers": "2.0.2",
         "hardhat": "2.6.8",
+        "hardhat-contract-sizer": "2.1.1",
         "solidity-coverage": "0.7.17"
       }
     },
@@ -15119,6 +15162,7 @@
       "requires": {
         "@nomiclabs/hardhat-ethers": "2.0.2",
         "hardhat": "2.6.8",
+        "hardhat-contract-sizer": "2.1.1",
         "solidity-coverage": "0.7.17"
       }
     },
@@ -16006,6 +16050,17 @@
         "restore-cursor": "^2.0.0"
       }
     },
+    "cli-table3": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
+      "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
+      "dev": true,
+      "requires": {
+        "colors": "^1.1.2",
+        "object-assign": "^4.1.0",
+        "string-width": "^4.2.0"
+      }
+    },
     "cli-width": {
       "version": "2.2.1",
       "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
@@ -16074,6 +16129,12 @@
     "color-name": {
       "version": "1.1.4",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -18818,6 +18879,16 @@
             "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "hardhat-contract-sizer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/hardhat-contract-sizer/-/hardhat-contract-sizer-2.1.1.tgz",
+      "integrity": "sha512-QgfuwdUkKT7Ugn6Zja26Eie7h6OLcBfWBewaaQtYMCzyglNafQPgUIznN2C42/iFmGrlqFPbqv4B98Iev89KSQ==",
+      "dev": true,
+      "requires": {
+        "cli-table3": "^0.6.0",
+        "colors": "^1.4.0"
       }
     },
     "has": {

--- a/packages/core-contracts/hardhat.config.js
+++ b/packages/core-contracts/hardhat.config.js
@@ -1,6 +1,15 @@
+require('hardhat-contract-sizer');
 require('solidity-coverage');
 require('@nomiclabs/hardhat-ethers');
 
 module.exports = {
-  solidity: '0.8.4',
+  solidity: {
+    version: '0.8.7',
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 200,
+      },
+    },
+  },
 };

--- a/packages/core-contracts/hardhat.config.js
+++ b/packages/core-contracts/hardhat.config.js
@@ -12,4 +12,7 @@ module.exports = {
       },
     },
   },
+  contractSizer: {
+    strict: true,
+  },
 };

--- a/packages/core-contracts/package.json
+++ b/packages/core-contracts/package.json
@@ -8,7 +8,9 @@
   ],
   "scripts": {
     "test": "hardhat test",
-    "coverage": "hardhat coverage"
+    "coverage": "hardhat coverage",
+    "compile-contracts": "hardhat compile",
+    "size-contracts": "hardhat size-contracts"
   },
   "keywords": [],
   "author": "",

--- a/packages/core-contracts/package.json
+++ b/packages/core-contracts/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "2.0.2",
     "hardhat": "2.6.8",
+    "hardhat-contract-sizer": "2.1.1",
     "solidity-coverage": "0.7.17"
   }
 }

--- a/packages/core-modules/hardhat.config.js
+++ b/packages/core-modules/hardhat.config.js
@@ -1,3 +1,4 @@
+require('hardhat-contract-sizer');
 require('solidity-coverage');
 require('@nomiclabs/hardhat-ethers');
 require('@synthetixio/deployer');

--- a/packages/core-modules/hardhat.config.js
+++ b/packages/core-modules/hardhat.config.js
@@ -19,4 +19,7 @@ module.exports = {
       url: 'http://localhost:8545',
     },
   },
+  contractSizer: {
+    strict: true,
+  },
 };

--- a/packages/core-modules/package.json
+++ b/packages/core-modules/package.json
@@ -11,7 +11,9 @@
   ],
   "scripts": {
     "test": "hardhat test",
-    "coverage": "hardhat coverage"
+    "coverage": "hardhat coverage",
+    "compile-contracts": "hardhat compile",
+    "size-contracts": "hardhat size-contracts"
   },
   "keywords": [],
   "author": "",

--- a/packages/core-modules/package.json
+++ b/packages/core-modules/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "2.0.2",
     "hardhat": "2.6.8",
+    "hardhat-contract-sizer": "2.1.1",
     "solidity-coverage": "0.7.17"
   }
 }

--- a/packages/synthetix-main/hardhat.config.js
+++ b/packages/synthetix-main/hardhat.config.js
@@ -28,4 +28,7 @@ module.exports = {
   deployer: {
     proxyContract: 'Synthetix',
   },
+  contractSizer: {
+    strict: true,
+  },
 };

--- a/packages/synthetix-main/hardhat.config.js
+++ b/packages/synthetix-main/hardhat.config.js
@@ -1,5 +1,6 @@
 require('dotenv').config();
 
+require('hardhat-contract-sizer');
 require('solidity-coverage');
 require('@nomiclabs/hardhat-ethers');
 require('@synthetixio/deployer');

--- a/packages/synthetix-main/package.json
+++ b/packages/synthetix-main/package.json
@@ -8,7 +8,9 @@
   ],
   "scripts": {
     "test": "hardhat test",
-    "coverage": "hardhat coverage"
+    "coverage": "hardhat coverage",
+    "compile-contracts": "hardhat compile",
+    "size-contracts": "hardhat size-contracts"
   },
   "keywords": [],
   "author": "",

--- a/packages/synthetix-main/package.json
+++ b/packages/synthetix-main/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "2.0.2",
     "hardhat": "2.6.8",
+    "hardhat-contract-sizer": "2.1.1",
     "solidity-coverage": "0.7.17"
   }
 }


### PR DESCRIPTION
Fix #550

The plugin [hardhat-contract-sizes](https://github.com/ItsNickBarry/hardhat-contract-sizer) was added to the packages:
* core-contracts
* core-modules
* synthetix-main

Which adds a new `npx hardhat size-contracts` hardhat task.

This PR also adds GA tests for checking if any contract is oversize in CI.

FYI, all contracts appear to be very small rn.