### PR TITLE
Abstracts nominee removal into an ArrayUtil

### DIFF
--- a/packages/core-contracts/contracts/mocks/utils/ArrayUtilMock.sol
+++ b/packages/core-contracts/contracts/mocks/utils/ArrayUtilMock.sol
@@ -1,0 +1,30 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../../utils/ArrayUtil.sol";
+
+contract ArrayUtilMock {
+    address[] _values;
+    mapping(address => uint) _positions;
+
+    function addValue(address value) public {
+        _values.push(value);
+        _positions[value] = _values.length;
+    }
+
+    function removeValue(address value) public {
+        ArrayUtil.removeValue(value, _values, _positions);
+    }
+
+    function valueAtIndex(uint index) public view returns (address) {
+        return _values[index];
+    }
+
+    function positionForValue(address value) public view returns (uint) {
+        return _positions[value];
+    }
+
+    function numValues() public view returns (uint) {
+        return _values.length;
+    }
+}

--- a/packages/core-contracts/contracts/mocks/utils/ArrayUtilMock.sol
+++ b/packages/core-contracts/contracts/mocks/utils/ArrayUtilMock.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.0;
 import "../../utils/ArrayUtil.sol";
 
 contract ArrayUtilMock {
-    address[] _values;
-    mapping(address => uint) _positions;
+    address[] private _values;
+    mapping(address => uint) private _positions;
 
     function addValue(address value) public {
         _values.push(value);

--- a/packages/core-contracts/contracts/utils/ArrayUtil.sol
+++ b/packages/core-contracts/contracts/utils/ArrayUtil.sol
@@ -1,0 +1,28 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+library ArrayUtil {
+    error ArrayValueNotFound(address element);
+
+    function removeValue(address value, address[] storage array, mapping(address => uint) storage positions) internal {
+        uint256 valuePosition = positions[value];
+        if (valuePosition == 0) {
+            revert ArrayValueNotFound(value);
+        }
+
+        uint256 valueIndex = valuePosition - 1;
+        uint256 lastIndex = array.length - 1;
+
+        // Swap value to be deleted with the last value in the array.
+        if (lastIndex != valueIndex) {
+            address lastValue = array[lastIndex];
+
+            array[valueIndex] = lastvalue;
+            positions[lastvalue] = valueIndex;
+        }
+
+        array.pop();
+
+        delete positions[value];
+    }
+}

--- a/packages/core-contracts/contracts/utils/ArrayUtil.sol
+++ b/packages/core-contracts/contracts/utils/ArrayUtil.sol
@@ -4,7 +4,11 @@ pragma solidity ^0.8.0;
 library ArrayUtil {
     error ArrayValueNotFound(address element);
 
-    function removeValue(address value, address[] storage array, mapping(address => uint) storage positions) internal {
+    function removeValue(
+        address value,
+        address[] storage array,
+        mapping(address => uint) storage positions
+    ) internal {
         uint256 valuePosition = positions[value];
         if (valuePosition == 0) {
             revert ArrayValueNotFound(value);
@@ -17,8 +21,8 @@ library ArrayUtil {
         if (lastIndex != valueIndex) {
             address lastValue = array[lastIndex];
 
-            array[valueIndex] = lastvalue;
-            positions[lastvalue] = valueIndex;
+            array[valueIndex] = lastValue;
+            positions[lastValue] = valueIndex;
         }
 
         array.pop();

--- a/packages/core-contracts/contracts/utils/ArrayUtil.sol
+++ b/packages/core-contracts/contracts/utils/ArrayUtil.sol
@@ -2,27 +2,27 @@
 pragma solidity ^0.8.0;
 
 library ArrayUtil {
-    error ArrayValueNotFound(address element);
+    error ArrayValueNotFound(address value);
 
     function removeValue(
         address value,
         address[] storage array,
         mapping(address => uint) storage positions
     ) internal {
-        uint256 valuePosition = positions[value];
+        uint valuePosition = positions[value];
         if (valuePosition == 0) {
             revert ArrayValueNotFound(value);
         }
 
-        uint256 valueIndex = valuePosition - 1;
-        uint256 lastIndex = array.length - 1;
+        uint valueIndex = valuePosition - 1;
+        uint lastIndex = array.length - 1;
 
         // Swap value to be deleted with the last value in the array.
         if (lastIndex != valueIndex) {
             address lastValue = array[lastIndex];
 
             array[valueIndex] = lastValue;
-            positions[lastValue] = valueIndex;
+            positions[lastValue] = valuePosition;
         }
 
         array.pop();

--- a/packages/core-contracts/test/contracts/utils/ArrayUtil.test.js
+++ b/packages/core-contracts/test/contracts/utils/ArrayUtil.test.js
@@ -1,8 +1,7 @@
 const { ethers } = hre;
-const assert = require('assert/strict');
 const assertBn = require('@synthetixio/core-js/utils/assertions/assert-bignumber');
 
-describe.only('ArrayUtil', () => {
+describe('ArrayUtil', () => {
   let ArrayUtil;
 
   let user1, user2, user3, user4, user5;

--- a/packages/core-contracts/test/contracts/utils/ArrayUtil.test.js
+++ b/packages/core-contracts/test/contracts/utils/ArrayUtil.test.js
@@ -1,0 +1,85 @@
+const { ethers } = hre;
+const assert = require('assert/strict');
+const assertBn = require('@synthetixio/core-js/utils/assertions/assert-bignumber');
+
+describe.only('ArrayUtil', () => {
+  let ArrayUtil;
+
+  let user1, user2, user3, user4, user5;
+
+  before('identify signers', async () => {
+    [user1, user2, user3, user4, user5] = await ethers.getSigners();
+  });
+
+  before('deploy the contract', async () => {
+    const factory = await ethers.getContractFactory('ArrayUtilMock');
+    ArrayUtil = await factory.deploy();
+  });
+
+  describe('when adding multiple values to the array', () => {
+    before('add several values to the array', async function () {
+      await (await ArrayUtil.addValue(user1.address)).wait();
+      await (await ArrayUtil.addValue(user2.address)).wait();
+      await (await ArrayUtil.addValue(user3.address)).wait();
+      await (await ArrayUtil.addValue(user4.address)).wait();
+      await (await ArrayUtil.addValue(user5.address)).wait();
+    });
+
+    it('reflects the expected data layout', async function () {
+      assertBn.eq(await ArrayUtil.numValues(), 5);
+
+      assertBn.eq(await ArrayUtil.valueAtIndex(0), user1.address);
+      assertBn.eq(await ArrayUtil.valueAtIndex(1), user2.address);
+      assertBn.eq(await ArrayUtil.valueAtIndex(2), user3.address);
+      assertBn.eq(await ArrayUtil.valueAtIndex(3), user4.address);
+      assertBn.eq(await ArrayUtil.valueAtIndex(4), user5.address);
+
+      assertBn.eq(await ArrayUtil.positionForValue(user1.address), 1);
+      assertBn.eq(await ArrayUtil.positionForValue(user2.address), 2);
+      assertBn.eq(await ArrayUtil.positionForValue(user3.address), 3);
+      assertBn.eq(await ArrayUtil.positionForValue(user4.address), 4);
+      assertBn.eq(await ArrayUtil.positionForValue(user5.address), 5);
+    });
+
+    describe('when removing a value', function () {
+      before('remove the 3rd value', async function () {
+        await (await ArrayUtil.removeValue(user3.address)).wait();
+      });
+
+      it('reflects the expected data layout', async function () {
+        assertBn.eq(await ArrayUtil.numValues(), 4);
+
+        assertBn.eq(await ArrayUtil.valueAtIndex(0), user1.address);
+        assertBn.eq(await ArrayUtil.valueAtIndex(1), user2.address);
+        assertBn.eq(await ArrayUtil.valueAtIndex(2), user5.address);
+        assertBn.eq(await ArrayUtil.valueAtIndex(3), user4.address);
+
+        assertBn.eq(await ArrayUtil.positionForValue(user1.address), 1);
+        assertBn.eq(await ArrayUtil.positionForValue(user2.address), 2);
+        assertBn.eq(await ArrayUtil.positionForValue(user3.address), 0);
+        assertBn.eq(await ArrayUtil.positionForValue(user5.address), 3);
+        assertBn.eq(await ArrayUtil.positionForValue(user4.address), 4);
+      });
+
+      describe('when removing another value', function () {
+        before('remove the 1st value', async function () {
+          await (await ArrayUtil.removeValue(user1.address)).wait();
+        });
+
+        it('reflects the expected data layout', async function () {
+          assertBn.eq(await ArrayUtil.numValues(), 3);
+
+          assertBn.eq(await ArrayUtil.valueAtIndex(0), user4.address);
+          assertBn.eq(await ArrayUtil.valueAtIndex(1), user2.address);
+          assertBn.eq(await ArrayUtil.valueAtIndex(2), user5.address);
+
+          assertBn.eq(await ArrayUtil.positionForValue(user1.address), 0);
+          assertBn.eq(await ArrayUtil.positionForValue(user4.address), 1);
+          assertBn.eq(await ArrayUtil.positionForValue(user2.address), 2);
+          assertBn.eq(await ArrayUtil.positionForValue(user3.address), 0);
+          assertBn.eq(await ArrayUtil.positionForValue(user5.address), 3);
+        });
+      });
+    });
+  });
+});

--- a/packages/core-contracts/test/contracts/utils/ArrayUtil.test.js
+++ b/packages/core-contracts/test/contracts/utils/ArrayUtil.test.js
@@ -1,5 +1,6 @@
 const { ethers } = hre;
 const assertBn = require('@synthetixio/core-js/utils/assertions/assert-bignumber');
+const assertRevert = require('@synthetixio/core-js/utils/assertions/assert-revert');
 
 describe('ArrayUtil', () => {
   let ArrayUtil;
@@ -38,6 +39,13 @@ describe('ArrayUtil', () => {
       assertBn.eq(await ArrayUtil.positionForValue(user3.address), 3);
       assertBn.eq(await ArrayUtil.positionForValue(user4.address), 4);
       assertBn.eq(await ArrayUtil.positionForValue(user5.address), 5);
+    });
+
+    it('reverts when trying to access a value beyond the length of the array', async function () {
+      await assertRevert(
+        ArrayUtil.valueAtIndex(5),
+        'Array accessed at an out-of-bounds or negative index'
+      );
     });
 
     describe('when removing a value', function () {

--- a/packages/core-modules/contracts/modules/CoreElectionModule.sol
+++ b/packages/core-modules/contracts/modules/CoreElectionModule.sol
@@ -89,6 +89,9 @@ contract CoreElectionModule is IElectionModule, ElectionStorage, OwnableMixin {
 
     function withdrawNomination() external override {
         ElectionData storage electionData = _currentElectionData();
+        if (electionData.nomineePositions[msg.sender] == 0) {
+            revert NotNominated(msg.sender);
+        }
 
         ArrayUtil.removeValue(msg.sender, electionData.nominees, electionData.nomineePositions);
     }

--- a/packages/core-modules/contracts/modules/CoreElectionModule.sol
+++ b/packages/core-modules/contracts/modules/CoreElectionModule.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import "@synthetixio/core-contracts/contracts/token/ERC20.sol";
 import "@synthetixio/core-contracts/contracts/ownership/OwnableMixin.sol";
 import "@synthetixio/core-contracts/contracts/proxy/UUPSProxy.sol";
+import "@synthetixio/core-contracts/contracts/utils/ArrayUtil.sol";
 import "../interfaces/IElectionModule.sol";
 import "../token/MemberToken.sol";
 import "../storage/ElectionStorage.sol";
@@ -77,44 +78,19 @@ contract CoreElectionModule is IElectionModule, ElectionStorage, OwnableMixin {
     function nominate() external override {
         ElectionData storage electionData = _currentElectionData();
 
-        if (electionData.nomineeIndexes[msg.sender] != 0) {
+        if (electionData.nomineePositions[msg.sender] != 0) {
             revert AlreadyNominated(msg.sender);
         }
 
         electionData.nominees.push(msg.sender);
-        electionData.nomineeIndexes[msg.sender] = electionData.nominees.length;
+        electionData.nomineePositions[msg.sender] = electionData.nominees.length;
         electionData.nomineeVotes[msg.sender] = 0;
     }
 
     function withdrawNomination() external override {
         ElectionData storage electionData = _currentElectionData();
 
-        uint256 valueIndex = electionData.nomineeIndexes[msg.sender];
-
-        if (valueIndex == 0) {
-            revert NotNominated(msg.sender);
-        }
-
-        uint256 toDeleteIndex = valueIndex - 1;
-        uint256 lastIndex = electionData.nominees.length - 1;
-
-        // If the address is not the last one on the Array, we have to move it to
-        // swap it with the last element, and then pop it, so we don't leave any
-        // empty spaces.
-        if (lastIndex != toDeleteIndex) {
-            address lastvalue = electionData.nominees[lastIndex];
-
-            // Move the last value to the index where the value to delete is
-            electionData.nominees[toDeleteIndex] = lastvalue;
-            // Update the index for the moved value
-            electionData.nomineeIndexes[lastvalue] = valueIndex; // Replace lastvalue's index to valueIndex
-        }
-
-        // Delete the slot where the moved value was stored
-        electionData.nominees.pop();
-
-        // Delete the index for the deleted slot
-        delete electionData.nomineeIndexes[msg.sender];
+        ArrayUtil.removeValue(msg.sender, electionData.nominees, electionData.nomineePositions);
     }
 
     function setNextSeatCount(uint seats) external override onlyOwner {
@@ -200,7 +176,7 @@ contract CoreElectionModule is IElectionModule, ElectionStorage, OwnableMixin {
             }
 
             // Validate that the candidate is a nominee
-            if (electionData.nomineeIndexes[candidate] == 0) {
+            if (electionData.nomineePositions[candidate] == 0) {
                 revert InvalidCandidate(candidate);
             }
 

--- a/packages/core-modules/contracts/storage/ElectionStorage.sol
+++ b/packages/core-modules/contracts/storage/ElectionStorage.sol
@@ -35,9 +35,9 @@ contract ElectionStorage {
          */
         address[] nominees;
         /**
-         * @dev Position of an address on the nominees Array.
+         * @dev Position of an address on the nominees Array. Note that position 1 corresponds to index 0.
          */
-        mapping(address => uint256) nomineeIndexes;
+        mapping(address => uint256) nomineesPositionOf;
         /**
          * @dev Flag to indicate if the election was evaluated (if batched, latest batch was processed).
          */

--- a/packages/core-modules/contracts/storage/ElectionStorage.sol
+++ b/packages/core-modules/contracts/storage/ElectionStorage.sol
@@ -37,7 +37,7 @@ contract ElectionStorage {
         /**
          * @dev Position of an address on the nominees Array. Note that position 1 corresponds to index 0.
          */
-        mapping(address => uint256) nomineesPositionOf;
+        mapping(address => uint256) nomineePositions;
         /**
          * @dev Flag to indicate if the election was evaluated (if batched, latest batch was processed).
          */


### PR DESCRIPTION
Fix #639

Note that this PR also renames the indexes array with the word "position". My idea is that we use "position" for 1-based, and "index" for 0-based.

This distinction actually found a bug in the algorithm that removes elements from the nominees array.