### PR TITLE
Tweaks on custom errors

### DIFF
--- a/packages/core-contracts/contracts/token/ERC721.sol
+++ b/packages/core-contracts/contracts/token/ERC721.sol
@@ -11,8 +11,6 @@ import "./ERC721Storage.sol";
 import "../utils/AddressUtil.sol";
 import "../utils/StringUtil.sol";
 
-import "hardhat/console.sol";
-
 /*
     Reference implementations:
     * OpenZeppelin - https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC721/ERC721.sol

--- a/packages/core-contracts/contracts/token/ERC721.sol
+++ b/packages/core-contracts/contracts/token/ERC721.sol
@@ -11,6 +11,8 @@ import "./ERC721Storage.sol";
 import "../utils/AddressUtil.sol";
 import "../utils/StringUtil.sol";
 
+import "hardhat/console.sol";
+
 /*
     Reference implementations:
     * OpenZeppelin - https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC721/ERC721.sol
@@ -234,14 +236,8 @@ contract ERC721 is IERC721, IERC721Metadata, ERC721Storage {
         if (AddressUtil.isContract(to)) {
             try IERC721Receiver(to).onERC721Received(msg.sender, from, tokenId, data) returns (bytes4 retval) {
                 return retval == IERC721Receiver.onERC721Received.selector;
-            } catch (bytes memory reason) {
-                if (reason.length == 0) {
-                    revert InvalidTransferRecipient(to);
-                } else {
-                    assembly {
-                        revert(add(32, reason), mload(reason))
-                    }
-                }
+            } catch {
+                return false;
             }
         } else {
             return true;

--- a/packages/core-js/utils/assertions/assert-revert.js
+++ b/packages/core-js/utils/assertions/assert-revert.js
@@ -14,10 +14,12 @@ module.exports = async function assertRevert(tx, expectedMessage) {
 
     if (!receivedMessage.includes(expectedMessage)) {
       // ----------------------------------------------------------------------------
-      // TODO: Remove this check once the issue is solved in hardhat.
+      // TODO: Remove this check once the following issue is solved in hardhat:
       // https://github.com/nomiclabs/hardhat/issues/1996
+      // Basically, the first time tests are run, the revert reason is not parsed,
+      // but the second time it is parsed just fine;
       if (receivedMessage.includes('reverted with an unrecognized custom error')) {
-        console.warn(`assert-revert was unable to parse reverse reason, and will ignore the reason: ${receivedMessage}`);
+        console.warn(`WARNING: assert-revert was unable to parse reverse reason, and will ignore the reason: ${receivedMessage}`);
         return;
       }
       // ----------------------------------------------------------------------------

--- a/packages/core-js/utils/assertions/assert-revert.js
+++ b/packages/core-js/utils/assertions/assert-revert.js
@@ -17,7 +17,7 @@ module.exports = async function assertRevert(tx, expectedMessage) {
       // TODO: Remove this check once the issue is solved in hardhat.
       // https://github.com/nomiclabs/hardhat/issues/1996
       if (receivedMessage.includes('reverted with an unrecognized custom error')) {
-        console.warn(`Unable to parse reverse reason.\n${receivedMessage}`);
+        console.warn(`assert-revert was unable to parse reverse reason, and will ignore the reason: ${receivedMessage}`);
         return;
       }
       // ----------------------------------------------------------------------------

--- a/packages/core-js/utils/assertions/assert-revert.js
+++ b/packages/core-js/utils/assertions/assert-revert.js
@@ -13,6 +13,15 @@ module.exports = async function assertRevert(tx, expectedMessage) {
     const receivedMessage = error.toString();
 
     if (!receivedMessage.includes(expectedMessage)) {
+      // ----------------------------------------------------------------------------
+      // TODO: Remove this check once the issue is solved in hardhat.
+      // https://github.com/nomiclabs/hardhat/issues/1996
+      if (receivedMessage.includes('reverted with an unrecognized custom error')) {
+        console.warn(`Unable to parse reverse reason.\n${receivedMessage}`);
+        return;
+      }
+      // ----------------------------------------------------------------------------
+
       throw new Error(
         `Transaction was expected to revert with "${expectedMessage}", but reverted with "${receivedMessage}"`
       );

--- a/packages/core-js/utils/assertions/assert-revert.js
+++ b/packages/core-js/utils/assertions/assert-revert.js
@@ -19,7 +19,9 @@ module.exports = async function assertRevert(tx, expectedMessage) {
       // Basically, the first time tests are run, the revert reason is not parsed,
       // but the second time it is parsed just fine;
       if (receivedMessage.includes('reverted with an unrecognized custom error')) {
-        console.warn(`WARNING: assert-revert was unable to parse reverse reason, and will ignore the reason: ${receivedMessage}`);
+        console.warn(
+          `WARNING: assert-revert was unable to parse reverse reason, and will ignore the reason: ${receivedMessage}`
+        );
         return;
       }
       // ----------------------------------------------------------------------------

--- a/packages/core-js/utils/assertions/assert-revert.js
+++ b/packages/core-js/utils/assertions/assert-revert.js
@@ -12,12 +12,7 @@ module.exports = async function assertRevert(tx, expectedMessage) {
   } else if (expectedMessage) {
     const receivedMessage = error.toString();
 
-    // TODO The condition covering 'unrecognized' is added temporarily to hack another issue.
-    // Remove it when https://github.com/Synthetixio/synthetix-v3/issues/273 is resolved
-    if (
-      !receivedMessage.includes(expectedMessage) &&
-      !receivedMessage.includes('reverted with an unrecognized custom error')
-    ) {
+    if (!receivedMessage.includes(expectedMessage)) {
       throw new Error(
         `Transaction was expected to revert with "${expectedMessage}", but reverted with "${receivedMessage}"`
       );

--- a/packages/core-js/utils/assertions/assert-revert.js
+++ b/packages/core-js/utils/assertions/assert-revert.js
@@ -20,7 +20,7 @@ module.exports = async function assertRevert(tx, expectedMessage) {
       // but the second time it is parsed just fine;
       if (receivedMessage.includes('reverted with an unrecognized custom error')) {
         console.warn(
-          `WARNING: assert-revert was unable to parse reverse reason, and will ignore the reason: ${receivedMessage}`
+          `WARNING: assert-revert was unable to parse revert reason. The reason will be ignored in this test: ${receivedMessage}`
         );
         return;
       }


### PR DESCRIPTION
Even though this does not solve #273, it emits a warning whenever an error cannot be parsed, being more explicit and not just ignoring the problem.

It also addresses what I believe to be a bug in OZ ERC721 implementation.