### PR TITLE
InitializableModules: Update CLI

### DIFF
--- a/packages/cli/subtasks/check-initializable.js
+++ b/packages/cli/subtasks/check-initializable.js
@@ -1,0 +1,31 @@
+const { subtask } = require('hardhat/config');
+const { SUBTASK_CHECK_INITIALIZATION } = require('../task-names');
+const logger = require('@synthetixio/core-js/utils/io/logger');
+const { capitalize } = require('@synthetixio/core-js/utils/misc/strings');
+
+subtask(
+  SUBTASK_CHECK_INITIALIZATION,
+  'Check if current contract is initializable and if it is initialized'
+).setAction(async (taskArguments, hre) => {
+  const target = hre.deployer.deployment.general.contracts[hre.cli.contractName];
+  const address = target.proxyAddress || target.deployedAddress;
+  const abi = hre.deployer.deployment.abis[hre.cli.contractName];
+  const abiFunctions = abi.filter((abiItem) => abiItem.name && abiItem.type === 'function');
+
+  const capitalizedContractName = capitalize(hre.cli.contractName.split(':')[1]);
+  const isInitializablefunctionName = `is${capitalizedContractName}Initialized`;
+  const initializafunctionName = `initialize${capitalizedContractName}()`;
+
+  const isInitializable = abiFunctions.some((f) => f.name === isInitializablefunctionName);
+
+  if (isInitializable) {
+    const contract = new hre.ethers.Contract(address, abi, hre.ethers.provider);
+    const result = await contract[isInitializablefunctionName]();
+
+    if (!result) {
+      logger.warn(
+        `Contract initializable but not initialized. Call ${initializafunctionName} with the right paramters first`
+      );
+    }
+  }
+});

