### PR TITLE
Fix contracts dependencies find

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7395,10 +7395,6 @@
       "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
       "dev": true
     },
-    "node_modules/just-map-values": {
-      "version": "1.2.1",
-      "integrity": "sha512-XLbcbUxfuMbkMKUJhhKCEWRjSS13oWrr5yCZbeg7+8xhk7WJZkVmvzNCtkKtosdguN2bplFnvOOUsd/t8oiGyw=="
-    },
     "node_modules/keccak": {
       "version": "3.0.2",
       "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
@@ -13581,7 +13577,6 @@
         "del": "6.0.0",
         "filter-values": "0.4.1",
         "glob": "7.1.7",
-        "just-map-values": "1.2.1",
         "mkdirp": "1.0.4",
         "mustache": "4.2.0",
         "solidity-ast": "0.4.26",
@@ -15454,7 +15449,6 @@
         "filter-values": "0.4.1",
         "glob": "7.1.7",
         "hardhat": "2.6.8",
-        "just-map-values": "1.2.1",
         "mkdirp": "1.0.4",
         "mocha": "9.1.1",
         "mustache": "4.2.0",
@@ -20208,10 +20202,6 @@
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
       "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
       "dev": true
-    },
-    "just-map-values": {
-      "version": "1.2.1",
-      "integrity": "sha512-XLbcbUxfuMbkMKUJhhKCEWRjSS13oWrr5yCZbeg7+8xhk7WJZkVmvzNCtkKtosdguN2bplFnvOOUsd/t8oiGyw=="
     },
     "keccak": {
       "version": "3.0.2",

--- a/packages/core-js/test/fixtures/sample-project/contracts/AnotherModule.sol
+++ b/packages/core-js/test/fixtures/sample-project/contracts/AnotherModule.sol
@@ -1,0 +1,7 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// solhint-disable-next-line no-empty-blocks
+contract AnotherModule {
+
+}

--- a/packages/core-js/test/fixtures/sample-project/contracts/MultipleInheritance.sol
+++ b/packages/core-js/test/fixtures/sample-project/contracts/MultipleInheritance.sol
@@ -1,0 +1,15 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AnotherModule} from "./AnotherModule.sol";
+import {SampleModule as AliasedModule} from "./SampleModule.sol";
+
+// solhint-disable-next-line no-empty-blocks
+contract SomeModule is AnotherModule {
+
+}
+
+// solhint-disable-next-line no-empty-blocks
+contract MultipleInheritancce is SomeModule, AliasedModule {
+
+}

--- a/packages/core-js/test/fixtures/sample-project/contracts/SampleModule.sol
+++ b/packages/core-js/test/fixtures/sample-project/contracts/SampleModule.sol
@@ -1,0 +1,7 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// solhint-disable-next-line no-empty-blocks
+contract SampleModule {
+
+}

