### PR TITLE
Election module/seats

### DIFF
--- a/packages/core-modules/contracts/modules/ElectionModule.sol
+++ b/packages/core-modules/contracts/modules/ElectionModule.sol
@@ -43,9 +43,6 @@ contract ElectionModule is
         store.currentEpochIndex = 1;
         _configureFirstEpochSchedule(nominationPeriodStartDate, votingPeriodStartDate, epochEndDate);
 
-        EpochData storage firstEpoch = store.epochs[1];
-        firstEpoch.seatCount = 1;
-
         _createCouncilToken(councilTokenName, councilTokenSymbol);
         _addCouncilMember(msg.sender);
 
@@ -127,7 +124,7 @@ contract ElectionModule is
         emit DefaultBallotEvaluationBatchSizeChanged(newDefaultBallotEvaluationBatchSize);
     }
 
-    function setNextEpochSeatCount(uint8 newSeatCount) external override onlyOwner {
+    function setNextEpochSeatCount(uint8 newSeatCount) external override onlyOwner onlyInPeriod(ElectionPeriod.Idle) {
         if (newSeatCount == 0) revert InvalidElectionSettings();
 
         _electionStore().settings.nextEpochSeatCount = newSeatCount;

--- a/packages/core-modules/contracts/storage/ElectionStorage.sol
+++ b/packages/core-modules/contracts/storage/ElectionStorage.sol
@@ -25,7 +25,6 @@ contract ElectionStorage {
     }
 
     struct EpochData {
-        uint8 seatCount;
         uint64 startDate;
         uint64 endDate;
         uint64 nominationPeriodStartDate;


### PR DESCRIPTION
Fix #783

If `nextEpochSeatCount` is modified during the evaluation of an election, the counting algo could fail. We could limit changing this setting to _not_ be in the evaluation period only, but I figured its also better for users to have a definite seat count during nominations and vote.