### PR TITLE
Blocking wrong initializer on EM

### DIFF
--- a/packages/core-modules/contracts/modules/ElectionModule.sol
+++ b/packages/core-modules/contracts/modules/ElectionModule.sol
@@ -29,7 +29,27 @@ contract ElectionModule is
         uint64 nominationPeriodStartDate,
         uint64 votingPeriodStartDate,
         uint64 epochEndDate
-    ) public override onlyOwner onlyIfNotInitialized {
+    ) external virtual override onlyOwner onlyIfNotInitialized {
+        _initializeElectionModule(
+            councilTokenName,
+            councilTokenSymbol,
+            firstCouncil,
+            minimumActiveMembers,
+            nominationPeriodStartDate,
+            votingPeriodStartDate,
+            epochEndDate
+        );
+    }
+
+    function _initializeElectionModule(
+        string memory councilTokenName,
+        string memory councilTokenSymbol,
+        address[] memory firstCouncil,
+        uint8 minimumActiveMembers,
+        uint64 nominationPeriodStartDate,
+        uint64 votingPeriodStartDate,
+        uint64 epochEndDate
+    ) internal {
         ElectionStore storage store = _electionStore();
 
         uint8 seatCount = uint8(firstCouncil.length);

--- a/packages/synthetix-governance/contracts/modules/ElectionModule.sol
+++ b/packages/synthetix-governance/contracts/modules/ElectionModule.sol
@@ -12,9 +12,22 @@ import "../submodules/election/CrossChainDebtShareManager.sol";
 /// @notice This extends the base ElectionModule by determining voting power by Synthetix v2 debt share
 contract ElectionModule is ISynthetixElectionModule, BaseElectionModule, DebtShareManager, CrossChainDebtShareManager {
     error TooManyCandidates();
+    error WrongInitializer();
+
+    /// @dev The BaseElectionModule initializer should not be called, and this one must be called instead
+    function initializeElectionModule(
+        string memory,
+        string memory,
+        address[] memory,
+        uint8,
+        uint64,
+        uint64,
+        uint64
+    ) external view override(BaseElectionModule, IElectionModule) onlyOwner onlyIfNotInitialized {
+        revert WrongInitializer();
+    }
 
     /// @dev Overloads the BaseElectionModule initializer with an additional parameter for the debt share contract
-    /// @dev The BaseElectionModule initializer should not be called, and this one must be called instead
     function initializeElectionModule(
         string memory councilTokenName,
         string memory councilTokenSymbol,
@@ -27,7 +40,7 @@ contract ElectionModule is ISynthetixElectionModule, BaseElectionModule, DebtSha
     ) external onlyOwner onlyIfNotInitialized {
         _setDebtShareContract(debtShareContract);
 
-        initializeElectionModule(
+        _initializeElectionModule(
             councilTokenName,
             councilTokenSymbol,
             firstCouncil,

--- a/packages/synthetix-governance/test/contracts/modules/ElectionModule/Initialize.test.js
+++ b/packages/synthetix-governance/test/contracts/modules/ElectionModule/Initialize.test.js
@@ -50,6 +50,17 @@ describe('SynthetixElectionModule (initialization)', () => {
     });
 
     describe('with the account that owns the instance', function () {
+      describe('with the wrong initializer', function () {
+        it('reverts', async function () {
+          await assertRevert(
+            ElectionModule.connect(owner)[
+              'initializeElectionModule(string,string,address[],uint8,uint64,uint64,uint64)'
+            ]('', '', [owner.address], 1, 0, 0, 0),
+            'WrongInitializer'
+          );
+        });
+      });
+
       describe('with invalid parameters', function () {
         describe('with invalid debtShareContract', function () {
           it('reverts', async function () {


### PR DESCRIPTION
Fix #962

`synthetix-governance` adds adds a parameter to the initializer. Still, nothing stops devs from calling the wrong initializer. Even though that situation could be recoverable, this PR enforces it by blocking access to the base initializer.