### PR TITLE
Slightly better cross chain debt share declaration

### DIFF
--- a/packages/synthetix-governance/contracts/interfaces/ISynthetixElectionModule.sol
+++ b/packages/synthetix-governance/contracts/interfaces/ISynthetixElectionModule.sol
@@ -41,5 +41,5 @@ interface ISynthetixElectionModule is IBaseElectionModule {
 
     function getCrossChainDebtShareMerkleRootBlocknumber() external view returns (uint);
 
-    function getCrossChainDebtShare(address account) external view returns (uint);
+    function getDeclaredCrossChainDebtShare(address account) external view returns (uint);
 }

--- a/packages/synthetix-governance/contracts/modules/ElectionModule.sol
+++ b/packages/synthetix-governance/contracts/modules/ElectionModule.sol
@@ -112,8 +112,8 @@ contract ElectionModule is ISynthetixElectionModule, BaseElectionModule, DebtSha
     }
 
     /// @notice Returns the Synthetix v2 debt shares for the provided address, at this epoch's snapshot, in other chains
-    function getCrossChainDebtShare(address user) external view override returns (uint) {
-        return _getCrossChainDebtShare(user);
+    function getDeclaredCrossChainDebtShare(address user) external view override returns (uint) {
+        return _getDeclaredCrossChainDebtShare(user);
     }
 
     // ---------------------------------------
@@ -122,7 +122,7 @@ contract ElectionModule is ISynthetixElectionModule, BaseElectionModule, DebtSha
 
     /// @dev Overrides the user's voting power by combining local chain debt share with debt shares in other chains, quadratically filtered
     function _getVotePower(address user) internal view override returns (uint) {
-        uint votePower = _getDebtShare(user) + _getCrossChainDebtShare(user);
+        uint votePower = _getDebtShare(user) + _getDeclaredCrossChainDebtShare(user);
 
         return MathUtil.sqrt(votePower);
     }

--- a/packages/synthetix-governance/contracts/submodules/election/CrossChainDebtShareManager.sol
+++ b/packages/synthetix-governance/contracts/submodules/election/CrossChainDebtShareManager.sol
@@ -10,6 +10,7 @@ contract CrossChainDebtShareManager is ElectionBase, DebtShareStorage {
     error MerkleRootNotSet();
     error MerkleRootAlreadySet();
     error InvalidMerkleProof();
+    error CrossChainDebtShareAlreadyDeclared();
 
     event CrossChainDebtShareMerkleRootSet(bytes32 merkleRoot, uint blocknumber, uint epoch);
     event CrossChainDebtShareDeclared(address user, uint debtShare);
@@ -32,6 +33,10 @@ contract CrossChainDebtShareManager is ElectionBase, DebtShareStorage {
     ) internal {
         CrossChainDebtShareData storage debtShareData = _debtShareStore().crossChainDebtShareData[_getCurrentEpochIndex()];
 
+        if (debtShareData.debtShares[user] != 0) {
+            revert CrossChainDebtShareAlreadyDeclared();
+        }
+
         if (debtShareData.merkleRoot == 0) {
             revert MerkleRootNotSet();
         }
@@ -45,7 +50,7 @@ contract CrossChainDebtShareManager is ElectionBase, DebtShareStorage {
         debtShareData.debtShares[user] = debtShare;
     }
 
-    function _getCrossChainDebtShare(address user) internal view returns (uint) {
+    function _getDeclaredCrossChainDebtShare(address user) internal view returns (uint) {
         CrossChainDebtShareData storage debtShareData = _debtShareStore().crossChainDebtShareData[_getCurrentEpochIndex()];
 
         return debtShareData.debtShares[user];

--- a/packages/synthetix-governance/test/unit/contracts/modules/ElectionModule/CrossChainDebtShare.test.js
+++ b/packages/synthetix-governance/test/unit/contracts/modules/ElectionModule/CrossChainDebtShare.test.js
@@ -165,7 +165,7 @@ describe('SynthetixElectionModule (cross chain debt share)', function () {
 
         describe('when retrieving the voter declared debt before declaring it', () => {
           it('has 0 debt share', async () => {
-            assertBn.equal(await ElectionModule.getCrossChainDebtShare(voter), 0);
+            assertBn.equal(await ElectionModule.getDeclaredCrossChainDebtShare(voter), 0);
           });
         });
 
@@ -189,9 +189,22 @@ describe('SynthetixElectionModule (cross chain debt share)', function () {
 
           it('has the right debt share', async () => {
             assertBn.equal(
-              await ElectionModule.getCrossChainDebtShare(voter),
+              await ElectionModule.getDeclaredCrossChainDebtShare(voter),
               parsedTree.claims[voter].amount
             );
+          });
+
+          describe('when a voter attempts to declare their cross chain debt shares again', function () {
+            it('reverts', async function () {
+              await assertRevert(
+                ElectionModule.declareCrossChainDebtShare(
+                  voter,
+                  parsedTree.claims[voter].amount,
+                  parsedTree.claims[voter].proof
+                ),
+                'CrossChainDebtShareAlreadyDeclared'
+              );
+            });
           });
         });
       });


### PR DESCRIPTION
Closes #943
Closes #944

We already had a view function to see the cross chain declared debt shares of a user. I just renamed the function from `getCrossChainDebtShare(user)` to `getDeclaredCrossChainDebtShare(user)` to make it clearer.

I also added a require statement to `declareCrossChainDebtShare(user, amount, ...)` so that it reverts when a user attempts to declare twice. In the past, it just succeeded by re-writing the amount stored in the merkle tree.