--- a/packages/cli/subtasks/check-initializable.js
+++ b/packages/cli/subtasks/check-initializable.js
@@ -13,18 +13,18 @@ subtask(
   const abiFunctions = abi.filter((abiItem) => abiItem.name && abiItem.type === 'function');
 
   const capitalizedContractName = capitalize(hre.cli.contractName.split(':')[1]);
-  const isInitializablefunctionName = `is${capitalizedContractName}Initialized`;
-  const initializafunctionName = `initialize${capitalizedContractName}()`;
+  const isInitializableFunctionName = `is${capitalizedContractName}Initialized`;
+  const initializeFunctionName = `initialize${capitalizedContractName}`;
 
-  const isInitializable = abiFunctions.some((f) => f.name === isInitializablefunctionName);
+  const isInitializable = abiFunctions.some((f) => f.name === isInitializableFunctionName);
 
   if (isInitializable) {
     const contract = new hre.ethers.Contract(address, abi, hre.ethers.provider);
-    const result = await contract[isInitializablefunctionName]();
+    const result = await contract[isInitializableFunctionName]();
 
     if (!result) {
       logger.warn(
-        `Contract initializable but not initialized. Call ${initializafunctionName} with the right paramters first`
+        `Contract initializable but not initialized. Call ${initializeFunctionName}() with the right paramters first`
       );
     }
   }

--- a/packages/cli/subtasks/check-initializable.js
+++ b/packages/cli/subtasks/check-initializable.js
@@ -13,14 +13,14 @@ subtask(
   const abiFunctions = abi.filter((abiItem) => abiItem.name && abiItem.type === 'function');
 
   const capitalizedContractName = capitalize(hre.cli.contractName.split(':')[1]);
-  const isInitializableFunctionName = `is${capitalizedContractName}Initialized`;
+  const isInitializedFunctionName = `is${capitalizedContractName}Initialized`;
   const initializeFunctionName = `initialize${capitalizedContractName}`;
 
-  const isInitializable = abiFunctions.some((f) => f.name === isInitializableFunctionName);
+  const isInitializable = abiFunctions.some((f) => f.name === isInitializedFunctionName);
 
   if (isInitializable) {
     const contract = new hre.ethers.Contract(address, abi, hre.ethers.provider);
-    const result = await contract[isInitializableFunctionName]();
+    const result = await contract[isInitializedFunctionName]();
 
     if (!result) {
       logger.warn(

--- a/packages/cli/subtasks/pick-function.js
+++ b/packages/cli/subtasks/pick-function.js
@@ -1,5 +1,5 @@
 const { subtask } = require('hardhat/config');
-const { SUBTASK_PICK_FUNCTION } = require('../task-names');
+const { SUBTASK_PICK_FUNCTION, SUBTASK_CHECK_INITIALIZATION } = require('../task-names');
 const prompts = require('prompts');
 const chalk = require('chalk');
 const { getFullFunctionSignature } = require('../internal/signatures');
@@ -20,6 +20,8 @@ subtask(SUBTASK_PICK_FUNCTION, 'Pick a function from the given contract').setAct
         value: functionAbi.name,
       };
     });
+
+    await hre.run(SUBTASK_CHECK_INITIALIZATION);
 
     const { functionName } = await prompts([
       {

--- a/packages/cli/task-names.js
+++ b/packages/cli/task-names.js
@@ -5,4 +5,5 @@ module.exports = {
   SUBTASK_PICK_FUNCTION: 'cli-pick-function',
   SUBTASK_PICK_PARAMETERS: 'cli-pick-parameters',
   SUBTASK_EXECUTE_CALL: 'cli-execute-call',
+  SUBTASK_CHECK_INITIALIZATION: 'cli-check-initialization',
 };

--- a/packages/cli/test/fixture-projects/initializable/contracts/Proxy.sol
+++ b/packages/cli/test/fixture-projects/initializable/contracts/Proxy.sol
@@ -1,0 +1,9 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@synthetixio/core-contracts/contracts/proxy/UUPSProxy.sol";
+
+contract Proxy is UUPSProxy {
+    // solhint-disable-next-line no-empty-blocks
+    constructor(address firstImplementation) UUPSProxy(firstImplementation) {}
+}

--- a/packages/cli/test/fixture-projects/initializable/contracts/modules/InitializableModule.sol
+++ b/packages/cli/test/fixture-projects/initializable/contracts/modules/InitializableModule.sol
@@ -1,0 +1,19 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@synthetixio/core-contracts/contracts/initializable/InitializableMixin.sol";
+import "../storage/InitializableStorage.sol";
+
+contract InitializableModule is InitializableStorage, InitializableMixin {
+    function _isInitialized() internal view override returns (bool) {
+        return _initializableStore().initialized;
+    }
+
+    function isInitializableModuleInitialized() external view returns (bool) {
+        return _isInitialized();
+    }
+
+    function initializeInitializableModule() external onlyIfNotInitialized {
+        _initializableStore().initialized = true;
+    }
+}

--- a/packages/cli/test/fixture-projects/initializable/contracts/modules/UpgradeModule.sol
+++ b/packages/cli/test/fixture-projects/initializable/contracts/modules/UpgradeModule.sol
@@ -1,0 +1,9 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {UpgradeModule as BaseUpgradeModule} from "@synthetixio/core-modules/contracts/modules/UpgradeModule.sol";
+
+// solhint-disable-next-line no-empty-blocks
+contract UpgradeModule is BaseUpgradeModule {
+
+}

--- a/packages/cli/test/fixture-projects/initializable/contracts/storage/InitializableStorage.sol
+++ b/packages/cli/test/fixture-projects/initializable/contracts/storage/InitializableStorage.sol
@@ -1,0 +1,15 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract InitializableStorage {
+    struct InitializableStore {
+        bool initialized;
+    }
+
+    function _initializableStore() internal pure returns (InitializableStore storage store) {
+        assembly {
+            // bytes32(uint(keccak256("io.synthetix.initializable")) - 1)
+            store.slot := 0xe1550b5a17836cfadda6044cd412df004a72cf007361a046298ac83a7992948c
+        }
+    }
+}

--- a/packages/cli/test/fixture-projects/initializable/hardhat.config.js
+++ b/packages/cli/test/fixture-projects/initializable/hardhat.config.js
@@ -1,0 +1,21 @@
+require('@nomiclabs/hardhat-ethers');
+require('@synthetixio/deployer');
+require('../../..');
+
+module.exports = {
+  solidity: {
+    version: '0.8.7',
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 200,
+      },
+    },
+  },
+  networks: {
+    local: {
+      url: 'http://localhost:8545',
+    },
+  },
+  deployer: {},
+};

--- a/packages/cli/test/fixture-projects/initializable/package.json
+++ b/packages/cli/test/fixture-projects/initializable/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "initializable",
+  "version": "1.0.0",
+  "description": "",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Synthetixio/synthetix-v3.git"
+  },
+  "main": "index.js",
+  "scripts": {
+    "test": "hardhat test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@nomiclabs/hardhat-ethers": "^2.0.2",
+    "ethers": "^5.4.6",
+    "hardhat": "^2.6.8"
+  }
+}

--- a/packages/cli/test/integration/check-initializable.test.js
+++ b/packages/cli/test/integration/check-initializable.test.js
@@ -16,6 +16,8 @@ describe('check-initializable', function () {
   });
 
   it('displays the contract not initialized warning', async function () {
-    this.cli.printed('Contract initializable but not initialized. Call initializeInitializableModule() with the right paramters first');
+    this.cli.printed(
+      'Contract initializable but not initialized. Call initializeInitializableModule() with the right paramters first'
+    );
   });
 });

