### PR TITLE
Warn about Nested structs in namespaces

### DIFF
--- a/packages/deployer/internal/storage-ast-validator.js
+++ b/packages/deployer/internal/storage-ast-validator.js
@@ -126,6 +126,23 @@ class ModuleStorageASTValidator {
     return errors;
   }
 
+  async findNestedStructDeclarations() {
+    const errors = [];
+
+    const structsMap = await buildContractsStructMap(this.contractNodes);
+
+    for (const structMap of structsMap) {
+      const structMembers = structMap.struct.members.filter((v) => v.type.startsWith('struct'));
+      if (structMembers.length > 0) {
+        errors.push({
+          msg: `Nested structs at ${structMap.contract.name}.${structMap.struct.name}`,
+        });
+      }
+    }
+
+    return errors;
+  }
+
   async findInvalidNamespaceMutations() {
     const errors = [];
 

--- a/packages/deployer/subtasks/validate-storage.js
+++ b/packages/deployer/subtasks/validate-storage.js
@@ -29,6 +29,7 @@ subtask(SUBTASK_VALIDATE_STORAGE).setAction(async (_, hre) => {
 
   const warningsFound = [];
   warningsFound.push(...validator.findNamespaceSlotChanges());
+  warningsFound.push(...(await validator.findNestedStructDeclarations()));
 
   for (const warning of warningsFound) {
     await prompter.ask(`Warning: ${warning.msg}. Do you wish to continue anyway?`);


### PR DESCRIPTION
Fix #716 

This PR adds a validation for nested structs. The core of the validation is in `storage-ast-validator.js` where I add a new validator function named `findNestedStructDeclarations()`. It will check the type of the members of the storage struct to see if there is another struct inside. 
