### PR TITLE
Add Merkle Tree validation

### DIFF
--- a/packages/core-contracts/contracts/mocks/utils/MerkleProofMock.sol
+++ b/packages/core-contracts/contracts/mocks/utils/MerkleProofMock.sol
@@ -1,0 +1,14 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../../utils/MerkleProof.sol";
+
+contract MerkleProofMock {
+    function verify(
+        bytes32[] memory proof,
+        bytes32 root,
+        bytes32 leaf
+    ) public pure returns (bool) {
+        return MerkleProof.verify(proof, root, leaf);
+    }
+}

--- a/packages/core-contracts/contracts/utils/MerkleProof.sol
+++ b/packages/core-contracts/contracts/utils/MerkleProof.sol
@@ -1,0 +1,36 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// Based on OpenZeppelin https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/MerkleProof.sol
+library MerkleProof {
+    function verify(
+        bytes32[] memory proof,
+        bytes32 root,
+        bytes32 leaf
+    ) internal pure returns (bool) {
+        bytes32 computedHash = leaf;
+
+        for (uint256 i = 0; i < proof.length; i++) {
+            bytes32 proofElement = proof[i];
+
+            if (computedHash <= proofElement) {
+                // Hash(current computed hash + current element of the proof)
+                computedHash = _efficientHash(computedHash, proofElement);
+            } else {
+                // Hash(current element of the proof + current computed hash)
+                computedHash = _efficientHash(proofElement, computedHash);
+            }
+        }
+
+        // Check if the computed hash (root) is equal to the provided root
+        return computedHash == root;
+    }
+
+    function _efficientHash(bytes32 a, bytes32 b) private pure returns (bytes32 value) {
+        assembly {
+            mstore(0x00, a)
+            mstore(0x20, b)
+            value := keccak256(0x00, 0x40)
+        }
+    }
+}

--- a/packages/core-contracts/test/contracts/utils/MerkleProof.test.js
+++ b/packages/core-contracts/test/contracts/utils/MerkleProof.test.js
@@ -1,0 +1,63 @@
+const { ethers } = hre;
+const assert = require('assert/strict');
+const MerkleTree = require('@synthetixio/core-js/utils/merkle-tree/merkle-tree.js');
+
+describe('MerkleProof', () => {
+  let MerkleProof;
+
+  let merkleTree;
+
+  let elements = [];
+
+  before('get some elements', async () => {
+    for (let i = 0; i < 10; i++) {
+      elements.push(ethers.utils.formatBytes32String(`${i}`));
+    }
+  });
+
+  before('deploy the contract', async () => {
+    const factory = await ethers.getContractFactory('MerkleProofMock');
+    MerkleProof = await factory.deploy();
+  });
+
+  before('build a merkle tree', () => {
+    merkleTree = new MerkleTree(elements.map((e) => Buffer.from(e.substr(2), 'hex')));
+  });
+
+  describe('verify(bytes32[] memory proof, bytes32 root, bytes32 leaf', () => {
+    it('shows a valid proof pass', async () => {
+      assert.equal(
+        await MerkleProof.verify(
+          merkleTree.getHexProof(Buffer.from(elements[0].substr(2), 'hex')),
+          merkleTree.getHexRoot(),
+          Buffer.from(elements[0].substr(2), 'hex')
+        ),
+        true
+      );
+    });
+
+    it('shows a proof for another entry fails', async () => {
+      assert.equal(
+        await MerkleProof.verify(
+          merkleTree.getHexProof(Buffer.from(elements[0].substr(2), 'hex')),
+          merkleTree.getHexRoot(),
+          Buffer.from(elements[1].substr(2), 'hex')
+        ),
+        false
+      );
+    });
+    it('shows an invalid proof fails', async () => {
+      const proof = merkleTree.getHexProof(Buffer.from(elements[0].substr(2), 'hex'));
+      proof.pop(); // Introduce an error in the proof removing one element
+
+      assert.equal(
+        await MerkleProof.verify(
+          proof,
+          merkleTree.getHexRoot(),
+          Buffer.from(elements[0].substr(2), 'hex')
+        ),
+        false
+      );
+    });
+  });
+});

--- a/packages/core-js/test/utils/merkle-tree/balance-tree.test.js
+++ b/packages/core-js/test/utils/merkle-tree/balance-tree.test.js
@@ -1,6 +1,5 @@
 const ethers = require('ethers');
 const { equal } = require('assert/strict');