--- a/packages/cli/test/integration/check-initializable.test.js
+++ b/packages/cli/test/integration/check-initializable.test.js
@@ -1,0 +1,21 @@
+const assert = require('assert/strict');
+const bootstrap = require('./helpers/bootstrap');
+
+describe('check-initializable', function () {
+  bootstrap('initializable');
+
+  before('use the cli', async function () {
+    this.timeout(60000);
+
+    await this.cli.start();
+    await this.cli.interact(this.cli.keys.ENTER); // Selects UpgradeModule
+    await this.cli.interact(this.cli.keys.CTRLC); // Return to contract list
+    await this.cli.interact(this.cli.keys.CTRLC); // Exit
+
+    assert.deepEqual(this.cli.errors, []);
+  });
+
+  it('displays the contract not initialized warning', async function () {
+    this.cli.printed('Contract initializable but not initialized. Call initializeInitializableModule() with the right paramters first');
+  });
+});

--- a/packages/cli/test/integration/helpers/bootstrap.js
+++ b/packages/cli/test/integration/helpers/bootstrap.js
@@ -4,7 +4,6 @@ const CliRunner = require('./cli-runner');
 
 function bootstrap(fixture) {
   before('set fixture project and network', function () {
-    
     const folder = path.join(
       __dirname,
       '..',

--- a/packages/cli/test/integration/helpers/bootstrap.js
+++ b/packages/cli/test/integration/helpers/bootstrap.js
@@ -2,8 +2,9 @@ const path = require('path');
 const { loadEnvironment } = require('@synthetixio/deployer/test/helpers/use-environment');
 const CliRunner = require('./cli-runner');
 
-function bootstrap() {
+function bootstrap(fixture) {
   before('set fixture project and network', function () {
+    
     const folder = path.join(
       __dirname,
       '..',
@@ -11,7 +12,7 @@ function bootstrap() {
       '..',
       'test',
       'fixture-projects',
-      'sample-project'
+      fixture ? fixture : 'sample-project'
     );
 
     this.hre = loadEnvironment(folder, 'local');

--- a/packages/core-js/test/utils/misc/strings.test.js
+++ b/packages/core-js/test/utils/misc/strings.test.js
@@ -1,0 +1,17 @@
+const { equal } = require('assert/strict');
+const { capitalize } = require('../../../utils/misc/strings');
+
+describe('utils/misc/strings.js', function () {
+  it('returns the strings with the correct format', function () {
+    equal(capitalize('someText'), 'SomeText');
+    equal(capitalize('SomeText'), 'SomeText');
+    equal(capitalize('sOmeText'), 'SOmeText');
+    equal(capitalize('SOmeText'), 'SOmeText');
+
+    equal(capitalize('s'), 'S');
+    equal(capitalize('S'), 'S');
+
+    equal(capitalize('1number'), '1number');
+    equal(capitalize('_otherValue'), '_otherValue');
+  });
+});

--- a/packages/core-js/utils/misc/strings.js
+++ b/packages/core-js/utils/misc/strings.js
@@ -1,0 +1,6 @@
+function capitalize(value) {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+module.exports = {
+  capitalize,
+};

--- a/packages/deployer/internal/initializable-ast-validator.js
+++ b/packages/deployer/internal/initializable-ast-validator.js
@@ -3,6 +3,7 @@ const {
   findContractDependencies,
   findFunctions,
 } = require('@synthetixio/core-js/utils/ast/finders');
+const { capitalize } = require('@synthetixio/core-js/utils/misc/strings');
 
 class ModuleInitializableASTValidator {
   constructor(asts) {
@@ -13,7 +14,7 @@ class ModuleInitializableASTValidator {
     const errors = [];
 
     for (const contractName of this.findInitializableContractNames()) {
-      const functionName = `is${_capitalizeContractName(contractName)}Initialized`;
+      const functionName = `is${capitalize(contractName)}Initialized`;
 
       if (!findFunctions(contractName, this.contractNodes).some((v) => v.name === functionName)) {
         errors.push({
@@ -29,7 +30,7 @@ class ModuleInitializableASTValidator {
     const errors = [];
 
     for (const contractName of this.findInitializableContractNames()) {
-      const functionName = `initialize${_capitalizeContractName(contractName)}`;
+      const functionName = `initialize${capitalize(contractName)}`;
 
       if (!findFunctions(contractName, this.contractNodes).some((v) => v.name === functionName)) {
         errors.push({
@@ -62,10 +63,6 @@ class ModuleInitializableASTValidator {
 
     return initializableContractNames;
   }
-}
-
-function _capitalizeContractName(contractName) {
-  return contractName.charAt(0).toUpperCase() + contractName.slice(1);
 }
 
 module.exports = ModuleInitializableASTValidator;


### PR DESCRIPTION
Fix #706

The PR adds the ability to check if the contract selected is initializable and if it is already initialized, raising a Warn message if not. That is accomplished with the introduction of a new subtask that is executed in the pick-function SUBTASK before showing the list of functions available.
