### PR TITLE
Add the ability to run multiple elections

### DIFF
--- a/packages/core-modules/contracts/mocks/ElectionTokenMock.sol
+++ b/packages/core-modules/contracts/mocks/ElectionTokenMock.sol
@@ -7,4 +7,8 @@ contract ElectionTokenMock is ERC20 {
     function mint(uint256 amount) external {
         _mint(msg.sender, amount);
     }
+
+    function burn(uint256 amount) external {
+        _burn(msg.sender, amount);
+    }
 }

--- a/packages/core-modules/contracts/modules/mocks/ElectionStorageMock.sol
+++ b/packages/core-modules/contracts/modules/mocks/ElectionStorageMock.sol
@@ -29,12 +29,12 @@ contract ElectionStorageMock is ElectionStorage {
         store.nominationPeriodPercent = 0;
     }
 
-    function getNextEpochRepresentatives() external view returns (address[] memory) {
-        return _electionData().nextEpochRepresentatives;
+    function getNextEpochMembers() external view returns (address[] memory) {
+        return _currentElectionData().nextEpochMembers;
     }
 
-    function getNextEpochRepresentativeVotes() external view returns (uint[] memory) {
-        return _electionData().nextEpochRepresentativeVotes;
+    function getNextEpochMemberVotes() external view returns (uint[] memory) {
+        return _currentElectionData().nextEpochMemberVotes;
     }
 
     function initNextEpochMock() external {
@@ -43,22 +43,22 @@ contract ElectionStorageMock is ElectionStorage {
         _electionStore().seatCount = _electionStore().nextSeatCount;
         _electionStore().epochDuration = _electionStore().nextEpochDuration;
         _electionStore().nominationPeriodPercent = _electionStore().nextNominationPeriodPercent;
-        _electionStore().electionDataIndex++;
+        _electionStore().latestElectionDataIndex++;
     }
 
     function getVoterVoteCandidatesMock(address addr) public view returns (address[] memory) {
-        ElectionData storage electionData = _electionData();
+        ElectionData storage electionData = _currentElectionData();
         VoteData storage voteData = electionData.votes[electionData.votesIndexes[addr]];
         return voteData.candidates;
     }
 
     function getVoterVoteVotePowerMock(address addr) public view returns (uint) {
-        ElectionData storage electionData = _electionData();
+        ElectionData storage electionData = _currentElectionData();
         VoteData storage voteData = electionData.votes[electionData.votesIndexes[addr]];
         return voteData.votePower;
     }
 
-    function _electionData() private view returns (ElectionData storage) {
-        return _electionStore().electionData[_electionStore().electionDataIndex];
+    function _currentElectionData() private view returns (ElectionData storage) {
+        return _electionStore().electionData[_electionStore().latestElectionDataIndex];
     }
 }

--- a/packages/core-modules/contracts/modules/mocks/ElectionStorageMock.sol
+++ b/packages/core-modules/contracts/modules/mocks/ElectionStorageMock.sol
@@ -30,11 +30,11 @@ contract ElectionStorageMock is ElectionStorage {
     }
 
     function getNextEpochRepresentatives() external view returns (address[] memory) {
-        return _electionStore().electionData.nextEpochRepresentatives;
+        return _electionData().nextEpochRepresentatives;
     }
 
     function getNextEpochRepresentativeVotes() external view returns (uint[] memory) {
-        return _electionStore().electionData.nextEpochRepresentativeVotes;
+        return _electionData().nextEpochRepresentativeVotes;
     }
 
     function initNextEpochMock() external {
@@ -43,21 +43,26 @@ contract ElectionStorageMock is ElectionStorage {
         _electionStore().seatCount = _electionStore().nextSeatCount;
         _electionStore().epochDuration = _electionStore().nextEpochDuration;
         _electionStore().nominationPeriodPercent = _electionStore().nextNominationPeriodPercent;
+        _electionStore().electionDataIndex++;
     }
 
     function getVoterVoteCandidatesMock(address addr) public view returns (address[] memory) {
-        ElectionData storage electionData = _electionStore().electionData;
+        ElectionData storage electionData = _electionData();
         VoteData storage voteData = electionData.votes[electionData.votesIndexes[addr]];
         return voteData.candidates;
     }
 
     function getVoterVoteVotePowerMock(address addr) public view returns (uint) {
-        ElectionData storage electionData = _electionStore().electionData;
+        ElectionData storage electionData = _electionData();
         VoteData storage voteData = electionData.votes[electionData.votesIndexes[addr]];
         return voteData.votePower;
     }
 
-    function getEpochStart() public view returns (uint) {
-        return _electionStore().epochStart;
+    // function getEpochStart() public view returns (uint) {
+    //     return _electionStore().epochStart;
+    // }
+
+    function _electionData() private view returns (ElectionData storage) {
+        return _electionStore().electionData[_electionStore().electionDataIndex];
     }
 }

--- a/packages/core-modules/contracts/modules/mocks/ElectionStorageMock.sol
+++ b/packages/core-modules/contracts/modules/mocks/ElectionStorageMock.sol
@@ -58,10 +58,6 @@ contract ElectionStorageMock is ElectionStorage {
         return voteData.votePower;
     }
 
-    // function getEpochStart() public view returns (uint) {
-    //     return _electionStore().epochStart;
-    // }
-
     function _electionData() private view returns (ElectionData storage) {
         return _electionStore().electionData[_electionStore().electionDataIndex];
     }

--- a/packages/core-modules/contracts/storage/ElectionStorage.sol
+++ b/packages/core-modules/contracts/storage/ElectionStorage.sol
@@ -43,13 +43,13 @@ contract ElectionStorage {
          */
         bool isElectionEvaluated;
         /**
-         * @dev Used to keep track of the next epoch's nextEpochRepresentativess. Gets erased when an epoch starts and a new council takes effect.
+         * @dev Used to keep track of the next epoch's nextEpochMembers. Gets erased when an epoch starts and a new council takes effect.
          */
-        address[] nextEpochRepresentatives;
+        address[] nextEpochMembers;
         /**
-         * @dev Used to keep track of the next epoch's nextEpochRepresentativess votes. Gets erased when an epoch starts and a new council takes effect.
+         * @dev Used to keep track of the next epoch's nextEpochMembers votes. Gets erased when an epoch starts and a new council takes effect.
          */
-        uint256[] nextEpochRepresentativeVotes;
+        uint256[] nextEpochMemberVotes;
         /**
          * @dev Used to keep track of the latest nominee processed in the last batch.
          */
@@ -66,13 +66,13 @@ contract ElectionStorage {
          */
         address electionTokenAddress;
         /**
-         * @dev Voting data for the current election
+         * @dev Voting data for the current and past elections
          */
         mapping(uint => ElectionData) electionData;
         /**
          * @dev Index pointing to the latest electionDta
          */
-        uint electionDataIndex;
+        uint latestElectionDataIndex;
         /**
          * @dev Number of members in the current epoch.
          */

--- a/packages/core-modules/contracts/storage/ElectionStorage.sol
+++ b/packages/core-modules/contracts/storage/ElectionStorage.sol
@@ -68,7 +68,11 @@ contract ElectionStorage {
         /**
          * @dev Voting data for the current election
          */
-        ElectionData electionData;
+        mapping(uint => ElectionData) electionData;
+        /**
+         * @dev Index pointing to the latest electionDta
+         */
+        uint electionDataIndex;
         /**
          * @dev Number of members in the current epoch.
          */

--- a/packages/core-modules/test/contracts/modules/CoreElectionModule.Plurality.test.js
+++ b/packages/core-modules/test/contracts/modules/CoreElectionModule.Plurality.test.js
@@ -71,9 +71,7 @@ describe('CoreElectionModule Count Votes using Simple Plurality strategy', () =>
 
       after('cleanup voters', async () => {
         for (const voter of voters) {
-          await ElectionToken.connect(voter).burn(
-            await ElectionToken.balanceOf(voter.address)
-          );
+          await ElectionToken.connect(voter).burn(await ElectionToken.balanceOf(voter.address));
         }
       });
 
@@ -185,9 +183,7 @@ describe('CoreElectionModule Count Votes using Simple Plurality strategy', () =>
 
       after('cleanup voters', async () => {
         for (const voter of voters) {
-          await ElectionToken.connect(voter).burn(
-            await ElectionToken.balanceOf(voter.address)
-          );
+          await ElectionToken.connect(voter).burn(await ElectionToken.balanceOf(voter.address));
         }
       });
 

--- a/packages/core-modules/test/contracts/modules/CoreElectionModule.Plurality.test.js
+++ b/packages/core-modules/test/contracts/modules/CoreElectionModule.Plurality.test.js
@@ -184,9 +184,9 @@ describe('CoreElectionModule Count Votes using Simple Plurality strategy', () =>
       });
 
       after('cleanup voters', async () => {
-        for (let i = 0; i < voters.length; i++) {
-          await ElectionToken.connect(voters[i]).burn(
-            await ElectionToken.balanceOf(voters[i].address)
+        for (const voter of voters) {
+          await ElectionToken.connect(voter).burn(
+            await ElectionToken.balanceOf(voter.address)
           );
         }
       });

--- a/packages/core-modules/test/contracts/modules/CoreElectionModule.Plurality.test.js
+++ b/packages/core-modules/test/contracts/modules/CoreElectionModule.Plurality.test.js
@@ -70,9 +70,9 @@ describe('CoreElectionModule Count Votes using Simple Plurality strategy', () =>
       });
 
       after('cleanup voters', async () => {
-        for (let i = 0; i < voters.length; i++) {
-          await ElectionToken.connect(voters[i]).burn(
-            await ElectionToken.balanceOf(voters[i].address)
+        for (const voter of voters) {
+          await ElectionToken.connect(voter).burn(
+            await ElectionToken.balanceOf(voter.address)
           );
         }
       });

--- a/packages/core-modules/test/contracts/modules/CoreElectionModule.Plurality.test.js
+++ b/packages/core-modules/test/contracts/modules/CoreElectionModule.Plurality.test.js
@@ -159,7 +159,6 @@ describe('CoreElectionModule Count Votes using Simple Plurality strategy', () =>
       });
     });
 
-    // Skipped until we figure out how to run more than one election :/
     describe('when counting a large number of votes and candidates', async () => {
       let candidates, voters;
 

--- a/packages/core-modules/test/contracts/modules/CoreElectionModule.Plurality.test.js
+++ b/packages/core-modules/test/contracts/modules/CoreElectionModule.Plurality.test.js
@@ -69,6 +69,14 @@ describe('CoreElectionModule Count Votes using Simple Plurality strategy', () =>
         }
       });
 
+      after('cleanup voters', async () => {
+        for (let i = 0; i < voters.length; i++) {
+          await ElectionToken.connect(voters[i]).burn(
+            await ElectionToken.balanceOf(voters[i].address)
+          );
+        }
+      });
+
       before('fastForward to voting phase', async () => {
         await fastForward(3 * day, ethers.provider);
       });
@@ -152,7 +160,7 @@ describe('CoreElectionModule Count Votes using Simple Plurality strategy', () =>
     });
 
     // Skipped until we figure out how to run more than one election :/
-    describe.skip('when counting a large number of votes and candidates', async () => {
+    describe('when counting a large number of votes and candidates', async () => {
       let candidates, voters;
 
       before('identify candidates and voters', async () => {
@@ -167,14 +175,20 @@ describe('CoreElectionModule Count Votes using Simple Plurality strategy', () =>
       });
 
       before('nominate and setup voters', async () => {
-        console.log(candidates.map((candidate) => candidate.address));
-        console.log(await CoreElectionModule.getNominees());
         await Promise.all(
           candidates.map((candidate) => CoreElectionModule.connect(candidate).nominate())
         );
 
         for (let i = 0; i < voters.length; i++) {
           await ElectionToken.connect(voters[i]).mint(100 + i * 10);
+        }
+      });
+
+      after('cleanup voters', async () => {
+        for (let i = 0; i < voters.length; i++) {
+          await ElectionToken.connect(voters[i]).burn(
+            await ElectionToken.balanceOf(voters[i].address)
+          );
         }
       });
 
@@ -232,6 +246,10 @@ describe('CoreElectionModule Count Votes using Simple Plurality strategy', () =>
                 await (await CoreElectionModule.evaluateElectionBatch()).wait();
                 finished = await CoreElectionModule.isElectionEvaluated();
               }
+
+              nextEpochRepresentatives = await ElectionStorageMock.getNextEpochRepresentatives();
+              nextEpochRepresentativeVotes =
+                await ElectionStorageMock.getNextEpochRepresentativeVotes();
             });
 
             it('the votes are counted correctly', async () => {
@@ -242,10 +260,10 @@ describe('CoreElectionModule Count Votes using Simple Plurality strategy', () =>
               equal(nextEpochRepresentatives.length, 3);
               deepEqual(nextEpochRepresentatives, [
                 candidates[0].address,
-                candidates[98].address,
-                candidates[99].address,
+                candidates[9].address,
+                candidates[8].address,
               ]);
-              deepEqual(nextEpochRepresentativeVotesParsed, ['500', '130', '140']);
+              deepEqual(nextEpochRepresentativeVotesParsed, ['1350', '190', '180']);
             });
           });
         });

--- a/packages/core-modules/test/contracts/modules/CoreElectionModule.Plurality.test.js
+++ b/packages/core-modules/test/contracts/modules/CoreElectionModule.Plurality.test.js
@@ -119,12 +119,11 @@ describe('CoreElectionModule Count Votes using Simple Plurality strategy', () =>
         });
 
         describe('when evaluating the election', () => {
-          let nextEpochRepresentatives, nextEpochRepresentativeVotes;
+          let nextEpochMembers, nextEpochMemberVotes;
           before('evaluate the election', async () => {
             await (await CoreElectionModule.evaluateElectionBatch()).wait();
-            nextEpochRepresentatives = await ElectionStorageMock.getNextEpochRepresentatives();
-            nextEpochRepresentativeVotes =
-              await ElectionStorageMock.getNextEpochRepresentativeVotes();
+            nextEpochMembers = await ElectionStorageMock.getNextEpochMembers();
+            nextEpochMemberVotes = await ElectionStorageMock.getNextEpochMemberVotes();
           });
 
           it('the election is evaluated', async () => {
@@ -132,17 +131,15 @@ describe('CoreElectionModule Count Votes using Simple Plurality strategy', () =>
           });
 
           it('the votes are counted correctly', async () => {
-            let nextEpochRepresentativeVotesParsed = nextEpochRepresentativeVotes.map((votes) =>
-              votes.toString()
-            );
+            let nextEpochMemberVotesParsed = nextEpochMemberVotes.map((votes) => votes.toString());
 
-            equal(nextEpochRepresentatives.length, 3);
-            deepEqual(nextEpochRepresentatives, [
+            equal(nextEpochMembers.length, 3);
+            deepEqual(nextEpochMembers, [
               candidates[0].address,
               candidates[3].address,
               candidates[4].address,
             ]);
-            deepEqual(nextEpochRepresentativeVotesParsed, ['500', '130', '140']);
+            deepEqual(nextEpochMemberVotesParsed, ['500', '130', '140']);
           });
         });
 
@@ -234,7 +231,7 @@ describe('CoreElectionModule Count Votes using Simple Plurality strategy', () =>
           });
 
           describe('when completing the batches', () => {
-            let nextEpochRepresentatives, nextEpochRepresentativeVotes;
+            let nextEpochMembers, nextEpochMemberVotes;
             before('evaluate the election', async () => {
               let finished = await CoreElectionModule.isElectionEvaluated();
               while (!finished) {
@@ -242,23 +239,22 @@ describe('CoreElectionModule Count Votes using Simple Plurality strategy', () =>
                 finished = await CoreElectionModule.isElectionEvaluated();
               }
 
-              nextEpochRepresentatives = await ElectionStorageMock.getNextEpochRepresentatives();
-              nextEpochRepresentativeVotes =
-                await ElectionStorageMock.getNextEpochRepresentativeVotes();
+              nextEpochMembers = await ElectionStorageMock.getNextEpochMembers();
+              nextEpochMemberVotes = await ElectionStorageMock.getNextEpochMemberVotes();
             });
 
             it('the votes are counted correctly', async () => {
-              let nextEpochRepresentativeVotesParsed = nextEpochRepresentativeVotes.map((votes) =>
+              let nextEpochMemberVotesParsed = nextEpochMemberVotes.map((votes) =>
                 votes.toString()
               );
 
-              equal(nextEpochRepresentatives.length, 3);
-              deepEqual(nextEpochRepresentatives, [
+              equal(nextEpochMembers.length, 3);
+              deepEqual(nextEpochMembers, [
                 candidates[0].address,
                 candidates[9].address,
                 candidates[8].address,
               ]);
-              deepEqual(nextEpochRepresentativeVotesParsed, ['1350', '190', '180']);
+              deepEqual(nextEpochMemberVotesParsed, ['1350', '190', '180']);
             });
           });
         });


### PR DESCRIPTION
Fixes #579, #609 

This PR fixes the problem we had when we faced the Solidity limitation where it's not possible to add struct with nested mappings to arrays. To overcome this issue I changed the array to a mapping and added an uint index to identify the latest. As a side effect, since the uint index is used incrementally we can access (if needed) previous election data.

⚠️ This PR merges into the feature branch feature-ElectionModule and not to main. After all the small pieces of ElectionModule are done we need to merge the feature branch into main ⚠️ 