-const { ok } = require('assert/strict');
 const BalanceTree = require('../../../utils/merkle-tree/balance-tree');
 
 function hexStringToBuffer(data) {

--- a/packages/core-js/test/utils/merkle-tree/balance-tree.test.js
+++ b/packages/core-js/test/utils/merkle-tree/balance-tree.test.js
@@ -1,0 +1,83 @@
+const ethers = require('ethers');
+const { equal } = require('assert/strict');
+const { ok } = require('assert/strict');
+const BalanceTree = require('../../../utils/merkle-tree/balance-tree');
+
+function hexStringToBuffer(data) {
+  return Buffer.from(data.substr(2), 'hex');
+}
+
+describe('utils/merkle-tree/balance-tree.js', function () {
+  let balances, tree;
+
+  before('build tree', () => {
+    balances = [];
+    for (let i = 0; i < 10; i++) {
+      balances.push({ account: ethers.Wallet.createRandom().address, amount: i + 1 });
+    }
+
+    tree = new BalanceTree(balances);
+  });
+
+  describe('when validating a proof against the right root', () => {
+    it('is validated', function () {
+      const proof = tree.getProof(balances[0].account, balances[0].amount);
+      const root = tree.getHexRoot();
+
+      equal(proof.length > 2, true);
+      equal(
+        BalanceTree.verifyProof(
+          hexStringToBuffer(balances[0].account),
+          balances[0].amount,
+          proof.map((e) => hexStringToBuffer(e)),
+          hexStringToBuffer(root)
+        ),
+        true
+      );
+    });
+  });
+
+  describe('when validating a proof against a wrong root', () => {
+    let wrongTree;
+    before('build wrong tree', () => {
+      const newBalances = [];
+      for (let i = 0; i < 10; i++) {
+        newBalances.push({ account: ethers.Wallet.createRandom().address, amount: i + 2 });
+      }
+
+      wrongTree = new BalanceTree(newBalances);
+    });
+
+    it('is rejected', function () {
+      const proof = tree.getProof(balances[0].account, balances[0].amount);
+      const root = wrongTree.getHexRoot();
+
+      equal(
+        BalanceTree.verifyProof(
+          hexStringToBuffer(balances[0].account),
+          balances[0].amount,
+          proof.map((e) => hexStringToBuffer(e)),
+          hexStringToBuffer(root)
+        ),
+        false
+      );
+    });
+  });
+
+  describe('when validating a proof from another element', () => {
+    it('is rejected', function () {
+      const proof = tree.getProof(balances[0].account, balances[0].amount);
+      const root = tree.getHexRoot();
+
+      equal(
+        BalanceTree.verifyProof(
+          hexStringToBuffer(balances[1].account),
+          balances[1].amount,
+          proof.map((e) => hexStringToBuffer(e)),
+          hexStringToBuffer(root)
+        ),
+        false
+      );
+    });
+  });
+});

--- a/packages/core-js/test/utils/merkle-tree/merkle-tree.test.js
+++ b/packages/core-js/test/utils/merkle-tree/merkle-tree.test.js
@@ -1,5 +1,5 @@
-const { deepEqual, ok } = require('assert/strict');
-const { bufferToHex, keccak256 } = require('ethereumjs-util');
+const { deepEqual } = require('assert/strict');
+const { keccak256 } = require('ethereumjs-util');
 const MerkleTree = require('../../../utils/merkle-tree/merkle-tree');
 
 describe('utils/merkle-tree/merkle-tree.js', function () {

--- a/packages/core-js/test/utils/merkle-tree/merkle-tree.test.js
+++ b/packages/core-js/test/utils/merkle-tree/merkle-tree.test.js
@@ -76,13 +76,9 @@ describe('utils/merkle-tree/merkle-tree.js', function () {
 
   describe('when creating an empty tree', function () {
     it('throws an error', () => {
-      throws(
-        () => {
-          new MerkleTree([]);
-        },
-        Error,
-        'empty tree'
-      );
+      throws(() => {
+        new MerkleTree([]);
+      }, 'Error: empty tree');
     });
   });
 
@@ -97,13 +93,9 @@ describe('utils/merkle-tree/merkle-tree.js', function () {
     });
 
     it('throws an error', () => {
-      throws(
-        () => {
-          tree.getProof(Buffer.from('3'));
-        },
-        Error,
-        'empty tree'
-      );
+      throws(() => {
+        tree.getProof(Buffer.from('3'));
+      }, 'Error: Element does not exist in Merkle tree');
     });
   });
 
@@ -126,13 +118,9 @@ describe('utils/merkle-tree/merkle-tree.js', function () {
       elements.push(Buffer.from('2'));
       elements.push('3');
 
-      throws(
-        () => {
-          MerkleTree._bufArrToHexArr(elements);
-        },
-        Error,
-        'Array is not an array of buffers'
-      );
+      throws(() => {
+        MerkleTree._bufArrToHexArr(elements);
+      }, 'Error: Array is not an array of buffers');
     });
   });
 });

