### PR TITLE
Fix debt share snapshot id type

### DIFF
--- a/packages/synthetix-governance/contracts/interfaces/IDebtShare.sol
+++ b/packages/synthetix-governance/contracts/interfaces/IDebtShare.sol
@@ -2,5 +2,5 @@
 pragma solidity ^0.8.0;
 
 interface IDebtShare {
-    function balanceOfOnPeriod(address account, uint128 periodId) external view returns (uint);
+    function balanceOfOnPeriod(address account, uint periodId) external view returns (uint);
 }

--- a/packages/synthetix-governance/contracts/interfaces/ISynthetixElectionModule.sol
+++ b/packages/synthetix-governance/contracts/interfaces/ISynthetixElectionModule.sol
@@ -27,10 +27,10 @@ interface ISynthetixElectionModule is IBaseElectionModule {
     function getDebtShareContract() external view returns (address);
 
     /// @notice Sets the Synthetix v2 DebtShare snapshot that determines vote power for this epoch
-    function setDebtShareSnapshotId(uint128 snapshotId) external;
+    function setDebtShareSnapshotId(uint snapshotId) external;
 
     /// @notice Returns the Synthetix v2 DebtShare snapshot id set for this epoch
-    function getDebtShareSnapshotId() external view returns (uint128);
+    function getDebtShareSnapshotId() external view returns (uint);
 
     /// @notice Returns the Synthetix v2 debt share for the provided address, at this epoch's snapshot
     function getDebtShare(address user) external view returns (uint);

--- a/packages/synthetix-governance/contracts/mocks/DebtShareMock.sol
+++ b/packages/synthetix-governance/contracts/mocks/DebtShareMock.sol
@@ -8,20 +8,20 @@ contract DebtShareMock is IDebtShare {
         mapping(address => uint) balances;
     }
 
-    mapping(uint => Period) private _periods;
+    mapping(uint128 => Period) private _periods;
 
     function setBalanceOfOnPeriod(
         address user,
         uint balance,
         uint periodId
     ) external {
-        Period storage period = _periods[periodId];
+        Period storage period = _periods[uint128(periodId)];
 
         period.balances[user] = balance;
     }
 
     function balanceOfOnPeriod(address user, uint periodId) external view virtual override returns (uint) {
-        Period storage period = _periods[periodId];
+        Period storage period = _periods[uint128(periodId)];
 
         return period.balances[user];
     }

--- a/packages/synthetix-governance/contracts/mocks/DebtShareMock.sol
+++ b/packages/synthetix-governance/contracts/mocks/DebtShareMock.sol
@@ -8,19 +8,19 @@ contract DebtShareMock is IDebtShare {
         mapping(address => uint) balances;
     }
 
-    mapping(uint128 => Period) private _periods;
+    mapping(uint => Period) private _periods;
 
     function setBalanceOfOnPeriod(
         address user,
         uint balance,
-        uint128 periodId
+        uint periodId
     ) external {
         Period storage period = _periods[periodId];
 
         period.balances[user] = balance;
     }
 
-    function balanceOfOnPeriod(address user, uint128 periodId) external view virtual override returns (uint) {
+    function balanceOfOnPeriod(address user, uint periodId) external view virtual override returns (uint) {
         Period storage period = _periods[periodId];
 
         return period.balances[user];

--- a/packages/synthetix-governance/contracts/modules/ElectionModule.sol
+++ b/packages/synthetix-governance/contracts/modules/ElectionModule.sol
@@ -83,11 +83,11 @@ contract ElectionModule is ISynthetixElectionModule, BaseElectionModule, DebtSha
         return address(_debtShareStore().debtShareContract);
     }
 
-    function setDebtShareSnapshotId(uint128 snapshotId) external override onlyOwner onlyInPeriod(ElectionPeriod.Nomination) {
+    function setDebtShareSnapshotId(uint snapshotId) external override onlyOwner onlyInPeriod(ElectionPeriod.Nomination) {
         _setDebtShareSnapshotId(snapshotId);
     }
 
-    function getDebtShareSnapshotId() external view override returns (uint128) {
+    function getDebtShareSnapshotId() external view override returns (uint) {
         return _getDebtShareSnapshotId();
     }
 

--- a/packages/synthetix-governance/contracts/storage/DebtShareStorage.sol
+++ b/packages/synthetix-governance/contracts/storage/DebtShareStorage.sol
@@ -9,7 +9,7 @@ contract DebtShareStorage {
         // Synthetix c2 DebtShare contract used to determine vote power in the local chain
         IDebtShare debtShareContract;
         // Array of debt share snapshot id's for each epoch
-        uint[] debtShareIds;
+        uint128[] debtShareIds;
         // Array of CrossChainDebtShareData's for each epoch
         CrossChainDebtShareData[] crossChainDebtShareData;
     }

--- a/packages/synthetix-governance/contracts/storage/DebtShareStorage.sol
+++ b/packages/synthetix-governance/contracts/storage/DebtShareStorage.sol
@@ -9,7 +9,7 @@ contract DebtShareStorage {
         // Synthetix c2 DebtShare contract used to determine vote power in the local chain
         IDebtShare debtShareContract;
         // Array of debt share snapshot id's for each epoch
-        uint128[] debtShareIds;
+        uint[] debtShareIds;
         // Array of CrossChainDebtShareData's for each epoch
         CrossChainDebtShareData[] crossChainDebtShareData;
     }

--- a/packages/synthetix-governance/contracts/submodules/election/DebtShareManager.sol
+++ b/packages/synthetix-governance/contracts/submodules/election/DebtShareManager.sol
@@ -13,9 +13,9 @@ contract DebtShareManager is ElectionBase, DebtShareStorage {
     error DebtShareSnapshotIdNotSet();
 
     event DebtShareContractSet(address contractAddress);
-    event DebtShareSnapshotIdSet(uint128 snapshotId);
+    event DebtShareSnapshotIdSet(uint snapshotId);
 
-    function _setDebtShareSnapshotId(uint128 snapshotId) internal {
+    function _setDebtShareSnapshotId(uint snapshotId) internal {
         DebtShareStore storage store = _debtShareStore();
 
         uint currentEpochIndex = _getCurrentEpochIndex();
@@ -24,10 +24,10 @@ contract DebtShareManager is ElectionBase, DebtShareStorage {
         emit DebtShareSnapshotIdSet(snapshotId);
     }
 
-    function _getDebtShareSnapshotId() internal view returns (uint128) {
+    function _getDebtShareSnapshotId() internal view returns (uint) {
         DebtShareStore storage store = _debtShareStore();
 
-        uint128 debtShareId = store.debtShareIds[_getCurrentEpochIndex()];
+        uint debtShareId = store.debtShareIds[_getCurrentEpochIndex()];
         if (debtShareId == 0) {
             revert DebtShareSnapshotIdNotSet();
         }
@@ -56,7 +56,7 @@ contract DebtShareManager is ElectionBase, DebtShareStorage {
     function _getDebtShare(address user) internal view returns (uint) {
         DebtShareStore storage store = _debtShareStore();
 
-        uint128 debtShareId = store.debtShareIds[_getCurrentEpochIndex()];
+        uint debtShareId = store.debtShareIds[_getCurrentEpochIndex()];
 
         return store.debtShareContract.balanceOfOnPeriod(user, debtShareId);
     }

--- a/packages/synthetix-governance/contracts/submodules/election/DebtShareManager.sol
+++ b/packages/synthetix-governance/contracts/submodules/election/DebtShareManager.sol
@@ -19,7 +19,7 @@ contract DebtShareManager is ElectionBase, DebtShareStorage {
         DebtShareStore storage store = _debtShareStore();
 
         uint currentEpochIndex = _getCurrentEpochIndex();
-        store.debtShareIds[currentEpochIndex] = snapshotId;
+        store.debtShareIds[currentEpochIndex] = uint128(snapshotId);
 
         emit DebtShareSnapshotIdSet(snapshotId);
     }
@@ -27,7 +27,7 @@ contract DebtShareManager is ElectionBase, DebtShareStorage {
     function _getDebtShareSnapshotId() internal view returns (uint) {
         DebtShareStore storage store = _debtShareStore();
 
-        uint debtShareId = store.debtShareIds[_getCurrentEpochIndex()];
+        uint128 debtShareId = store.debtShareIds[_getCurrentEpochIndex()];
         if (debtShareId == 0) {
             revert DebtShareSnapshotIdNotSet();
         }
@@ -56,8 +56,8 @@ contract DebtShareManager is ElectionBase, DebtShareStorage {
     function _getDebtShare(address user) internal view returns (uint) {
         DebtShareStore storage store = _debtShareStore();
 
-        uint debtShareId = store.debtShareIds[_getCurrentEpochIndex()];
+        uint128 debtShareId = store.debtShareIds[_getCurrentEpochIndex()];
 
-        return store.debtShareContract.balanceOfOnPeriod(user, debtShareId);
+        return store.debtShareContract.balanceOfOnPeriod(user, uint(debtShareId));
     }
 }


### PR DESCRIPTION
This fix updates the expected `snapshotId` type from `uint128` to `uint`, so, it has the same interface than the one deployed on Synthetix V2: https://github.com/Synthetixio/synthetix/blob/develop/contracts/SynthetixDebtShare.sol#L98:L112

This was causing an error when trying to get the user's debt share with the `ElectionModule.getDebtShare(address)` method.