### PR TITLE
InitializableMixin

### DIFF
--- a/packages/core-contracts/contracts/errors/InitError.sol
+++ b/packages/core-contracts/contracts/errors/InitError.sol
@@ -3,4 +3,5 @@ pragma solidity ^0.8.0;
 
 library InitError {
     error AlreadyInitialized();
+    error NotInitialized();
 }

--- a/packages/core-contracts/contracts/initializable/InitializableMixin.sol
+++ b/packages/core-contracts/contracts/initializable/InitializableMixin.sol
@@ -1,0 +1,24 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../errors/InitError.sol";
+
+abstract contract InitializableMixin {
+    modifier onlyIfInitialized() {
+        if (!_isInitialized()) {
+            revert InitError.NotInitialized();
+        }
+
+        _;
+    }
+
+    modifier onlyIfNotInitialized() {
+        if (_isInitialized()) {
+            revert InitError.AlreadyInitialized();
+        }
+
+        _;
+    }
+
+    function _isInitialized() internal view virtual returns (bool);
+}

--- a/packages/core-contracts/contracts/mocks/initializable/InitializableMock.sol
+++ b/packages/core-contracts/contracts/mocks/initializable/InitializableMock.sol
@@ -1,0 +1,40 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../../initializable/InitializableMixin.sol";
+
+contract InitializableMock is InitializableMixin {
+    bool private _initialized;
+    uint256 private _value;
+    uint256 private _nonCriticalValue;
+
+    function _isInitialized() internal view override returns (bool) {
+        return _initialized;
+    }
+
+    function initializeInitializableMock(uint256 initialValue) public onlyIfNotInitialized {
+        _value = initialValue;
+
+        _initialized = true;
+    }
+
+    function isInitializableMockInitialized() public view returns (bool) {
+        return _isInitialized();
+    }
+
+    function doubleValue() public onlyIfInitialized {
+        _value *= 2;
+    }
+
+    function getValue() public view onlyIfInitialized returns (uint256) {
+        return _value;
+    }
+
+    function getNonCriticalValue() public view returns (uint256) {
+        return _nonCriticalValue;
+    }
+
+    function setNonCriticalValue(uint256 nonCriticalValue) public {
+        _nonCriticalValue = nonCriticalValue;
+    }
+}

--- a/packages/core-contracts/test/contracts/initializable/Initializable.test.js
+++ b/packages/core-contracts/test/contracts/initializable/Initializable.test.js
@@ -1,0 +1,87 @@
+const { ethers } = hre;
+const assert = require('assert/strict');
+const assertRevert = require('@synthetixio/core-js/utils/assertions/assert-revert');
+const assertBn = require('@synthetixio/core-js/utils/assertions/assert-bignumber');
+
+describe('Initializable', () => {
+  let Initializable;
+
+  before('deploy the contract', async () => {
+    const factory = await ethers.getContractFactory('InitializableMock');
+    Initializable = await factory.deploy();
+  });
+
+  describe('before the contract is initialized', () => {
+    it('shows that is not initialized', async () => {
+      assert.equal(await Initializable.isInitializableMockInitialized(), false);
+    });
+
+    describe('when attempting to access a protected function', () => {
+      it('reverts', async () => {
+        await assertRevert(Initializable.doubleValue(), 'NotInitialized');
+      });
+    });
+
+    describe('when attempting to access a protected view', () => {
+      it('reverts', async () => {
+        await assertRevert(Initializable.getValue(), 'NotInitialized');
+      });
+    });
+
+    describe('when attempting to reach non protected functions', () => {
+      before('sets the value', async () => {
+        let tx = await Initializable.setNonCriticalValue(10);
+        await tx.wait();
+      });
+
+      it('gets the right value', async () => {
+        assertBn.eq(await Initializable.getNonCriticalValue(), 10);
+      });
+    });
+  });
+
+  describe('after the contract is initialized', () => {
+    before('initialize the contract', async () => {
+      let tx = await Initializable.initializeInitializableMock(42);
+      await tx.wait();
+    });
+
+    it('shows that is initialized', async () => {
+      assert.equal(await Initializable.isInitializableMockInitialized(), true);
+    });
+
+    describe('when attempting to initialize it again', () => {
+      it('reverts', async () => {
+        await assertRevert(Initializable.initializeInitializableMock(42), 'AlreadyInitialized');
+      });
+    });
+
+    describe('when attempting to access a protected view', () => {
+      it('gets the right value', async () => {
+        assertBn.eq(await Initializable.getValue(), 42);
+      });
+    });
+
+    describe('when attempting to access a protected function', () => {
+      before('initialize the contract', async () => {
+        let tx = await Initializable.doubleValue();
+        await tx.wait();
+      });
+
+      it('gets the right value', async () => {
+        assertBn.eq(await Initializable.getValue(), 84);
+      });
+    });
+
+    describe('when attempting to reach non protected functions', () => {
+      before('sets the value', async () => {
+        let tx = await Initializable.setNonCriticalValue(12);
+        await tx.wait();
+      });
+
+      it('gets the right value', async () => {
+        assertBn.eq(await Initializable.getNonCriticalValue(), 12);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fix #703  Create an initializableMixin in core-contracts and adds test coverage.