### PR TITLE
Mint next account

### DIFF
--- a/packages/synthetix-main/contracts/interfaces/IAccountToken.sol
+++ b/packages/synthetix-main/contracts/interfaces/IAccountToken.sol
@@ -5,6 +5,9 @@ import "@synthetixio/core-contracts/contracts/interfaces/IERC721.sol";
 
 /// @title NFT token identifying an Account
 interface IAccountToken is IERC721 {
-    /// @notice mints a new token (NFT) with the "requestedAccountId" id owned by "owner". It can ol=nly be called by the system
+    /// @notice mints a new token (NFT) with the "requestedAccountId" id owned by "owner".
     function mint(address owner, uint requestedAccountId) external;
+
+    /// @notice mints a new token (NFT) with at the next available id owned by "owner".
+    function mintNext(address owner) external returns (uint256 accountId);
 }

--- a/packages/synthetix-main/contracts/satellites/AccountToken.sol
+++ b/packages/synthetix-main/contracts/satellites/AccountToken.sol
@@ -47,12 +47,21 @@ contract AccountToken is IAccountToken, ERC721, AccountTokenStorage, Initializab
     // ---------------------------------------
     // Mint/Transfer
     // ---------------------------------------
-    function mint(address owner, uint256 accountId) external override {
-        _mint(owner, accountId);
+    function mint(address _owner, uint256 accountId) public override {
+        _mint(_owner, accountId);
 
-        IAccountModule(_accountStore().mainProxy).transferAccount(owner, accountId);
+        IAccountModule(_accountStore().mainProxy).transferAccount(_owner, accountId);
 
-        emit AccountMinted(owner, accountId);
+        emit AccountMinted(_owner, accountId);
+    }
+
+    function mintNext(address _owner) external override returns (uint256 accountId) {
+        while (_exists(_accountStore().recentIdUsed)) {
+            _accountStore().recentIdUsed++;
+        }
+        accountId = _accountStore().recentIdUsed;
+
+        mint(_owner, accountId);
     }
 
     function _postTransfer(

--- a/packages/synthetix-main/contracts/storage/AccountTokenStorage.sol
+++ b/packages/synthetix-main/contracts/storage/AccountTokenStorage.sol
@@ -5,6 +5,7 @@ contract AccountTokenStorage {
     struct AccountStore {
         bool initialized;
         address mainProxy;
+        uint256 recentIdUsed;
     }
 
     function _accountStore() internal pure returns (AccountStore storage store) {


### PR DESCRIPTION
In general, we'd like accounts to be generated with incrementing IDs. We started by allowing accounts to be created at any ID, mostly because in the case of a multicall, you're going to want to be able to queue up later transactions to reference the account ID you're creating. But if two accounts were created on the same block, the account creation would revert for the second, leading to a poor user experience.

This function allows our peripheral `Onboarding` contract (as well as a UI for just creating an account token without onboarding) to create an account with an incrementing ID with no risk of reversion. Open to renaming to something other than `mintNext`.