### PR TITLE
Election module/storage refactor

### DIFF
--- a/packages/core-modules/contracts/modules/ElectionModule.sol
+++ b/packages/core-modules/contracts/modules/ElectionModule.sol
@@ -32,7 +32,7 @@ contract ElectionModule is
     ) external override onlyOwner onlyIfNotInitialized {
         ElectionStore storage store = _electionStore();
 
-        ElectionSettings storage settings = store.settings;
+        ElectionSettings storage settings = _getElectionSettings();
         settings.minNominationPeriodDuration = 2 days;
         settings.minVotingPeriodDuration = 2 days;
         settings.minEpochDuration = 7 days;
@@ -111,7 +111,7 @@ contract ElectionModule is
     function setMaxDateAdjustmentTolerance(uint64 newMaxDateAdjustmentTolerance) external override onlyOwner {
         if (newMaxDateAdjustmentTolerance == 0) revert InvalidElectionSettings();
 
-        _electionStore().settings.maxDateAdjustmentTolerance = newMaxDateAdjustmentTolerance;
+        _getElectionSettings().maxDateAdjustmentTolerance = newMaxDateAdjustmentTolerance;
 
         emit MaxDateAdjustmentToleranceChanged(newMaxDateAdjustmentTolerance);
     }
@@ -119,7 +119,7 @@ contract ElectionModule is
     function setDefaultBallotEvaluationBatchSize(uint newDefaultBallotEvaluationBatchSize) external override onlyOwner {
         if (newDefaultBallotEvaluationBatchSize == 0) revert InvalidElectionSettings();
 
-        _electionStore().settings.defaultBallotEvaluationBatchSize = newDefaultBallotEvaluationBatchSize;
+        _getElectionSettings().defaultBallotEvaluationBatchSize = newDefaultBallotEvaluationBatchSize;
 
         emit DefaultBallotEvaluationBatchSizeChanged(newDefaultBallotEvaluationBatchSize);
     }
@@ -127,7 +127,7 @@ contract ElectionModule is
     function setNextEpochSeatCount(uint8 newSeatCount) external override onlyOwner onlyInPeriod(ElectionPeriod.Idle) {
         if (newSeatCount == 0) revert InvalidElectionSettings();
 
-        _electionStore().settings.nextEpochSeatCount = newSeatCount;
+        _getElectionSettings().nextEpochSeatCount = newSeatCount;
 
         emit NextEpochSeatCountChanged(newSeatCount);
     }
@@ -237,21 +237,21 @@ contract ElectionModule is
             uint64 minEpochDuration
         )
     {
-        ElectionSettings storage settings = _electionStore().settings;
+        ElectionSettings storage settings = _getElectionSettings();
 
         return (settings.minNominationPeriodDuration, settings.minVotingPeriodDuration, settings.minEpochDuration);
     }
 
     function getMaxDateAdjustmenTolerance() external view override returns (uint64) {
-        return _electionStore().settings.maxDateAdjustmentTolerance;
+        return _getElectionSettings().maxDateAdjustmentTolerance;
     }
 
     function getDefaultBallotEvaluationBatchSize() external view override returns (uint) {
-        return _electionStore().settings.defaultBallotEvaluationBatchSize;
+        return _getElectionSettings().defaultBallotEvaluationBatchSize;
     }
 
     function getNextEpochSeatCount() external view override returns (uint8) {
-        return _electionStore().settings.nextEpochSeatCount;
+        return _getElectionSettings().nextEpochSeatCount;
     }
 
     // Epoch and periods