--- a/packages/core-js/test/utils/merkle-tree/merkle-tree.test.js
+++ b/packages/core-js/test/utils/merkle-tree/merkle-tree.test.js
@@ -1,0 +1,75 @@
+const { deepEqual, ok } = require('assert/strict');
+const { bufferToHex, keccak256 } = require('ethereumjs-util');
+const MerkleTree = require('../../../utils/merkle-tree/merkle-tree');
+
+describe('utils/merkle-tree/merkle-tree.js', function () {
+  describe('basic tree', function () {
+    let elements, root, tree;
+
+    before('create the smallest tree', () => {
+      elements = [];
+      elements.push(Buffer.from('1'));
+      elements.push(Buffer.from('2'));
+      root = keccak256(Buffer.concat(elements.sort(Buffer.compare)));
+      tree = new MerkleTree(elements);
+    });
+
+    it('root is valid', function () {
+      deepEqual(root, tree.getRoot());
+    });
+
+    it('hex root is valid', function () {
+      deepEqual('0x' + root.toString('hex'), tree.getHexRoot());
+    });
+
+    it('proofs are valid', function () {
+      deepEqual([elements[1]], tree.getProof(elements[0]));
+      deepEqual([elements[0]], tree.getProof(elements[1]));
+    });
+
+    it('hex proofs are valid', function () {
+      deepEqual(['0x' + elements[1].toString('hex')], tree.getHexProof(elements[0]));
+      deepEqual(['0x' + elements[0].toString('hex')], tree.getHexProof(elements[1]));
+    });
+  });
+
+  describe('large tree', function () {
+    let elements, tree;
+
+    before('create the smallest tree', () => {
+      elements = [];
+      for (let i = 1; i < 100000; i++) {
+        elements.push(Buffer.from('' + i));
+      }
+      tree = new MerkleTree(elements);
+    });
+
+    it('proof is valid (calculated offline)', function () {
+      const proof = [
+        '0x3130',
+        '0x2f577a9004fb8afc70f705780ac13847591b610cf896b9f10f9fb40c32f6c619',
+        '0x39304c411ceea42dd7d785f00b820ec18ba9051d1d72e3c2335de7a775a77054',
+        '0x49ce22d2edf5a0cd2a09f1c3976dfc3f31faafeacdfb2d5753367a6b0b86999f',
+        '0x5e85690946df43a366f4dae22e510544e9535d67d1085a0d457b4f76004e5637',
+        '0x27759ecb9cdfce0822d095f4e6b8a67e6a940985d3766a2adb7a44517ee38ec2',
+        '0xb2fc4470132247328384f5bf5bea53a185ffaf21d4083784dcb5ae636ae8fef6',
+        '0x19ad8c89ec97cabb82085261a727d81b6a6e132e9671cb4f463f3e140994a6e2',
+        '0x940ce297813d789ca1712e42f4d2c923976bda61995c33a2478ab122ee1c8254',
+        '0x37e0fcf84c3ecf82e1c3afdf77a9ec98bac1c321a186b6dccd49d9a6f4618c0d',
+        '0x492d47747744e8a1dcd6a312a17025d479a1aec8598f4152a3ea5b5416826a8a',
+        '0x6fae9c4863f5107a9f1570b407adcddc9dfefcdfffca846b80a69848189ea88c',
+        '0xbed2a885cfbc8f1aa6f498cde9e7ceadacc339d64f591f60cc81a670de297383',
+        '0x906dc3dd7be9ec06912f52a7a6c64c13fc04b9839bf9fb0cd201c2c062fda277',
+        '0x30e7d40dc28baae6a745c673d45062590c34b95c00875ae159f7e2e35e767d4d',
+        '0x7ec791713b6e1f992c70f2e18acd3d19db715ff75d247fc2acc46ab70d4ba7e9',
+        '0x5c1ed5d5c70d2b32aa8366b22bc70b86bdcf9fa1033d21fe0fcb4ff9ec293e05',
+      ];
+      deepEqual(proof, tree.getHexProof(elements[0]));
+    });
+
+    it('root is valid (calculated offline)', function () {
+      const root = '0x851a1a8eeb1f817cd7f713c0e25ba14bffb4d3d1c8fbc9c1682a254640592df5';
+      deepEqual(root, tree.getHexRoot());
+    });
+  });
+});

