### PR TITLE
Add Count Votes using simple counting method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15190,7 +15190,7 @@
       "requires": {
         "@nomiclabs/hardhat-ethers": "2.0.2",
         "hardhat": "2.6.8",
-        "hardhat-contract-sizer": "*",
+        "hardhat-contract-sizer": "2.1.1",
         "solidity-coverage": "0.7.17"
       }
     },

--- a/packages/core-modules/contracts/interfaces/IElectionModule.sol
+++ b/packages/core-modules/contracts/interfaces/IElectionModule.sol
@@ -12,15 +12,29 @@ interface IElectionModule {
 
     function getElectionTokenAddress() external view returns (address);
 
-    function getNominees() external view returns (address[] memory);
-
     function nominate() external;
 
     function withdrawNomination() external;
 
-    function setSeatCount(uint seats) external;
+    function getNominees() external view returns (address[] memory);
 
-    function setPeriodPercent(uint8 percent) external;
+    function elect(address[] memory candidates) external;
+
+    function isElectionEvaluated() external view returns (bool);
+
+    function evaluateElectionBatch() external;
+
+    function resolveElection() external;
+
+    function isEpochFinished() external view returns (bool);
+
+    function isNominating() external view returns (bool);
+
+    function isVoting() external view returns (bool);
+
+    function getSeatCount() external view returns (uint);
+
+    function getPeriodPercent() external view returns (uint);
 
     function setNextSeatCount(uint seats) external;
 
@@ -28,15 +42,11 @@ interface IElectionModule {
 
     function setNextPeriodPercent(uint8 percent) external;
 
-    function elect(address[] memory candidates) external;
+    function getNextSeatCount() external view returns (uint);
 
-    function getNomineeVotes(address nominee) external view returns (uint);
+    function getNextEpochDuration() external view returns (uint);
 
-    function isEpochFinished() external view returns (bool);
-
-    function isNominating() external view returns (bool);
-
-    function isVoting() external view returns (bool);
+    function getNextPeriodPercent() external view returns (uint);
 
     function setupFirstEpoch() external;
 }

--- a/packages/core-modules/contracts/interfaces/IElectionModule.sol
+++ b/packages/core-modules/contracts/interfaces/IElectionModule.sol
@@ -49,4 +49,8 @@ interface IElectionModule {
     function getNextPeriodPercent() external view returns (uint);
 
     function setupFirstEpoch() external;
+
+    function setMaxProcessingBatchSize(uint size) external;
+
+    function getMaxProcessingBatchSize() external view returns (uint);
 }

--- a/packages/core-modules/contracts/modules/CoreElectionModule.sol
+++ b/packages/core-modules/contracts/modules/CoreElectionModule.sol
@@ -236,20 +236,24 @@ contract CoreElectionModule is IElectionModule, ElectionStorage, OwnableMixin {
             uint currentNomineeVotes = electionData.nomineeVotes[currentNominee];
 
             if (currentNomineeVotes > 0) {
-                if (electionData.winner.length < store.seatCount) {
+                if (electionData.nextEpochRepresentatives.length < store.seatCount) {
                     // seats not filled, fill it with whoever received votes
-                    electionData.winner.push(currentNominee);
-                    electionData.winnerVotes.push(currentNomineeVotes);
+                    electionData.nextEpochRepresentatives.push(currentNominee);
+                    electionData.nextEpochRepresentativeVotes.push(currentNomineeVotes);
 
-                    if (electionData.winner.length == store.seatCount) {
-                        (lessVotedCandidateIdx, lessVotedCandidateVotes) = _findLessVoted(electionData.winnerVotes);
+                    if (electionData.nextEpochRepresentatives.length == store.seatCount) {
+                        (lessVotedCandidateIdx, lessVotedCandidateVotes) = _findLessVoted(
+                            electionData.nextEpochRepresentativeVotes
+                        );
                     }
                 } else if (currentNomineeVotes > lessVotedCandidateVotes) {
                     // replace minimun
-                    electionData.winner[lessVotedCandidateIdx] = currentNominee;
-                    electionData.winnerVotes[lessVotedCandidateIdx] = currentNomineeVotes;
+                    electionData.nextEpochRepresentatives[lessVotedCandidateIdx] = currentNominee;
+                    electionData.nextEpochRepresentativeVotes[lessVotedCandidateIdx] = currentNomineeVotes;
 
-                    (lessVotedCandidateIdx, lessVotedCandidateVotes) = _findLessVoted(electionData.winnerVotes);
+                    (lessVotedCandidateIdx, lessVotedCandidateVotes) = _findLessVoted(
+                        electionData.nextEpochRepresentativeVotes
+                    );
                 }
             }
         }

--- a/packages/core-modules/contracts/modules/mocks/ElectionStorageMock.sol
+++ b/packages/core-modules/contracts/modules/mocks/ElectionStorageMock.sol
@@ -4,8 +4,24 @@ pragma solidity ^0.8.0;
 import "../../storage/ElectionStorage.sol";
 
 contract ElectionStorageMock is ElectionStorage {
-    function setNextSeatCountMock(uint seats) external {
+    function setSeatCountMock(uint seats) external {
         _electionStore().seatCount = seats;
+    }
+
+    function getWinners() external view returns (address[] memory) {
+        return _electionStore().electionData.winner;
+    }
+
+    function getWinnerVotes() external view returns (uint[] memory) {
+        return _electionStore().electionData.winnerVotes;
+    }
+
+    function initNextEpochMock() external {
+        // solhint-disable-next-line not-rely-on-time
+        _electionStore().epochStart = block.timestamp;
+        _electionStore().seatCount = _electionStore().nextSeatCount;
+        _electionStore().epochDuration = _electionStore().nextEpochDuration;
+        _electionStore().nominationPeriodPercent = _electionStore().nextNominationPeriodPercent;
     }
 
     function getVoterVoteCandidatesMock(address addr) public view returns (address[] memory) {

--- a/packages/core-modules/contracts/modules/mocks/ElectionStorageMock.sol
+++ b/packages/core-modules/contracts/modules/mocks/ElectionStorageMock.sol
@@ -8,12 +8,12 @@ contract ElectionStorageMock is ElectionStorage {
         _electionStore().seatCount = seats;
     }
 
-    function getWinners() external view returns (address[] memory) {
-        return _electionStore().electionData.winner;
+    function getNextEpochRepresentatives() external view returns (address[] memory) {
+        return _electionStore().electionData.nextEpochRepresentatives;
     }
 
-    function getWinnerVotes() external view returns (uint[] memory) {
-        return _electionStore().electionData.winnerVotes;
+    function getNextEpochRepresentativeVotes() external view returns (uint[] memory) {
+        return _electionStore().electionData.nextEpochRepresentativeVotes;
     }
 
     function initNextEpochMock() external {

--- a/packages/core-modules/contracts/storage/ElectionStorage.sol
+++ b/packages/core-modules/contracts/storage/ElectionStorage.sol
@@ -45,11 +45,11 @@ contract ElectionStorage {
         /**
          * @dev Used to keep track of the next epoch's winners. Gets erased when an epoch starts and a new council takes effect.
          */
-        address[] winners;
+        address[] winner;
         /**
          * @dev Used to keep track of the next epoch's winners votes. Gets erased when an epoch starts and a new council takes effect.
          */
-        uint256[] winnersVotes;
+        uint256[] winnerVotes;
         /**
          * @dev Used to keep track of the latest nominee processed in the last batch.
          */

--- a/packages/core-modules/contracts/storage/ElectionStorage.sol
+++ b/packages/core-modules/contracts/storage/ElectionStorage.sol
@@ -38,6 +38,22 @@ contract ElectionStorage {
          * @dev Position of an address on the nominees Array.
          */
         mapping(address => uint256) nomineeIndexes;
+        /**
+         * @dev Flag to indicate if the election was evaluated (if batched, latest batch was processed).
+         */
+        bool isElectionEvaluated;
+        /**
+         * @dev Used to keep track of the next epoch's winners. Gets erased when an epoch starts and a new council takes effect.
+         */
+        address[] winners;
+        /**
+         * @dev Used to keep track of the next epoch's winners votes. Gets erased when an epoch starts and a new council takes effect.
+         */
+        uint256[] winnersVotes;
+        /**
+         * @dev Used to keep track of the latest nominee processed in the last batch.
+         */
+        uint256 processedBatchIdx;
     }
 
     struct ElectionStore {

--- a/packages/core-modules/contracts/storage/ElectionStorage.sol
+++ b/packages/core-modules/contracts/storage/ElectionStorage.sol
@@ -97,6 +97,10 @@ contract ElectionStorage {
          * @dev Staging duration for the next epoch.
          */
         uint nextNominationPeriodPercent;
+        /**
+         * @dev Used to limit the batch size. This shouldn't be erased on an epoch change
+         */
+        uint256 maxProcessingBatchSize;
     }
 
     function _electionStore() internal pure returns (ElectionStore storage store) {

--- a/packages/core-modules/contracts/storage/ElectionStorage.sol
+++ b/packages/core-modules/contracts/storage/ElectionStorage.sol
@@ -43,13 +43,13 @@ contract ElectionStorage {
          */
         bool isElectionEvaluated;
         /**
-         * @dev Used to keep track of the next epoch's winners. Gets erased when an epoch starts and a new council takes effect.
+         * @dev Used to keep track of the next epoch's nextEpochRepresentativess. Gets erased when an epoch starts and a new council takes effect.
          */
-        address[] winner;
+        address[] nextEpochRepresentatives;
         /**
-         * @dev Used to keep track of the next epoch's winners votes. Gets erased when an epoch starts and a new council takes effect.
+         * @dev Used to keep track of the next epoch's nextEpochRepresentativess votes. Gets erased when an epoch starts and a new council takes effect.
          */
-        uint256[] winnerVotes;
+        uint256[] nextEpochRepresentativeVotes;
         /**
          * @dev Used to keep track of the latest nominee processed in the last batch.
          */

--- a/packages/core-modules/test/contracts/modules/CoreElectionModule.Plurality.test.js
+++ b/packages/core-modules/test/contracts/modules/CoreElectionModule.Plurality.test.js
@@ -1,0 +1,152 @@
+const { deepEqual, equal } = require('assert/strict');
+const assertRevert = require('@synthetixio/core-js/utils/assert-revert');
+const { bootstrap } = require('@synthetixio/deployer/utils/tests');
+const initializer = require('../../helpers/initializer');
+const { fastForward } = require('@synthetixio/core-js/utils/rpc');
+const assertBignumber = require('@synthetixio/core-js/utils/assert-bignumber');
+
+const { ethers } = hre;
+
+describe('CoreElectionModule Count Votes using Simple Plurality strategy', () => {
+  const { proxyAddress } = bootstrap(initializer);
+
+  let CoreElectionModule, ElectionStorageMock, ElectionToken;
+  let owner;
+
+  const minute = 60 * 1000;
+  const day = 24 * 60 * minute;
+  const week = 7 * day;
+
+  before('identify signers, candidates and voters', async () => {
+    [owner] = await ethers.getSigners();
+  });
+
+  before('identify modules', async () => {
+    CoreElectionModule = await ethers.getContractAt('CoreElectionModule', proxyAddress());
+    ElectionStorageMock = await ethers.getContractAt('ElectionStorageMock', proxyAddress());
+  });
+
+  before('setup tokens', async () => {
+    const factory = await ethers.getContractFactory('ElectionTokenMock');
+    ElectionToken = await factory.deploy();
+
+    await (
+      await CoreElectionModule.connect(owner).setElectionTokenAddress(ElectionToken.address)
+    ).wait();
+
+    await (await CoreElectionModule.createMemberToken('Member Token', 'cmt')).wait();
+  });
+
+  it('setup is done', async () => {
+    equal(await CoreElectionModule.isEpochFinished(), false, 'wrong epoch finished state');
+  });
+
+  describe('when counting votes', async () => {
+    describe('when counting a small number of votes', async () => {
+      let candidates, voters;
+
+      before('identify candidates and voters', async () => {
+        candidates = (await ethers.getSigners()).slice(2, 7);
+        voters = (await ethers.getSigners()).slice(2, 7);
+      });
+
+      before('set epoch', async () => {
+        await (await CoreElectionModule.connect(owner).setNextEpochDuration(week)).wait();
+        await (await CoreElectionModule.connect(owner).setNextPeriodPercent(15)).wait();
+        await (await CoreElectionModule.connect(owner).setNextSeatCount(3)).wait();
+        await (await ElectionStorageMock.initNextEpochMock()).wait();
+      });
+
+      before('nominate and setup voters', async () => {
+        await Promise.all(
+          candidates.map((candidate) => CoreElectionModule.connect(candidate).nominate())
+        );
+
+        for (let i = 0; i < voters.length; i++) {
+          await ElectionToken.connect(voters[i]).mint(100 + i * 10);
+        }
+      });
+
+      before('fastForward to voting phase', async () => {
+        await fastForward(3 * day, ethers.provider);
+      });
+
+      it('is voting phase', async () => {
+        equal(await CoreElectionModule.isVoting(), true, 'wrong voting phase');
+        assertBignumber.eq(await CoreElectionModule.getPeriodPercent(), 15);
+        assertBignumber.eq(await CoreElectionModule.getSeatCount(), 3);
+      });
+
+      describe('when attempting to evaluate the election before time', () => {
+        it('reverts', async () => {
+          await assertRevert(CoreElectionModule.evaluateElectionBatch(), 'EpochNotFinished');
+        });
+      });
+
+      describe('when casting votes', () => {
+        before('cast votes', async () => {
+          for (let i = 1; i < voters.length; i++) {
+            let candidateIdx = i % candidates.length;
+            if (candidateIdx == 0) {
+              await CoreElectionModule.connect(voters[i]).elect([candidates[0].address]);
+              continue;
+            }
+            await CoreElectionModule.connect(voters[i]).elect([
+              candidates[0].address,
+              candidates[candidateIdx].address,
+            ]);
+          }
+        });
+
+        before('fastForward to close voting phase', async () => {
+          await fastForward(week, ethers.provider);
+        });
+
+        before('set the batch size to fit all candidates', async () => {
+          await (await CoreElectionModule.connect(owner).setMaxProcessingBatchSize(10)).wait();
+        });
+
+        it('the election is not evaluated', async () => {
+          equal(await CoreElectionModule.isElectionEvaluated(), false);
+        });
+
+        describe('when evaluating the election', () => {
+          let winners, winnerVotes;
+          before('evaluate the election', async () => {
+            await (await CoreElectionModule.evaluateElectionBatch()).wait();
+            winners = await ElectionStorageMock.getWinners();
+            winnerVotes = await ElectionStorageMock.getWinnerVotes();
+          });
+
+          it('the election is evaluated', async () => {
+            equal(await CoreElectionModule.isElectionEvaluated(), true);
+          });
+
+          it('the votes are counted correctly', async () => {
+            let winnerVotesParsed = winnerVotes.map((votes) => votes.toString());
+
+            equal(winners.length, 3);
+            deepEqual(winners, [
+              candidates[0].address,
+              candidates[3].address,
+              candidates[4].address,
+            ]);
+            deepEqual(winnerVotesParsed, ['500', '130', '140']);
+          });
+        });
+
+        describe('when attempting to evaluate the election again', () => {
+          it('reverts', async () => {
+            await assertRevert(
+              CoreElectionModule.evaluateElectionBatch(),
+              'ElectionAlreadyEvaluated'
+            );
+          });
+        });
+      });
+    });
+
+    // describe('when counting a large number of votes', async () => {
+    // })
+  });
+});


### PR DESCRIPTION
Fix #558 

Count Votes using Simple counting and plurality to resolve the election. 

In this way to resolve the election, the Election Evaluation is done by counting votes for candidates no matter the preference order. The candidate(s) that receives the more votes wins. 

When a vote is casted, all the candidates in the ballot receive the voting power of the voter, if the voter changes the vote (vote again with another ballot) the previous one should be rolled back (votes decremented) and new ones will receive their vote power.

At the moment of counting votes, there's a list of candidates with the votes received. We need to loop over this list to find the ones most voted and that will give us the winners of the election.

This PR also includes some cleanup.