--- a/packages/core-js/test/utils/ast/finders.test.js
+++ b/packages/core-js/test/utils/ast/finders.test.js
@@ -3,9 +3,8 @@ const { equal, notEqual } = require('assert/strict');
 const {
   findContractDependencies,
   findFunctionSelectors,
-  findFunctions,
+  findFunctionNodes,
   findContractNodeWithName,
-  findContractNodeWithId,
   findContractNodeStructs,
   findContractNodeVariables,
   findContractStateVariables,
@@ -80,7 +79,7 @@ describe('utils/ast/finders.js find AST artifacts', function () {
 
   describe('find function', function () {
     it('finds selectors from a contract', async () => {
-      const functions = await findFunctions('AnotherModule', astNodes);
+      const functions = await findFunctionNodes('AnotherModule', astNodes);
 
       equal(functions.length, 3, 'AnotherModule should have 1 function');
       equal(
@@ -126,21 +125,6 @@ describe('utils/ast/finders.js find AST artifacts', function () {
     it('doesnt find a contract with an invalid name', async () => {
       const node = await findContractNodeWithName('NotAValidModuleName', asts['AnotherModule']);
       equal(node, undefined, 'NotAValidModuleName should not be found');
-    });
-  });
-
-  describe('find contract node by id', function () {
-    it('finds a contract with a valid id', async () => {
-      const node = await findContractNodeWithId(620, asts['AnotherModule']);
-      notEqual(node, undefined);
-      equal(node.nodeType, 'ContractDefinition');
-      equal(node.name, 'AnotherModule');
-      equal(node.id, 620);
-    });
-
-    it('doesnt find a contract with an invalid name', async () => {
-      const node = await findContractNodeWithName(549, asts['AnotherModule']);
-      equal(node, undefined);
     });
   });
 

--- a/packages/core-js/test/utils/ast/finders.test.js
+++ b/packages/core-js/test/utils/ast/finders.test.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { equal, notEqual } = require('assert/strict');
+const { equal, notEqual, deepEqual } = require('assert/strict');
 const {
   findContractDependencies,
   findFunctionSelectors,
@@ -29,21 +29,40 @@ describe('utils/ast/finders.js find AST artifacts', function () {
     sampleProjectAstNodes = Object.values(sampleProject.asts);
   });
 
-  describe('find contract dependencies', function () {
-    it('finds contract dependencies of a simple contract', async () => {
-      const AnotherModule = 'contracts/modules/AnotherModule.sol:AnotherModule';
-      const dependencies = await findContractDependencies(AnotherModule, astNodes);
-      equal(dependencies.length, 3, 'AnotherModule should have 3 dependencies');
-
-      equal(
-        dependencies.some((fqName) => fqName === AnotherModule),
-        true,
-        'AnotherModule should be present in the list of dependencies'
-      );
+  describe('find contract node', function () {
+    it('finds a contract node by fully qualified name', function () {
+      const fqName = 'contracts/TokenModule.sol:TokenModule';
+      const contractNode = findContractNode(fqName, sampleProjectAstNodes);
+      equal(contractNode.name, 'TokenModule');
     });
 
-    it('finds contract dependencies of a complex contract', async () => {
-      const dependencies = await findContractDependencies(
+    it('returns undefined on invalid contract', function () {
+      const fqName = 'contracts/TokenModule.sol:InvalidContract';
+      const contractNode = findContractNode(fqName, sampleProjectAstNodes);
+      equal(contractNode, undefined);
+    });
+
+    it('returns undefined on invalid source', function () {
+      const fqName = 'contracts/InvalidSource.sol:InvalidContract';
+      const contractNode = findContractNode(fqName, sampleProjectAstNodes);
+      equal(contractNode, undefined);
+    });
+  });
+
+  describe('find contract dependencies', function () {
+    it('finds contract dependencies of a simple contract', function () {
+      const fqName = 'contracts/MultipleInheritance.sol:MultipleInheritancce';
+
+      deepEqual(findContractDependencies(fqName, sampleProjectAstNodes), [
+        'contracts/MultipleInheritance.sol:MultipleInheritancce',
+        'contracts/MultipleInheritance.sol:SomeModule',
+        'contracts/AnotherModule.sol:AnotherModule',
+        'contracts/SampleModule.sol:SampleModule',
+      ]);
+    });
+
+    it('finds contract dependencies of a complex contract', function () {
+      const dependencies = findContractDependencies(
         'contracts/modules/SettingsModule.sol:SettingsModule',
         astNodes
       );
@@ -60,22 +79,22 @@ describe('utils/ast/finders.js find AST artifacts', function () {
   });
 
   describe('find function selectors', function () {
-    it('finds selectors from a contract', async () => {
+    it('finds selectors from a contract', function () {
       const AnotherModule = 'contracts/modules/AnotherModule.sol:AnotherModule';
-      const selectors = await findFunctionSelectors(AnotherModule, astNodes);
+      const selectors = findFunctionSelectors(AnotherModule, astNodes);
       equal(selectors.length, 1, 'AnotherModule should have 1 selector');
       equal(selectors[0].selector, '0x45aa2181', 'AnotherModule selector should be 0x45aa2181');
     });
 
-    it('doesnt find selectors from a contract that doesnt expose any', async () => {
-      const selectors = await findFunctionSelectors('contracts/Router.sol:Router', astNodes);
+    it('doesnt find selectors from a contract that doesnt expose any', function () {
+      const selectors = findFunctionSelectors('contracts/Router.sol:Router', astNodes);
       equal(selectors.length, 0, 'Router should not have any selector');
     });
   });
 
   describe('find function', function () {
-    it('finds selectors from a contract', async () => {
-      const functions = await findFunctionNodes(
+    it('finds selectors from a contract', function () {
+      const functions = findFunctionNodes(
         'contracts/modules/AnotherModule.sol:AnotherModule',
         astNodes
       );
@@ -93,46 +112,44 @@ describe('utils/ast/finders.js find AST artifacts', function () {
       );
     });
 
-    it('doesnt find selectors from a contract that doesnt expose any', async () => {
-      const selectors = await findFunctionSelectors('contracts/Router.sol:Router', astNodes);
+    it('doesnt find selectors from a contract that doesnt expose any', function () {
+      const selectors = findFunctionSelectors('contracts/Router.sol:Router', astNodes);
       equal(selectors.length, 0, 'Router should not have any selector');
     });
   });
 
   describe('find all the contract definitions on the given node', function () {
-    it('finds the expected contract definition on the node', async () => {
-      const nodes = await findContractDefinitions(asts['AnotherModule']);
+    it('finds the expected contract definition on the node', function () {
+      const nodes = findContractDefinitions(asts['AnotherModule']);
       equal(nodes.length, 1);
       equal(nodes[0].nodeType, 'ContractDefinition');
       equal(nodes[0].name, 'AnotherModule');
     });
 
-    it('doesnt find a contract with an invalid name', async () => {
-      const nodes = await findContractDefinitions(noContractAst);
+    it('doesnt find a contract with an invalid name', function () {
+      const nodes = findContractDefinitions(noContractAst);
       equal(nodes.length, 0);
     });
   });
 
   describe('find contract node structs', function () {
-    it('finds a contract struct', async () => {
-      const node = await findContractNodeStructs(asts['SettingsNamespace']);
+    it('finds a contract struct', function () {
+      const node = findContractNodeStructs(asts['SettingsNamespace']);
       notEqual(node, undefined);
       equal(node.length, 1);
       equal(node[0].nodeType, 'StructDefinition');
       equal(node[0].name, 'SettingsStorage');
     });
 
-    it('doesnt find a struct from a contract without one', async () => {
-      const node = await findContractNodeStructs(asts['AnotherModule']);
+    it('doesnt find a struct from a contract without one', function () {
+      const node = findContractNodeStructs(asts['AnotherModule']);
       equal(node.length, 0);
     });
   });
 
   describe('find contract node variables', function () {
-    it('finds a variable node with a valid name', async () => {
-      const node = await findContractNodeVariables(
-        findContractNodeStructs(asts['SettingsNamespace'])[0]
-      );
+    it('finds a variable node with a valid name', function () {
+      const node = findContractNodeVariables(findContractNodeStructs(asts['SettingsNamespace'])[0]);
 
       notEqual(node, undefined);
       equal(node.length, 1);
@@ -143,14 +160,26 @@ describe('utils/ast/finders.js find AST artifacts', function () {
 
   describe('find contract node state variables', function () {
     it('doesnt find a state variable', function () {
-      const node = findContractStateVariables('SettingsNamespace', asts['SettingsNamespace']);
-      notEqual(node, undefined);
+      const contractNode = findContractNode(
+        'contracts/SampleModule.sol:SampleModule',
+        sampleProjectAstNodes
+      );
+      const node = findContractStateVariables(contractNode);
       equal(node.length, 0);
+    });
+
+    it('should find a state variables', function () {
+      const contractNode = findContractNode(
+        'contracts/TokenModule.sol:TokenModule',
+        sampleProjectAstNodes
+      );
+      const node = findContractStateVariables(contractNode);
+      equal(node.length, 1);
     });
   });
 
   describe('find case vaules (YUL)', function () {
-    it('finds case values from Router contract', async () => {
+    it('finds case values from Router contract', function () {
       const routerSelectors = findYulCaseValues(asts['Router']);
       notEqual(routerSelectors, undefined);
       equal(routerSelectors.length > 2, true);
@@ -162,7 +191,7 @@ describe('utils/ast/finders.js find AST artifacts', function () {
       );
     });
 
-    it('doesnt find case values on not-case contract', async () => {
+    it('doesnt find case values on not-case contract', function () {
       const routerSelectors = findYulCaseValues(asts['AnotherModule']);
       notEqual(routerSelectors, undefined);
       equal(routerSelectors.length == 0, true);
@@ -170,14 +199,14 @@ describe('utils/ast/finders.js find AST artifacts', function () {
   });
 
   describe('find storage slot assignments (YUL)', function () {
-    it('finds storage slot assignemnts', async () => {
+    it('finds storage slot assignemnts', function () {
       const slots = findYulStorageSlotAssignments(asts['SettingsNamespace']);
       notEqual(slots, undefined);
       equal(slots.length == 1, true);
       equal(slots[0], '0x64b748fbda347b7e22c5029a23b4e647df311daee8f2a42947ab7ccf61af2e87');
     });
 
-    it('doesnt find storage slot assignemnts', async () => {
+    it('doesnt find storage slot assignemnts', function () {
       const slots = findYulStorageSlotAssignments(asts['AnotherModule']);
       notEqual(slots, undefined);
       equal(slots.length == 0, true);

--- a/packages/core-js/test/utils/misc/array-filters.test.js
+++ b/packages/core-js/test/utils/misc/array-filters.test.js
@@ -1,10 +1,16 @@
 const { deepEqual } = require('assert/strict');
-const { onlyRepeated } = require('../../../utils/misc/array-filters');
+const { onlyRepeated, onlyUnique } = require('../../../utils/misc/array-filters');
 
 describe('utils/misc/array-filters.js', function () {
   describe('#onlyRepeated', function () {
     it('leaves one instance of repeated values', function () {
       deepEqual([2, null], [1, 2, 2, 3, null, null, null].filter(onlyRepeated));
+    });
+  });
+
+  describe('#onlyUnique', function () {
+    it('leaves only unqiue values', function () {
+      deepEqual([1, 2, 3, null], [1, 2, 2, 3, null, null, null].filter(onlyUnique));
     });
   });
 });

--- a/packages/core-js/utils/ast/finders.js
+++ b/packages/core-js/utils/ast/finders.js
@@ -239,6 +239,17 @@ function _findCotractSourceByFullyQualifiedName(contractFullyQualifiedName, astN
   return { baseNode, contractNode };
 }
 
+function _findInheritedLocalNodeNames(contractNode, sourceUnitNode) {
+  return Array.from(findAll('InheritanceSpecifier', contractNode))
+    .map((inheritNode) => inheritNode.baseName.referencedDeclaration)
+    .map(
+      (declarationId) =>
+        Object.entries(sourceUnitNode.exportedSymbols).find(([, ids]) =>
+          ids.includes(declarationId)
+        )[0]
+    );
+}
+
 /**
  * Get the complete tree of dependencies from the given contract. This methods
  * takes an objects with the keys from all the contracts and the values are their
@@ -252,17 +263,10 @@ function findContractDependenciesByFullyQualifiedName(contractFullyQualifiedName
     contractFullyQualifiedName,
     astNodes
   );
-
-  const inheritNodeNames = Array.from(findAll('InheritanceSpecifier', contractNode))
-    .map((inheritNode) => inheritNode.baseName.referencedDeclaration)
-    .map((declarationId) =>
-      Object.entries(baseNode.exportedSymbols).find((symbolName, ids) =>
-        ids.includes(declarationId)
-      )
-    );
+  const inheritedNodeNames = _findInheritedLocalNodeNames(contractNode, baseNode);
 
   console.log(JSON.stringify(baseNode, null, 2));
-  console.log(JSON.stringify(inheritNodeNames, null, 2));
+  console.log(JSON.stringify(inheritedNodeNames, null, 2));
 }
 
 /**

--- a/packages/core-js/utils/ast/finders.js
+++ b/packages/core-js/utils/ast/finders.js
@@ -225,14 +225,15 @@ function findImportedContractFullyQualifiedName(localContractName, baseAstNode, 
 /**
  * Get all the function selectors definitions from the complete tree of contract
  * nodes starting from the given root contract definition
- * @param {string} contractName
+ * @param {string} contractFullyQualifiedName
  * @param {import("solidity-ast").SourceUnit[]} astNodes
  * @returns {import("solidity-ast").ContractDefinition[]}
  */
-function findFunctionSelectors(contractName, astNodes) {
+function findFunctionSelectors(contractFullyQualifiedName, astNodes) {
   const selectors = [];
 
-  for (const contractNode of findContractDependencies(contractName, astNodes)) {
+  for (const contractFqName of findContractDependencies(contractFullyQualifiedName, astNodes)) {
+    const contractNode = findContractNode(contractFqName, astNodes);
     const currentSelectors = _findFunctionSelectors(contractNode);
     if (currentSelectors.length > 0) {
       selectors.push(...currentSelectors);

--- a/packages/core-js/utils/ast/finders.js
+++ b/packages/core-js/utils/ast/finders.js
@@ -116,7 +116,7 @@ function _findFunctionSelectors(contractNode) {
  * @returns {string[]}
  */
 function findContractDependencies(contractFullyQualifiedName, astNodes) {
-  const { baseNode, contractNode } = _findCotractSourceByFullyQualifiedName(
+  const { baseNode, contractNode } = _findContractSourceByFullyQualifiedName(
     contractFullyQualifiedName,
     astNodes
   );
@@ -146,7 +146,7 @@ function _findSourceUnitByAbsolutePath(absolutePath, astNodes) {
   }
 }
 
-function _findCotractSourceByFullyQualifiedName(contractFullyQualifiedName, astNodes) {
+function _findContractSourceByFullyQualifiedName(contractFullyQualifiedName, astNodes) {
   const { sourceName, contractName } = parseFullyQualifiedName(contractFullyQualifiedName);
   const baseNode = _findSourceUnitByAbsolutePath(sourceName, astNodes);
   const contractNode = findContractNodeWithName(contractName, baseNode);
@@ -184,10 +184,11 @@ function _findLocalContractFullyQualifiedName(localContractName, localSourceUnit
  * @returns {string[]}
  */
 function findContractNode(contractFullyQualifiedName, astNodes) {
-  const { contractNode } = _findCotractSourceByFullyQualifiedName(
+  const { contractNode } = _findContractSourceByFullyQualifiedName(
     contractFullyQualifiedName,
     astNodes
   );
+
   return contractNode;
 }
 
@@ -251,7 +252,7 @@ function findFunctionSelectors(contractName, astNodes) {
 function findFunctionNodes(contractFullyQualifiedName, astNodes) {
   return findContractDependencies(contractFullyQualifiedName, astNodes).flatMap(
     (contractFullyQualifiedName) => {
-      const { contractNode } = _findCotractSourceByFullyQualifiedName(
+      const { contractNode } = _findContractSourceByFullyQualifiedName(
         contractFullyQualifiedName,
         astNodes
       );

--- a/packages/core-js/utils/ast/finders.js
+++ b/packages/core-js/utils/ast/finders.js
@@ -101,9 +101,8 @@ function _findFunctionSelectors(contractNode) {
 }
 
 /**
- * Get the complete tree of dependencies from the given contract. This methods
- * takes an objects with the keys from all the contracts and the values are their
- * AST nodes.
+ * Get the complete tree of dependencies from the given contract. This method recursevely
+ * finds the inherited contracts following variable references.
  * @param {string} contractFullyQualifiedName
  * @param {import("solidity-ast").SourceUnit[]} astNodes
  * @returns {string[]}
@@ -171,9 +170,7 @@ function _findLocalContractFullyQualifiedName(localContractName, localSourceUnit
 }
 
 /**
- * Get the complete tree of dependencies from the given contract. This methods
- * takes an objects with the keys from all the contracts and the values are their
- * AST nodes.
+ * Find a contracts node on the ASTs trees.
  * @param {string} contractFullyQualifiedName
  * @param {import("solidity-ast").SourceUnit[]} astNodes
  * @returns {string[]}

--- a/packages/core-js/utils/misc/array-filters.js
+++ b/packages/core-js/utils/misc/array-filters.js
@@ -7,6 +7,15 @@ function onlyRepeated(value, index, self) {
   return self.indexOf(value) !== last && index === last;
 }
 
+/**
+ * Filter all the values from an array to get only unique ones
+ *   e.g.: [1, 1, 2, 3].filter(onlyUnique) // => [1, 2, 3]
+ */
+function onlyUnique(value, index, self) {
+  return self.indexOf(value) === index;
+}
+
 module.exports = {
+  onlyUnique,
   onlyRepeated,
 };

--- a/packages/deployer/.nycrc.json
+++ b/packages/deployer/.nycrc.json
@@ -6,6 +6,7 @@
     "subtasks/**/*.js",
     "internal/**/*.js"
   ],
+  "exclude": ["utils/tests.js"],
   "check-coverage": true,
   "reporter": ["lcov", "text"],
   "branches": 1,

--- a/packages/deployer/internal/initializable-ast-validator.js
+++ b/packages/deployer/internal/initializable-ast-validator.js
@@ -1,7 +1,7 @@
 const {
   findContractDefinitions,
   contractHasDependency,
-  findFunctions,
+  findFunctionNodes,
 } = require('@synthetixio/core-js/utils/ast/finders');
 const { capitalize } = require('@synthetixio/core-js/utils/misc/strings');
 
@@ -16,7 +16,9 @@ class ModuleInitializableASTValidator {
     for (const contractName of this.findInitializableContractNames()) {
       const functionName = `is${capitalize(contractName)}Initialized`;
 
-      if (!findFunctions(contractName, this.contractNodes).some((v) => v.name === functionName)) {
+      if (
+        !findFunctionNodes(contractName, this.contractNodes).some((v) => v.name === functionName)
+      ) {
         errors.push({
           msg: `Initializable contract ${contractName} missing ${functionName} function!}`,
         });
@@ -32,7 +34,9 @@ class ModuleInitializableASTValidator {
     for (const contractName of this.findInitializableContractNames()) {
       const functionName = `initialize${capitalize(contractName)}`;
 
-      if (!findFunctions(contractName, this.contractNodes).some((v) => v.name === functionName)) {
+      if (
+        !findFunctionNodes(contractName, this.contractNodes).some((v) => v.name === functionName)
+      ) {
         errors.push({
           msg: `Initializable contract ${contractName} missing ${functionName} function!}`,
         });

--- a/packages/deployer/internal/initializable-ast-validator.js
+++ b/packages/deployer/internal/initializable-ast-validator.js
@@ -5,6 +5,9 @@ const {
 } = require('@synthetixio/core-js/utils/ast/finders');
 const { capitalize } = require('@synthetixio/core-js/utils/misc/strings');
 
+const INITIALIZABLE_MIXIN =
+  '@synthetixio/core-contracts/contracts/initializable/InitializableMixin.sol:InitializableMixin';
+
 class ModuleInitializableASTValidator {
   constructor(asts) {
     this.contractNodes = asts.map(findContractDefinitions).flat();

--- a/packages/deployer/internal/interface-ast-validator.js
+++ b/packages/deployer/internal/interface-ast-validator.js
@@ -1,62 +1,34 @@
 const {
-  findContractDefinitions,
   findContractDependencies,
-  findFunctions,
-  findContractDependenciesByFullyQualifiedName,
+  findFunctionNodes,
+  findContractNode,
 } = require('@synthetixio/core-js/utils/ast/finders');
-const { contractIsModule } = require('../internal/contract-helper');
 
 class InterfaceCoverageASTValidator {
-  constructor(asts, isModuleChecker = contractIsModule) {
-    this.asts = asts;
-    this.contractNodes = asts.flatMap(findContractDefinitions);
-    this.moduleNodes = asts
-      .filter((v) => isModuleChecker(v.absolutePath))
-      .map(findContractDefinitions)
-      .flat();
+  constructor(contractFullyQualifiedNames, astNodes) {
+    this.contractFullyQualifiedNames = contractFullyQualifiedNames;
+    this.astNodes = astNodes;
   }
 
   findFunctionsNotDefinedInInterfaces() {
     const errors = [];
 
-    for (const module of this.moduleNodes) {
-      const visibleFunctions = this._findVisibleFunctions(module);
+    for (const contractFullyQualifiedName of this.contractFullyQualifiedNames) {
+      const visibleFunctions = this._findVisibleFunctions(contractFullyQualifiedName);
 
       if (visibleFunctions.length === 0) {
         continue;
       }
 
-      const interfacedFunctions = this._findInterfaceFunctions(module);
+      const interfacedFunctions = this._findInterfaceFunctions(contractFullyQualifiedName);
 
       for (const visibleFunction of visibleFunctions) {
         if (
           !interfacedFunctions.some((f) => f.functionSelector === visibleFunction.functionSelector)
         ) {
           errors.push({
-            msg: `Visible function ${visibleFunction.name} of contract ${module.name} not found in the inherited interfaces`,
+            msg: `Visible function ${visibleFunction.name} of contract ${contractFullyQualifiedName} not found in the inherited interfaces`,
           });
-
-          // console.log(
-          //   '==>',
-          //   visibleFunctions.map((m) => m.name)
-          // );
-          // console.log(
-          //   '-->',
-          //   interfacedFunctions.map((m) => m.name)
-          // );
-          // console.log(
-          //   module.name,
-          //   findContractDependencies(module, this.asts).map((m) => m.name)
-          // );
-          console.log(
-            module.name,
-            findContractDependenciesByFullyQualifiedName(
-              'contracts/modules/SecondaryModule.sol:SecondaryModule',
-              this.asts
-            )
-          );
-
-          throw new Error('error');
         }
       }
     }
@@ -64,23 +36,27 @@ class InterfaceCoverageASTValidator {
     return errors;
   }
 
-  _findVisibleFunctions(module) {
-    const visibleFunctions = findFunctions(module.name, this.contractNodes)
+  _findVisibleFunctions(contractFullyQualifiedName) {
+    const visibleFunctions = findFunctionNodes(contractFullyQualifiedName, this.astNodes)
       .filter((f) => f.visibility === 'public' || f.visibility === 'external')
       .filter((f) => !f.name.startsWith('c_0x')); // Filter out coverage added functions
 
     return visibleFunctions;
   }
 
-  _findInterfaceFunctions(module) {
+  _findInterfaceFunctions(contractFullyQualifiedName) {
     const interfacedFunctions = [];
 
-    for (const dependency of findContractDependencies(module, this.contractNodes)) {
-      if (dependency.contractKind != 'interface') {
+    const dependencies = findContractDependencies(contractFullyQualifiedName, this.astNodes);
+
+    for (const dependencyFullyQualifiedName of dependencies) {
+      const contractNode = findContractNode(dependencyFullyQualifiedName, this.astNodes);
+
+      if (contractNode.contractKind != 'interface') {
         continue;
       }
 
-      interfacedFunctions.push(...findFunctions(dependency, this.contractNodes));
+      interfacedFunctions.push(...findFunctionNodes(dependencyFullyQualifiedName, this.astNodes));
     }
 
     return interfacedFunctions;

--- a/packages/deployer/internal/satellites-validator.js
+++ b/packages/deployer/internal/satellites-validator.js
@@ -2,7 +2,7 @@ const {
   contractHasDependency,
   findContractDefinitions,
   findContractNodeWithName,
-  findFunctions,
+  findFunctionNodes,
 } = require('@synthetixio/core-js/utils/ast/finders');
 const { capitalize } = require('@synthetixio/core-js/utils/misc/strings');
 
@@ -23,7 +23,7 @@ module.exports = class SatellitesValidator {
 
     for (const satelliteFactoryNode of this.satelliteFactoryNodes) {
       const functionName = `get${capitalize(satelliteFactoryNode.name)}Satellites`;
-      const getterNode = findFunctions(satelliteFactoryNode, this.astNodes).find(
+      const getterNode = findFunctionNodes(satelliteFactoryNode, this.astNodes).find(
         (node) => node.name === functionName
       );
 

--- a/packages/deployer/internal/satellites-validator.js
+++ b/packages/deployer/internal/satellites-validator.js
@@ -4,6 +4,7 @@ const {
   findFunctionNodes,
 } = require('@synthetixio/core-js/utils/ast/finders');
 const { capitalize } = require('@synthetixio/core-js/utils/misc/strings');
+const { ContractValidationError } = require('./errors');
 
 const SATELLITE_FACTORY =
   '@synthetixio/core-contracts/contracts/satellite/SatelliteFactory.sol:SatelliteFactory';
@@ -44,5 +45,9 @@ class SatellitesValidator {
     );
   }
 }
+
+SatellitesValidator.SatellitesValidationError = class SatellitesValidationError extends (
+  ContractValidationError
+) {};
 
 module.exports = SatellitesValidator;

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -12,15 +12,14 @@
   "author": "",
   "license": "MIT",
   "peerDependencies": {
-    "hardhat": "^2.0.0",
-    "@nomiclabs/hardhat-ethers": "^2.0.2"
+    "@nomiclabs/hardhat-ethers": "^2.0.2",
+    "hardhat": "^2.0.0"
   },
   "dependencies": {
     "chalk": "4.1.2",
     "del": "6.0.0",
     "filter-values": "0.4.1",
     "glob": "7.1.7",
-    "just-map-values": "1.2.1",
     "mkdirp": "1.0.4",
     "mustache": "4.2.0",
     "solidity-ast": "0.4.26",

--- a/packages/deployer/subtasks/validate-initializables.js
+++ b/packages/deployer/subtasks/validate-initializables.js
@@ -7,8 +7,11 @@ const { SUBTASK_VALIDATE_INITIALIZABLES } = require('../task-names');
 subtask(SUBTASK_VALIDATE_INITIALIZABLES).setAction(async (_, hre) => {
   logger.subtitle('Validating initializable contracts');
 
+  const moduleFullyQualifiedNames = Object.values(hre.deployer.deployment.general.contracts)
+    .filter(({ isModule }) => isModule)
+    .map((c) => c.contractFullyQualifiedName);
   const astNodes = Object.values(hre.deployer.deployment.sources).map((val) => val.ast);
-  const validator = new ModuleInitializableASTValidator(astNodes);
+  const validator = new ModuleInitializableASTValidator(moduleFullyQualifiedNames, astNodes);
 
   const errorsFound = [];
 

--- a/packages/deployer/subtasks/validate-interfaces.js
+++ b/packages/deployer/subtasks/validate-interfaces.js
@@ -7,10 +7,11 @@ const { SUBTASK_VALIDATE_INTERFACES } = require('../task-names');
 subtask(SUBTASK_VALIDATE_INTERFACES).setAction(async (_, hre) => {
   logger.subtitle('Validating all visible functions are defined in interfaces');
 
-  const { deployment } = hre.deployer;
-
-  const asts = Object.values(deployment.sources).map((val) => val.ast);
-  const validator = new InterfaceCoverageASTValidator(asts);
+  const moduleFullyQualifiedNames = Object.values(hre.deployer.deployment.general.contracts)
+    .filter(({ isModule }) => isModule)
+    .map((c) => c.contractFullyQualifiedName);
+  const astNodes = Object.values(hre.deployer.deployment.sources).map((val) => val.ast);
+  const validator = new InterfaceCoverageASTValidator(moduleFullyQualifiedNames, astNodes);
 
   const errorsFound = validator.findFunctionsNotDefinedInInterfaces();
 

--- a/packages/deployer/subtasks/validate-router.js
+++ b/packages/deployer/subtasks/validate-router.js
@@ -1,4 +1,3 @@
-const mapValues = require('just-map-values');
 const { subtask } = require('hardhat/config');
 const { getFullyQualifiedName } = require('hardhat/utils/contract-names');
 const logger = require('@synthetixio/core-js/utils/io/logger');
@@ -41,12 +40,12 @@ async function _runSourceValidations() {
   });
 
   logger.debug('Validating Router source code');
+
   errorsFound.push(...(await validator.findMissingModuleSelectors()));
   errorsFound.push(...(await validator.findRepeatedModuleSelectors()));
-  if (errorsFound.length > 0) {
-    errorsFound.forEach((error) => {
-      logger.error(error.msg);
-    });
+
+  for (const error of errorsFound) {
+    logger.error(error.msg);
   }
 
   return errorsFound;
@@ -55,17 +54,17 @@ async function _runSourceValidations() {
 async function _runASTValidations(routerFullyQualifiedName) {
   const errorsFound = [];
 
-  const asts = mapValues(hre.deployer.deployment.sources, (val) => val.ast);
-  const validator = new RouterASTValidator(routerFullyQualifiedName, asts);
+  const astNodes = Object.values(hre.deployer.deployment.sources).map((val) => val.ast);
+  const validator = new RouterASTValidator(routerFullyQualifiedName, astNodes);
 
   logger.debug('Validating Router compiled code');
+
   errorsFound.push(...(await validator.findMissingModuleSelectors()));
   errorsFound.push(...(await validator.findUnreachableModuleSelectors()));
   errorsFound.push(...(await validator.findDuplicateModuleSelectors()));
-  if (errorsFound.length > 0) {
-    errorsFound.forEach((error) => {
-      logger.error(error.msg);
-    });
+
+  for (const error of errorsFound) {
+    logger.error(error.msg);
   }
 
   return errorsFound;

--- a/packages/deployer/subtasks/validate-satellites.js
+++ b/packages/deployer/subtasks/validate-satellites.js
@@ -1,7 +1,6 @@
 const { subtask } = require('hardhat/config');
 const logger = require('@synthetixio/core-js/utils/io/logger');
 const SatellitesValidator = require('../internal/satellites-validator');
-const { ContractValidationError } = require('../internal/errors');
 const { SUBTASK_VALIDATE_SATELLITES } = require('../task-names');
 
 subtask(SUBTASK_VALIDATE_SATELLITES).setAction(async (_, hre) => {
@@ -23,7 +22,7 @@ subtask(SUBTASK_VALIDATE_SATELLITES).setAction(async (_, hre) => {
       logger.debug(JSON.stringify(error, null, 2));
     }
 
-    throw new ContractValidationError(
+    throw new SatellitesValidator.SatellitesValidationError(
       `Invalid satellite factory implementation on: ${errorsFound
         .map((error) => error.contractName)
         .join(', ')}`

--- a/packages/deployer/subtasks/validate-satellites.js
+++ b/packages/deployer/subtasks/validate-satellites.js
@@ -7,8 +7,11 @@ const { SUBTASK_VALIDATE_SATELLITES } = require('../task-names');
 subtask(SUBTASK_VALIDATE_SATELLITES).setAction(async (_, hre) => {
   logger.subtitle('Validating satellite factory contracts');
 
+  const moduleFullyQualifiedNames = Object.values(hre.deployer.deployment.general.contracts)
+    .filter(({ isModule }) => isModule)
+    .map((c) => c.contractFullyQualifiedName);
   const astNodes = Object.values(hre.deployer.deployment.sources).map((val) => val.ast);
-  const validator = new SatellitesValidator(astNodes);
+  const validator = new SatellitesValidator(moduleFullyQualifiedNames, astNodes);
 
   const errorsFound = [];
 

--- a/packages/deployer/test/fixture-projects/inconsistent-satellites/contracts/interfaces/ITokenModule.sol
+++ b/packages/deployer/test/fixture-projects/inconsistent-satellites/contracts/interfaces/ITokenModule.sol
@@ -1,0 +1,8 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@synthetixio/core-contracts/contracts/interfaces/ISatelliteFactory.sol";
+
+interface ITokenModule {
+    function getSatellitesInvalid() external pure returns (ISatelliteFactory.Satellite[] memory);
+}

--- a/packages/deployer/test/fixture-projects/inconsistent-satellites/contracts/modules/TokenModule.sol
+++ b/packages/deployer/test/fixture-projects/inconsistent-satellites/contracts/modules/TokenModule.sol
@@ -2,15 +2,15 @@
 pragma solidity ^0.8.0;
 
 import "@synthetixio/core-contracts/contracts/satellite/SatelliteFactory.sol";
+import "../interfaces/ITokenModule.sol";
 
-contract TokenModule is SatelliteFactory {
-    Satellite[] private _satellites;
-
-    function _getSatellites() internal view override returns (Satellite[] memory) {
-        return _satellites;
+contract TokenModule is SatelliteFactory, ITokenModule {
+    function _getSatellites() internal pure override returns (Satellite[] memory) {
+        Satellite[] memory satellites = new Satellite[](0);
+        return satellites;
     }
 
-    function getSatellitesInvalid() public view returns (Satellite[] memory) {
+    function getSatellitesInvalid() external pure override returns (Satellite[] memory) {
         return _getSatellites();
     }
 }

--- a/packages/deployer/test/integration/inconsistent-satellites.test.js
+++ b/packages/deployer/test/integration/inconsistent-satellites.test.js
@@ -1,6 +1,6 @@
 const { loadEnvironment, deployOnEnvironment } = require('../helpers/use-environment');
 const { rejects } = require('assert/strict');
-const { ContractValidationError } = require('../../internal/errors');
+const { SatellitesValidationError } = require('../../internal/satellites-validator');
 
 describe('inconsistent-satellites', function () {
   let hre;
@@ -18,7 +18,7 @@ describe('inconsistent-satellites', function () {
           alias: 'first',
           clear: true,
         });
-      }, ContractValidationError);
+      }, SatellitesValidationError);
     });
   });
 });

--- a/packages/deployer/test/unit/internal/initializable-ast-validator.test.js
+++ b/packages/deployer/test/unit/internal/initializable-ast-validator.test.js
@@ -1,16 +1,29 @@
 const { equal } = require('assert/strict');
-const ModuleInitializableASTValidator = require('../../../internal/initializable-ast-validator');
+const { findContractDefinitions } = require('@synthetixio/core-js/utils/ast/finders');
 const asts = require('@synthetixio/core-js/test/fixtures/initializable-ast.json');
 const { clone } = require('@synthetixio/core-js/utils/misc/clone');
+const ModuleInitializableASTValidator = require('../../../internal/initializable-ast-validator');
 
 describe('internal/initializable-ast-validator.js', function () {
+  const fqNames = Object.values(asts).flatMap((sourceNode) =>
+    findContractDefinitions(sourceNode).map(
+      (contractNode) => `${sourceNode.absolutePath}:${contractNode.name}`
+    )
+  );
+
+  const initMixin = 'contracts/initializable/InitializableMixin.sol:InitializableMixin';
+
   describe('validations without errors (happy path)', () => {
     let sampleAsts, validator;
     let errorsFound = [];
 
     before('set asts and validator', () => {
       sampleAsts = clone(asts);
-      validator = new ModuleInitializableASTValidator(Object.values(sampleAsts));
+      validator = new ModuleInitializableASTValidator(
+        fqNames,
+        Object.values(sampleAsts),
+        initMixin
+      );
     });
 
     before('use the validator to find problems', async () => {
@@ -34,7 +47,11 @@ describe('internal/initializable-ast-validator.js', function () {
       sampleAsts['contracts/mocks/initializable/InitializableMock.sol'].nodes[3].nodes[5].name =
         'not_initializeInitializableMock';
 
-      validator = new ModuleInitializableASTValidator(Object.values(sampleAsts));
+      validator = new ModuleInitializableASTValidator(
+        fqNames,
+        Object.values(sampleAsts),
+        initMixin
+      );
     });
 
     before('use the validator to find problems', async () => {
@@ -57,7 +74,11 @@ describe('internal/initializable-ast-validator.js', function () {
       sampleAsts['contracts/mocks/initializable/InitializableMock.sol'].nodes[3].nodes[6].name =
         'not_isInitializableMockInitialized';
 
-      validator = new ModuleInitializableASTValidator(Object.values(sampleAsts));
+      validator = new ModuleInitializableASTValidator(
+        fqNames,
+        Object.values(sampleAsts),
+        initMixin
+      );
     });
 
     before('use the validator to find problems', async () => {

--- a/packages/deployer/test/unit/internal/storage-ast-validator.test.js
+++ b/packages/deployer/test/unit/internal/storage-ast-validator.test.js
@@ -1,9 +1,16 @@
 const { equal } = require('assert/strict');
+const { findContractDefinitions } = require('@synthetixio/core-js/utils/ast/finders');
 const ModuleStorageASTValidator = require('../../../internal/storage-ast-validator');
 const asts = require('@synthetixio/core-js/test/fixtures/asts.json');
 const { clone } = require('@synthetixio/core-js/utils/misc/clone');
 
 describe('internal/storage-ast-validator.js', function () {
+  const fqNames = Object.values(asts).flatMap((sourceNode) =>
+    findContractDefinitions(sourceNode).map(
+      (contractNode) => `${sourceNode.absolutePath}:${contractNode.name}`
+    )
+  );
+
   describe('validations without errors (happy path)', () => {
     let currentAsts, previousAsts, validator;
     let errorsFound = [];
@@ -11,7 +18,11 @@ describe('internal/storage-ast-validator.js', function () {
     before('set asts and validator', () => {
       currentAsts = clone(asts);
       previousAsts = clone(asts);
-      validator = new ModuleStorageASTValidator(currentAsts, previousAsts);
+      validator = new ModuleStorageASTValidator(
+        fqNames,
+        Object.values(currentAsts),
+        Object.values(previousAsts)
+      );
     });
 
     before('use the validator to find problems', async () => {
@@ -36,7 +47,11 @@ describe('internal/storage-ast-validator.js', function () {
         'ProxyNamespace'
       ].nodes[1].nodes[1].body.statements[0].AST.statements[0].value.value =
         '0x9dbde58b6f7305fccdc5abd7ea1096e84de3f9ee47d83d8c3efc3e5557ac9c00';
-      validator = new ModuleStorageASTValidator(currentAsts, previousAsts);
+      validator = new ModuleStorageASTValidator(
+        fqNames,
+        Object.values(currentAsts),
+        Object.values(previousAsts)
+      );
     });
 
     before('use the validator to find problems', async () => {
@@ -58,7 +73,12 @@ describe('internal/storage-ast-validator.js', function () {
         'ProxyNamespace'
       ].nodes[1].nodes[1].body.statements[0].AST.statements[0].value.value =
         '0x1f33674ed9c09f309c0798b8fcbe9c48911f48b2defee8aecb930c5ef6f80e37';
-      validator = new ModuleStorageASTValidator(currentAsts, previousAsts);
+      previousAsts = clone(asts);
+      validator = new ModuleStorageASTValidator(
+        fqNames,
+        Object.values(currentAsts),
+        Object.values(previousAsts)
+      );
     });
 
     before('use the validator to find problems', async () => {


### PR DESCRIPTION
Closes #772

The main objective of this PR is to stop relying on using `"id"`'s for querying the AST tree which started to be unreliable on edge cases and change the `finders.js` interfaces to use fully qualified names.