--- a/packages/core-js/test/utils/merkle-tree/parse-balance-tree.test.js
+++ b/packages/core-js/test/utils/merkle-tree/parse-balance-tree.test.js
@@ -1,0 +1,48 @@
+const ethers = require('ethers');
+const { ok, equal } = require('assert/strict');
+const { parseBalanceMap } = require('../../../utils/merkle-tree/parse-balance-tree');
+const BalanceTree = require('../../../utils/merkle-tree/balance-tree');
+
+function hexStringToBuffer(data) {
+  return Buffer.from(data.substr(2), 'hex');
+}
+
+describe('utils/merkle-tree/parse-balance-tree.js', function () {
+  let inputData, parsedTree;
+
+  before('build tree', () => {
+    inputData = {};
+    for (let i = 0; i < 10; i++) {
+      inputData[ethers.Wallet.createRandom().address] = '' + (i + 1);
+    }
+
+    parsedTree = parseBalanceMap(inputData);
+  });
+
+  it('gets a parsed tree with the right format', () => {
+    ok(typeof parsedTree === 'object');
+    ok(typeof parsedTree.merkleRoot === 'string');
+
+    const key = Object.keys(parsedTree.claims)[0];
+
+    ok(typeof parsedTree.claims === 'object');
+    ok(typeof parsedTree.claims[key] === 'object');
+    ok(typeof parsedTree.claims[key].amount === 'string');
+    ok(typeof parsedTree.claims[key].proof === 'object');
+    ok(typeof parsedTree.claims[key].proof[0] === 'string');
+  });
+
+  it('gets a valid proof for the tree root', () => {
+    const account = Object.keys(parsedTree.claims)[0];
+
+    equal(
+      BalanceTree.verifyProof(
+        hexStringToBuffer(account),
+        parsedTree.claims[account].amount,
+        parsedTree.claims[account].proof.map((e) => hexStringToBuffer(e)),
+        hexStringToBuffer(parsedTree.merkleRoot)
+      ),
+      true
+    );
+  });
+});

--- a/packages/core-js/test/utils/merkle-tree/parse-balance-tree.test.js
+++ b/packages/core-js/test/utils/merkle-tree/parse-balance-tree.test.js
@@ -1,5 +1,5 @@
 const ethers = require('ethers');
-const { ok, equal } = require('assert/strict');
+const { ok, equal, throws } = require('assert/strict');
 const { parseBalanceMap } = require('../../../utils/merkle-tree/parse-balance-tree');
 const BalanceTree = require('../../../utils/merkle-tree/balance-tree');
 
