### PR TITLE
Rename variables to align with literature

### DIFF
--- a/packages/core-modules/contracts/interfaces/IElectionModule.sol
+++ b/packages/core-modules/contracts/interfaces/IElectionModule.sol
@@ -18,11 +18,17 @@ interface IElectionModule {
 
     function getMembers() external view returns (address[] memory);
 
-    function getNominees() external view returns (address[] memory);
+    function getCandidates() external view returns (address[] memory);
+
+    function elect(address[] memory candidates) external;
 
     function isElectionEvaluated() external view returns (bool);
 
     function evaluateElectionBatch() external;
+
+    function setMaxProcessingBatchSize(uint size) external;
+
+    function getMaxProcessingBatchSize() external view returns (uint);
 
     function resolveElection() external;
 
@@ -32,27 +38,23 @@ interface IElectionModule {
 
     function isVoting() external view returns (bool);
 
-    function getSeatCount() external view returns (uint);
-
-    function getPeriodPercent() external view returns (uint);
-
     function setNextSeatCount(uint seats) external;
 
     function setNextEpochDuration(uint64 duration) external;
 
     function setNextPeriodPercent(uint8 percent) external;
 
-    function getNextSeatCount() external view returns (uint);
+    function getSeatCount() external view returns (uint);
 
-    function elect(address[] memory candidates) external;
+    function getEpochDuration() external view returns (uint);
+
+    function getPeriodPercent() external view returns (uint);
+
+    function getNextSeatCount() external view returns (uint);
 
     function getNextEpochDuration() external view returns (uint);
 
     function getNextPeriodPercent() external view returns (uint);
 
     function setupFirstEpoch() external;
-
-    function setMaxProcessingBatchSize(uint size) external;
-
-    function getMaxProcessingBatchSize() external view returns (uint);
 }

--- a/packages/core-modules/contracts/modules/mocks/ElectionStorageMock.sol
+++ b/packages/core-modules/contracts/modules/mocks/ElectionStorageMock.sol
@@ -48,14 +48,14 @@ contract ElectionStorageMock is ElectionStorage {
 
     function getVoterVoteCandidatesMock(address addr) public view returns (address[] memory) {
         ElectionData storage electionData = _currentElectionData();
-        VoteData storage voteData = electionData.votes[electionData.votesIndexes[addr]];
-        return voteData.candidates;
+        Ballot storage ballot = electionData.ballots[electionData.ballotsIndex[addr]];
+        return ballot.candidates;
     }
 
     function getVoterVoteVotePowerMock(address addr) public view returns (uint) {
         ElectionData storage electionData = _currentElectionData();
-        VoteData storage voteData = electionData.votes[electionData.votesIndexes[addr]];
-        return voteData.votePower;
+        Ballot storage ballot = electionData.ballots[electionData.ballotsIndex[addr]];
+        return ballot.votePower;
     }
 
     function _currentElectionData() private view returns (ElectionData storage) {

--- a/packages/core-modules/contracts/storage/ElectionStorage.sol
+++ b/packages/core-modules/contracts/storage/ElectionStorage.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 contract ElectionStorage {
-    struct VoteData {
+    struct Ballot {
         /**
          * @dev the ordered list of candidates the user voted
          */
@@ -15,45 +15,46 @@ contract ElectionStorage {
 
     struct ElectionData {
         /**
-         * @dev History of all the votes casted by voter addrees
+         * @dev Compilation of all the ballots casted by voters. Works together with ballotsIndexes
          */
-        VoteData[] votes;
+        Ballot[] ballots;
         /**
-         * @dev Position of an address on the votes Array.
+         * @dev Position of an address (voter) on the ballots Array.
          */
-        mapping(address => uint256) votesIndexes;
+        mapping(address => uint256) ballotsIndex;
         /**
-         * @dev number of votes a nominee has for being a council member in the next epoch.
+         * @dev number of votes a candidate has for being a council member in the next epoch.
+         * @dev Note the interpretation is dependant on the voting strategy
          */
-        mapping(address => uint256) nomineeVotes;
+        mapping(address => uint256) candidateVotes;
         /**
          * @dev History of addresses that voted on any of the elections.
          */
         mapping(address => bool) addressVoted;
         /**
-         * @dev Used to keep track of the next epoch's nominees. Gets erased when an epoch starts and a new council takes effect.
+         * @dev Used to keep track of the next epoch's nominees.
          */
-        address[] nominees;
+        address[] candidates;
         /**
-         * @dev Position of an address on the nominees Array. Note that position 1 corresponds to index 0.
+         * @dev Position of an address on the candidates Array. Note that position 1 corresponds to index 0.
          */
-        mapping(address => uint256) nomineePositions;
+        mapping(address => uint256) candidatePositions;
+        /**
+         * @dev Used to keep track of the latest candidate processed in the last batch.
+         */
+        uint256 processedBatchIndex;
         /**
          * @dev Flag to indicate if the election was evaluated (if batched, latest batch was processed).
          */
         bool isElectionEvaluated;
         /**
-         * @dev Used to keep track of the next epoch's nextEpochMembers. Gets erased when an epoch starts and a new council takes effect.
+         * @dev Used to keep track of the next epoch's nextEpochMembers.
          */
         address[] nextEpochMembers;
         /**
-         * @dev Used to keep track of the next epoch's nextEpochMembers votes. Gets erased when an epoch starts and a new council takes effect.
+         * @dev Used to keep track of the next epoch's nextEpochMembers votes.
          */
         uint256[] nextEpochMemberVotes;
-        /**
-         * @dev Used to keep track of the latest nominee processed in the last batch.
-         */
-        uint256 processedBatchIdx;
     }
 
     struct ElectionStore {

--- a/packages/core-modules/test/contracts/modules/CoreElectionModule.Plurality.test.js
+++ b/packages/core-modules/test/contracts/modules/CoreElectionModule.Plurality.test.js
@@ -17,7 +17,7 @@ describe('CoreElectionModule: Evaluate and Resolve elections using Simple Plural
   const day = 24 * 60 * minute;
   const week = 7 * day;
 
-  before('identify signers, candidates and voters', async () => {
+  before('identify owner', async () => {
     [owner] = await ethers.getSigners();
   });
 

--- a/packages/core-modules/test/contracts/modules/CoreElectionModule.test.js
+++ b/packages/core-modules/test/contracts/modules/CoreElectionModule.test.js
@@ -165,6 +165,7 @@ describe('CoreElectionModule: Setup, Getters, Setters, Reverts and Voting', () =
 
       it('gets setted with the right parameters', async () => {
         assertBn.eq(await CoreElectionModule.getSeatCount(), 1);
+        assertBn.eq(await CoreElectionModule.getEpochDuration(), (2 * day) / 1000);
         assertBn.eq(await CoreElectionModule.getPeriodPercent(), 0);
         equal(await CoreElectionModule.isVoting(), true);
         equal(await CoreElectionModule.isNominating(), false);
@@ -237,10 +238,10 @@ describe('CoreElectionModule: Setup, Getters, Setters, Reverts and Voting', () =
   describe('when the address self nominates', () => {
     it('can nominate several addresses', async () => {
       await (await CoreElectionModule.connect(owner).nominate()).wait();
-      deepEqual(await CoreElectionModule.getNominees(), [owner.address]);
+      deepEqual(await CoreElectionModule.getCandidates(), [owner.address]);
 
       await (await CoreElectionModule.connect(user).nominate()).wait();
-      deepEqual(await CoreElectionModule.getNominees(), [owner.address, user.address]);
+      deepEqual(await CoreElectionModule.getCandidates(), [owner.address, user.address]);
     });
 
     it('reverts when trying to nominate several times the same address', async () => {
@@ -249,10 +250,10 @@ describe('CoreElectionModule: Setup, Getters, Setters, Reverts and Voting', () =
 
     it('can withdraw their own nominations', async () => {
       await (await CoreElectionModule.connect(owner).withdrawNomination()).wait();
-      deepEqual(await CoreElectionModule.getNominees(), [user.address]);
+      deepEqual(await CoreElectionModule.getCandidates(), [user.address]);
 
       await (await CoreElectionModule.connect(user).withdrawNomination()).wait();
-      deepEqual(await CoreElectionModule.getNominees(), []);
+      deepEqual(await CoreElectionModule.getCandidates(), []);
     });
 
     it('reverts when withdrawing a not nominated address', async () => {
@@ -298,7 +299,7 @@ describe('CoreElectionModule: Setup, Getters, Setters, Reverts and Voting', () =
           await assertRevert(CoreElectionModule.connect(user).elect([]), 'MissingCandidates');
         });
 
-        it('reverts when trying to elect more candidates than nominees', async () => {
+        it('reverts when trying to elect more candidates than candidates available', async () => {
           await assertRevert(
             CoreElectionModule.connect(user).elect([
               user.address,


### PR DESCRIPTION
Fix #666 👿  

This PR changes the name of some variables to better align with the literature. Basically a nomination is a way to be a candidate, and the vote data (what the voter present) is a ballot.