--- a/packages/core-modules/contracts/storage/ElectionStorage.sol
+++ b/packages/core-modules/contracts/storage/ElectionStorage.sol
@@ -12,7 +12,7 @@ contract ElectionStorage {
         mapping(address => uint) councilTokenIds;
         mapping(uint => EpochData) epochs;
         mapping(uint => ElectionData) elections;
-        ElectionSettings settings; // TODO: This kind of nesting could be problematic.
+        mapping(address => ElectionSettings) settings;
     }
 
     struct ElectionSettings {

--- a/packages/core-modules/contracts/submodules/election/ElectionBase.sol
+++ b/packages/core-modules/contracts/submodules/election/ElectionBase.sol
@@ -60,6 +60,13 @@ contract ElectionBase is ElectionStorage, InitializableMixin {
         return _electionStore().initialized;
     }
 
+    // Settings helpers
+    // ~~~~~~~~~~~~~~~~~~
+
+    function _getElectionSettings() internal view returns (ElectionSettings storage) {
+        return _electionStore().settings[address(this)];
+    }
+
     // Epoch helpers
     // ~~~~~~~~~~~~~~~~~~
 

--- a/packages/core-modules/contracts/submodules/election/ElectionSchedule.sol
+++ b/packages/core-modules/contracts/submodules/election/ElectionSchedule.sol
@@ -107,7 +107,7 @@ contract ElectionSchedule is ElectionBase {
         uint64 votingPeriodDuration = epochEndDate - votingPeriodStartDate;
         uint64 nominationPeriodDuration = votingPeriodStartDate - nominationPeriodStartDate;
 
-        ElectionSettings storage settings = _electionStore().settings;
+        ElectionSettings storage settings = _getElectionSettings();
 
         // Ensure all durations are above minimums
         if (
@@ -126,7 +126,7 @@ contract ElectionSchedule is ElectionBase {
         uint64 newEpochEndDate,
         bool ensureChangesAreSmall
     ) internal {
-        uint64 maxDateAdjustmentTolerance = _electionStore().settings.maxDateAdjustmentTolerance;
+        uint64 maxDateAdjustmentTolerance = _getElectionSettings().maxDateAdjustmentTolerance;
         if (ensureChangesAreSmall) {
             if (
                 _uint64AbsDifference(newEpochEndDate, epoch.endDate) > maxDateAdjustmentTolerance ||
@@ -160,7 +160,7 @@ contract ElectionSchedule is ElectionBase {
         uint64 newMinVotingPeriodDuration,
         uint64 newMinEpochDuration
     ) internal {
-        ElectionSettings storage settings = _electionStore().settings;
+        ElectionSettings storage settings = _getElectionSettings();
 
         if (newMinNominationPeriodDuration == 0 || newMinVotingPeriodDuration == 0 || newMinEpochDuration == 0) {
             revert InvalidElectionSettings();

--- a/packages/core-modules/contracts/submodules/election/ElectionTally.sol
+++ b/packages/core-modules/contracts/submodules/election/ElectionTally.sol
@@ -8,7 +8,7 @@ contract ElectionTally is ElectionBase {
 
     function _evaluateNextBallotBatch(uint numBallots) internal {
         if (numBallots == 0) {
-            numBallots = _electionStore().settings.defaultBallotEvaluationBatchSize;
+            numBallots = _getElectionSettings().defaultBallotEvaluationBatchSize;
         }
 
         ElectionData storage election = _getCurrentElection();
@@ -29,7 +29,7 @@ contract ElectionTally is ElectionBase {
         uint fromIndex,
         uint toIndex
     ) internal {
-        ElectionSettings storage settings = _electionStore().settings;
+        ElectionSettings storage settings = _getElectionSettings();
         uint numSeats = settings.nextEpochSeatCount;
 
         for (uint ballotIndex = fromIndex; ballotIndex < toIndex; ballotIndex++) {


### PR DESCRIPTION
Fix #758

This is an idea to solve the issue. Save the settings struct in a mapping:
```
    struct ElectionStore {
        uint a;
        mapping(address => ElectionSettings) settings;
        uint b;
    }
```

And always call it via `store.settings[address(this)]`. In fact, always use a helper `_getElectionSettings()`that wraps this.