@@ -8,41 +8,78 @@ function hexStringToBuffer(data) {
 }
 
 describe('utils/merkle-tree/parse-balance-tree.js', function () {
-  let inputData, parsedTree;
+  describe('when parsing vaild input data', () => {
+    let inputData, parsedTree;
 
-  before('build tree', () => {
-    inputData = {};
-    for (let i = 0; i < 10; i++) {
-      inputData[ethers.Wallet.createRandom().address] = '' + (i + 1);
-    }
+    before('build tree', () => {
+      inputData = {};
+      for (let i = 0; i < 10; i++) {
+        inputData[ethers.Wallet.createRandom().address] = '' + (i + 1);
+      }
 
-    parsedTree = parseBalanceMap(inputData);
+      parsedTree = parseBalanceMap(inputData);
+    });
+
+    it('gets a parsed tree with the right format', () => {
+      ok(typeof parsedTree === 'object');
+      ok(typeof parsedTree.merkleRoot === 'string');
+
+      const key = Object.keys(parsedTree.claims)[0];
+
+      ok(typeof parsedTree.claims === 'object');
+      ok(typeof parsedTree.claims[key] === 'object');
+      ok(typeof parsedTree.claims[key].amount === 'string');
+      ok(typeof parsedTree.claims[key].proof === 'object');
+      ok(typeof parsedTree.claims[key].proof[0] === 'string');
+    });
+
+    it('gets a valid proof for the tree root', () => {
+      const account = Object.keys(parsedTree.claims)[0];
+
+      equal(
+        BalanceTree.verifyProof(
+          hexStringToBuffer(account),
+          parsedTree.claims[account].amount,
+          parsedTree.claims[account].proof.map((e) => hexStringToBuffer(e)),
+          hexStringToBuffer(parsedTree.merkleRoot)
+        ),
+        true
+      );
+    });
   });
 
-  it('gets a parsed tree with the right format', () => {
-    ok(typeof parsedTree === 'object');
-    ok(typeof parsedTree.merkleRoot === 'string');
+  describe('when attempting to parse an invalid address', () => {
+    let inputData;
 
-    const key = Object.keys(parsedTree.claims)[0];
+    before('build input data', () => {
+      inputData = {};
+      for (let i = 0; i < 10; i++) {
+        inputData[ethers.Wallet.createRandom().address] = '' + (i + 1);
+      }
+      inputData['0x00112233'] = '12';
+    });
 
-    ok(typeof parsedTree.claims === 'object');
-    ok(typeof parsedTree.claims[key] === 'object');
-    ok(typeof parsedTree.claims[key].amount === 'string');
-    ok(typeof parsedTree.claims[key].proof === 'object');
-    ok(typeof parsedTree.claims[key].proof[0] === 'string');
+    it('throws an arror', () => {
+      throws(() => {
+        parseBalanceMap(inputData);
+      }, 'Error: Found invalid address: 0x00112233');
+    });
   });
+  describe('when attempting to parse an zero balance', () => {
+    let inputData;
 
-  it('gets a valid proof for the tree root', () => {
-    const account = Object.keys(parsedTree.claims)[0];
+    before('build input data', () => {
+      inputData = {};
+      for (let i = 0; i < 10; i++) {
+        inputData[ethers.Wallet.createRandom().address] = '' + (i + 1);
+      }
+      inputData[ethers.Wallet.createRandom().address] = '0';
+    });
 
-    equal(
-      BalanceTree.verifyProof(
-        hexStringToBuffer(account),
-        parsedTree.claims[account].amount,
-        parsedTree.claims[account].proof.map((e) => hexStringToBuffer(e)),
-        hexStringToBuffer(parsedTree.merkleRoot)
-      ),
-      true
-    );
+    it('throws an arror', () => {
+      throws(() => {
+        parseBalanceMap(inputData);
+      }, 'Error: Invalid amount for account: ');
+    });
   });
 });

--- a/packages/core-js/utils/merkle-tree/balance-tree.js
+++ b/packages/core-js/utils/merkle-tree/balance-tree.js
@@ -1,0 +1,41 @@
+// based on https://github.com/Uniswap/merkle-distributor/tree/master/src
+import { utils } from 'ethers';
+import MerkleTree from './merkle-tree';
+
+class BalanceTree {
+  constructor(balances) {
+    this.tree = new MerkleTree(
+      balances.map(({ account, amount }) => {
+        return BalanceTree.toNode(account, amount);
+      })
+    );
+  }
+
+  static verifyProof(account, amount, proof, root) {
+    let pair = BalanceTree.toNode(account, amount);
+    for (const item of proof) {
+      pair = MerkleTree.combinedHash(pair, item);
+    }
+
+    return pair.equals(root);
+  }
+
+  // keccak256(abi.encode(account, amount))
+  static toNode(account, amount) {
+    return Buffer.from(
+      utils.solidityKeccak256(['address', 'uint256'], [account, amount]).substr(2),
+      'hex'
+    );
+  }
+
+  getHexRoot() {
+    return this.tree.getHexRoot();
+  }
+
+  // returns the hex bytes32 values of the proof
+  getProof(account, amount) {
+    return this.tree.getHexProof(BalanceTree.toNode(account, amount));
+  }
+}
+
+module.exports = BalanceTree;

--- a/packages/core-js/utils/merkle-tree/balance-tree.js
+++ b/packages/core-js/utils/merkle-tree/balance-tree.js
@@ -1,6 +1,6 @@
 // based on https://github.com/Uniswap/merkle-distributor/tree/master/src
-import { utils } from 'ethers';
-import MerkleTree from './merkle-tree';
+const { utils } = require('ethers');
+const MerkleTree = require('./merkle-tree');
 
 class BalanceTree {
   constructor(balances) {
@@ -11,6 +11,7 @@ class BalanceTree {
     );
   }
 
+  // eslint-disable-next-line max-params
   static verifyProof(account, amount, proof, root) {
     let pair = BalanceTree.toNode(account, amount);
     for (const item of proof) {

--- a/packages/core-js/utils/merkle-tree/merkle-tree.js
+++ b/packages/core-js/utils/merkle-tree/merkle-tree.js
@@ -1,10 +1,6 @@
 const { bufferToHex, keccak256 } = require('ethereumjs-util');
 
 class MerkleTree {
-  // private readonly elements: Buffer[]
-  // private readonly bufferElementPositionIndex: { [hexElement: string]: number }
-  // private readonly layers: Buffer[][]
-
   constructor(elements) {
     this.elements = [...elements];
     // Sort elements

--- a/packages/core-js/utils/merkle-tree/merkle-tree.js
+++ b/packages/core-js/utils/merkle-tree/merkle-tree.js
@@ -1,5 +1,4 @@
-// based on https://github.com/Uniswap/merkle-distributor/tree/master/src
-import { bufferToHex, keccak256 } from 'ethereumjs-util';
+const { bufferToHex, keccak256 } = require('ethereumjs-util');
 
 class MerkleTree {
   // private readonly elements: Buffer[]
@@ -39,6 +38,7 @@ class MerkleTree {
   }
 
   getNextLayer(elements) {
+    // eslint-disable-next-line max-params
     return elements.reduce((layer, el, idx, arr) => {
       if (idx % 2 === 0) {
         // Hash the current element with its pair element

--- a/packages/core-js/utils/merkle-tree/merkle-tree.js
+++ b/packages/core-js/utils/merkle-tree/merkle-tree.js
@@ -1,0 +1,126 @@
+// based on https://github.com/Uniswap/merkle-distributor/tree/master/src
+import { bufferToHex, keccak256 } from 'ethereumjs-util';
+
+class MerkleTree {
+  // private readonly elements: Buffer[]
+  // private readonly bufferElementPositionIndex: { [hexElement: string]: number }
+  // private readonly layers: Buffer[][]
+
+  constructor(elements) {
+    this.elements = [...elements];
+    // Sort elements
+    this.elements.sort(Buffer.compare);
+    // Deduplicate elements
+    this.elements = MerkleTree._bufDedup(this.elements);
+
+    this.bufferElementPositionIndex = this.elements.reduce((memo, el, index) => {
+      memo[bufferToHex(el)] = index;
+      return memo;
+    }, {});
+
+    // Create layers
+    this.layers = this.getLayers(this.elements);
+  }
+
+  getLayers(elements) {
+    if (elements.length === 0) {
+      throw new Error('empty tree');
+    }
+
+    const layers = [];
+    layers.push(elements);
+
+    // Get next layer until we reach the root
+    while (layers[layers.length - 1].length > 1) {
+      layers.push(this.getNextLayer(layers[layers.length - 1]));
+    }
+
+    return layers;
+  }
+
+  getNextLayer(elements) {
+    return elements.reduce((layer, el, idx, arr) => {
+      if (idx % 2 === 0) {
+        // Hash the current element with its pair element
+        layer.push(MerkleTree.combinedHash(el, arr[idx + 1]));
+      }
+
+      return layer;
+    }, []);
+  }
+
+  static combinedHash(first, second) {
+    if (!first) {
+      return second;
+    }
+    if (!second) {
+      return first;
+    }
+
+    return keccak256(MerkleTree._sortAndConcat(first, second));
+  }
+
+  getRoot() {
+    return this.layers[this.layers.length - 1][0];
+  }
+
+  getHexRoot() {
+    return bufferToHex(this.getRoot());
+  }
+
+  getProof(el) {
+    let idx = this.bufferElementPositionIndex[bufferToHex(el)];
+
+    if (typeof idx !== 'number') {
+      throw new Error('Element does not exist in Merkle tree');
+    }
+
+    return this.layers.reduce((proof, layer) => {
+      const pairElement = MerkleTree._getPairElement(idx, layer);
+
+      if (pairElement) {
+        proof.push(pairElement);
+      }
+
+      idx = Math.floor(idx / 2);
+
+      return proof;
+    }, []);
+  }
+
+  getHexProof(el) {
+    const proof = this.getProof(el);
+
+    return MerkleTree._bufArrToHexArr(proof);
+  }
+
+  static _getPairElement(idx, layer) {
+    const pairIdx = idx % 2 === 0 ? idx + 1 : idx - 1;
+
+    if (pairIdx < layer.length) {
+      return layer[pairIdx];
+    } else {
+      return null;
+    }
+  }
+
+  static _bufDedup(elements) {
+    return elements.filter((el, idx) => {
+      return idx === 0 || !elements[idx - 1].equals(el);
+    });
+  }
+
+  static _bufArrToHexArr(arr) {
+    if (arr.some((el) => !Buffer.isBuffer(el))) {
+      throw new Error('Array is not an array of buffers');
+    }
+
+    return arr.map((el) => '0x' + el.toString('hex'));
+  }
+
+  static _sortAndConcat(...args) {
+    return Buffer.concat([...args].sort(Buffer.compare));
+  }
+}
+
+module.exports = MerkleTree;

--- a/packages/core-js/utils/merkle-tree/parse-balance-tree.js
+++ b/packages/core-js/utils/merkle-tree/parse-balance-tree.js
@@ -1,6 +1,6 @@
 // based on https://github.com/Uniswap/merkle-distributor/tree/master/src
-import { BigNumber, utils } from 'ethers';
-import BalanceTree from './balance-tree';
+const { BigNumber, utils } = require('ethers');
+const BalanceTree = require('./balance-tree');
 
 const { isAddress, getAddress } = utils;
 
@@ -26,15 +26,15 @@ const { isAddress, getAddress } = utils;
 // type OldFormat = { [account: string]: number | string }
 // type NewFormat = { address: string; earnings: string; reasons: string }
 
-export function parseBalanceMap(balances) {
+function parseBalanceMap(balances) {
   // if balances are in an old format, process them
   const balancesInNewFormat = Array.isArray(balances)
     ? balances
     : Object.keys(balances).map((account) => ({
-        address: account,
-        earnings: `${balances[account].toString(16)}`,
-        reasons: '',
-      }));
+      address: account,
+      earnings: `${balances[account].toString(16)}`,
+      reasons: '',
+    }));
 
   const dataByAddress = balancesInNewFormat.reduce(
     (memo, { address: account, earnings, reasons }) => {
@@ -72,7 +72,7 @@ export function parseBalanceMap(balances) {
       // index,
       amount: amount.toHexString(),
       proof: tree.getProof(index, address, amount),
-      // ...(flags ? { flags } : {}),
+      ...(flags ? { flags } : {}),
     };
     return memo;
   }, {});
@@ -82,3 +82,7 @@ export function parseBalanceMap(balances) {
     claims,
   };
 }
+
+module.exports = {
+  parseBalanceMap,
+};

--- a/packages/core-js/utils/merkle-tree/parse-balance-tree.js
+++ b/packages/core-js/utils/merkle-tree/parse-balance-tree.js
@@ -1,0 +1,84 @@
+// based on https://github.com/Uniswap/merkle-distributor/tree/master/src
+import { BigNumber, utils } from 'ethers';
+import BalanceTree from './balance-tree';
+
+const { isAddress, getAddress } = utils;
+
+// This is the blob that gets distributed and pinned to IPFS.
+// It is completely sufficient for recreating the entire merkle tree.
+// Anyone can verify that all air drops are included in the tree,
+// and the tree has no additional distributions.
+// interface MerkleDistributorInfo {
+//   merkleRoot: string
+//   tokenTotal: string
+//   claims: {
+//     [account: string]: {
+//       index: number
+//       amount: string
+//       proof: string[]
+//       flags?: {
+//         [flag: string]: boolean
+//       }
+//     }
+//   }
+// }
+
+// type OldFormat = { [account: string]: number | string }
+// type NewFormat = { address: string; earnings: string; reasons: string }
+
+export function parseBalanceMap(balances) {
+  // if balances are in an old format, process them
+  const balancesInNewFormat = Array.isArray(balances)
+    ? balances
+    : Object.keys(balances).map((account) => ({
+        address: account,
+        earnings: `${balances[account].toString(16)}`,
+        reasons: '',
+      }));
+
+  const dataByAddress = balancesInNewFormat.reduce(
+    (memo, { address: account, earnings, reasons }) => {
+      if (!isAddress(account)) {
+        throw new Error(`Found invalid address: ${account}`);
+      }
+      const parsed = getAddress(account);
+      if (memo[parsed]) throw new Error(`Duplicate address: ${parsed}`);
+      const parsedNum = BigNumber.from(earnings);
+      if (parsedNum.lte(0)) throw new Error(`Invalid amount for account: ${account}`);
+
+      const flags = {
+        // isSOCKS: reasons.includes('socks'),
+        // isLP: reasons.includes('lp'),
+        // isUser: reasons.includes('user'),
+      };
+
+      memo[parsed] = { amount: parsedNum, ...(reasons === '' ? {} : { flags }) };
+      return memo;
+    },
+    {}
+  );
+
+  const sortedAddresses = Object.keys(dataByAddress).sort();
+
+  // construct a tree
+  const tree = new BalanceTree(
+    sortedAddresses.map((address) => ({ account: address, amount: dataByAddress[address].amount }))
+  );
+
+  // generate claims
+  const claims = sortedAddresses.reduce((memo, address, index) => {
+    const { amount, flags } = dataByAddress[address];
+    memo[address] = {
+      // index,
+      amount: amount.toHexString(),
+      proof: tree.getProof(index, address, amount),
+      // ...(flags ? { flags } : {}),
+    };
+    return memo;
+  }, {});
+
+  return {
+    merkleRoot: tree.getHexRoot(),
+    claims,
+  };
+}

--- a/packages/core-js/utils/merkle-tree/parse-balance-tree.js
+++ b/packages/core-js/utils/merkle-tree/parse-balance-tree.js
@@ -28,12 +28,14 @@ const { isAddress, getAddress } = utils;
 
 function parseBalanceMap(balances) {
   // if balances are in an old format, process them
+  /* eslint-disable indent */
   const balancesInNewFormat = Array.isArray(balances)
     ? balances
     : Object.keys(balances).map((account) => ({
-      address: account,
-      balance: `${balances[account].toString(16)}`,
-    }));
+        address: account,
+        balance: `${balances[account].toString(16)}`,
+      }));
+  /* eslint-enable indent */
 
   const dataByAddress = balancesInNewFormat.reduce((memo, { address: account, balance }) => {
     if (!isAddress(account)) {

--- a/packages/core-js/utils/merkle-tree/parse-balance-tree.js
+++ b/packages/core-js/utils/merkle-tree/parse-balance-tree.js
@@ -4,28 +4,6 @@ const BalanceTree = require('./balance-tree');
 
 const { isAddress, getAddress } = utils;
 
-// This is the blob that gets distributed and pinned to IPFS.
-// It is completely sufficient for recreating the entire merkle tree.
-// Anyone can verify that all air drops are included in the tree,
-// and the tree has no additional distributions.
-// interface MerkleDistributorInfo {
-//   merkleRoot: string
-//   tokenTotal: string
-//   claims: {
-//     [account: string]: {
-//       index: number
-//       amount: string
-//       proof: string[]
-//       flags?: {
-//         [flag: string]: boolean
-//       }
-//     }
-//   }
-// }
-
-// type OldFormat = { [account: string]: number | string }
-// type NewFormat = { address: string; earnings: string; reasons: string }
-
 function parseBalanceMap(balances) {
   // if balances are in an old format, process them
   /* eslint-disable indent */


### PR DESCRIPTION
Fix #838 

This PR adds a: 

1. **merkle-tree util to core-js**: it create a basic merkle-tree, a balance-merkle-tree (merkle-tree from address-balance pairs), and parse a json containing the addresses and balances and build an artifact to be consumed by a Frontend.
2. **merkle-proof validator lib to core-contracts**: this gets an address, balance, merkle-tree root and merkle-tree proof and verify the address/balance pair is in the merkle tree.

Note:  the **merkle-tree contract** for the L1 to L2 debt shares integration will be done in a separate PR.
  