### PR TITLE
Better way to run CLI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,13 +45,8 @@ jobs:
           node-version: "16.8.0"
           cache: "npm"
       - run: npm ci
-      - name: Start local node & execute tests
+      - name: Execute tests
         run: |
-          cd packages/cli/test/fixture-projects/sample-project
-          npx hardhat node > /dev/null 2>&1 &
-          sleep 10
-          npx hardhat deploy --network local --clear --no-confirm --instance test
-          cd ../../..
           npm test
 
   test-sample:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "mocha",
+    "test": "./scripts/test.sh",
     "coverage": "nyc mocha",
     "test:watch": "mocha --watch"
   },

--- a/packages/cli/scripts/test.sh
+++ b/packages/cli/scripts/test.sh
@@ -1,0 +1,13 @@
+set -x
+
+# Start local chain
+cd test/fixture-projects/sample-project
+npx hardhat node > /dev/null 2>&1 &
+sleep 10
+
+# Deploy on local chain
+npx hardhat deploy --network local --clear --quiet --no-confirm --instance test
+
+# Run tests
+cd ../../..
+npx mocha


### PR DESCRIPTION
Fix #644

This PR wraps running of CLI tests in a script. This was previously encoded in a Github Actions yaml file, which made it not evident how the tests are supposed to be ran.

Now it's encoded in npm test.