### PR TITLE
Add next epoch validation scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14401,7 +14401,8 @@
     },
     "packages/core-contracts": {
       "name": "@synthetixio/core-contracts",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "license": "MIT"
     },
     "packages/core-js": {
       "name": "@synthetixio/core-js",

--- a/packages/scripts/data/councils-epoch-0.json
+++ b/packages/scripts/data/councils-epoch-0.json
@@ -1,0 +1,58 @@
+[
+  {
+    "name": "ambassador-council",
+    "owner": "0x6cd3f878852769e04A723A5f66CA7DD4d9E38A6C",
+    "nominatedOwner": "0x0000000000000000000000000000000000000000",
+    "getNominationPeriodStartDate": "2022-06-10",
+    "getVotingPeriodStartDate": "2022-06-17",
+    "getEpochEndDate": "2022-07-01",
+    "getNextEpochSeatCount": 3,
+    "councilTokenName": "Synthetix Ambassador Council Token",
+    "councilTokenSymbol": "SNX-ACT",
+    "getCouncilMembers": [
+      "0xDe910777C787903F78C89e7a0bf7F4C435cBB1Fe"
+    ]
+  },
+  {
+    "name": "grants-council",
+    "owner": "0x6cd3f878852769e04A723A5f66CA7DD4d9E38A6C",
+    "nominatedOwner": "0x0000000000000000000000000000000000000000",
+    "getNominationPeriodStartDate": "2022-06-10",
+    "getVotingPeriodStartDate": "2022-06-17",
+    "getEpochEndDate": "2022-07-01",
+    "getNextEpochSeatCount": 5,
+    "councilTokenName": "Synthetix Grants Council Token",
+    "councilTokenSymbol": "SNX-GCT",
+    "getCouncilMembers": [
+      "0xDe910777C787903F78C89e7a0bf7F4C435cBB1Fe"
+    ]
+  },
+  {
+    "name": "spartan-council",
+    "owner": "0x6cd3f878852769e04A723A5f66CA7DD4d9E38A6C",
+    "nominatedOwner": "0x0000000000000000000000000000000000000000",
+    "getNominationPeriodStartDate": "2022-06-10",
+    "getVotingPeriodStartDate": "2022-06-17",
+    "getEpochEndDate": "2022-07-01",
+    "getNextEpochSeatCount": 8,
+    "councilTokenName": "Synthetix Spartan Council Token",
+    "councilTokenSymbol": "SNX-SCT",
+    "getCouncilMembers": [
+      "0xDe910777C787903F78C89e7a0bf7F4C435cBB1Fe"
+    ]
+  },
+  {
+    "name": "treasury-council",
+    "owner": "0x6cd3f878852769e04A723A5f66CA7DD4d9E38A6C",
+    "nominatedOwner": "0x0000000000000000000000000000000000000000",
+    "getNominationPeriodStartDate": "2022-06-10",
+    "getVotingPeriodStartDate": "2022-06-17",
+    "getEpochEndDate": "2022-07-01",
+    "getNextEpochSeatCount": 4,
+    "councilTokenName": "Synthetix Treasury Council Token",
+    "councilTokenSymbol": "SNX-TCT",
+    "getCouncilMembers": [
+      "0xDe910777C787903F78C89e7a0bf7F4C435cBB1Fe"
+    ]
+  }
+]

--- a/packages/scripts/data/councils-epoch-1.json
+++ b/packages/scripts/data/councils-epoch-1.json
@@ -1,0 +1,46 @@
+[
+  {
+    "name": "ambassador-council",
+    "owner": "0x6cd3f878852769e04A723A5f66CA7DD4d9E38A6C",
+    "nominatedOwner": "0x0000000000000000000000000000000000000000",
+    "getNominationPeriodStartDate": "2022-07-12T11:46:21.000Z",
+    "getVotingPeriodStartDate": "2022-07-19T11:46:21.000Z",
+    "getEpochEndDate": "2022-08-02T11:46:21.000Z",
+    "getNextEpochSeatCount": 3,
+    "councilTokenName": "Synthetix Ambassador Council Token",
+    "councilTokenSymbol": "SNX-ACT"
+  },
+  {
+    "name": "grants-council",
+    "owner": "0x6cd3f878852769e04A723A5f66CA7DD4d9E38A6C",
+    "nominatedOwner": "0x0000000000000000000000000000000000000000",
+    "getNominationPeriodStartDate": "2022-07-12T11:41:40.000Z",
+    "getVotingPeriodStartDate": "2022-07-19T11:41:40.000Z",
+    "getEpochEndDate": "2022-08-02T11:41:40.000Z",
+    "getNextEpochSeatCount": 5,
+    "councilTokenName": "Synthetix Grants Council Token",
+    "councilTokenSymbol": "SNX-GCT"
+  },
+  {
+    "name": "spartan-council",
+    "owner": "0x6cd3f878852769e04A723A5f66CA7DD4d9E38A6C",
+    "nominatedOwner": "0x0000000000000000000000000000000000000000",
+    "getNominationPeriodStartDate": "2022-07-12T11:40:43.000Z",
+    "getVotingPeriodStartDate": "2022-07-19T11:40:43.000Z",
+    "getEpochEndDate": "2022-08-02T11:40:43.000Z",
+    "getNextEpochSeatCount": 8,
+    "councilTokenName": "Synthetix Spartan Council Token",
+    "councilTokenSymbol": "SNX-SCT"
+  },
+  {
+    "name": "treasury-council",
+    "owner": "0x6cd3f878852769e04A723A5f66CA7DD4d9E38A6C",
+    "nominatedOwner": "0x0000000000000000000000000000000000000000",
+    "getNominationPeriodStartDate": "2022-07-12T11:38:12.000Z",
+    "getVotingPeriodStartDate": "2022-07-19T11:38:12.000Z",
+    "getEpochEndDate": "2022-08-02T11:38:12.000Z",
+    "getNextEpochSeatCount": 4,
+    "councilTokenName": "Synthetix Treasury Council Token",
+    "councilTokenSymbol": "SNX-TCT"
+  }
+]

--- a/packages/scripts/data/councils-epoch-1.json
+++ b/packages/scripts/data/councils-epoch-1.json
@@ -7,6 +7,13 @@
     "getVotingPeriodStartDate": "2022-07-19T11:46:21.000Z",
     "getEpochEndDate": "2022-08-02T11:46:21.000Z",
     "getNextEpochSeatCount": 3,
+    "getEpochIndex": 1,
+    "getCurrentPeriod": 0,
+    "members": [
+      "0x585639fBf797c1258eBA8875c080Eb63C833d252",
+      "0x98Ab20307fdABa1ce8b16d69d22461c6dbe85459",
+      "0xF68D2BfCecd7895BBa05a7451Dd09A1749026454"
+    ],
     "councilTokenName": "Synthetix Ambassador Council Token",
     "councilTokenSymbol": "SNX-ACT"
   },
@@ -18,6 +25,15 @@
     "getVotingPeriodStartDate": "2022-07-19T11:41:40.000Z",
     "getEpochEndDate": "2022-08-02T11:41:40.000Z",
     "getNextEpochSeatCount": 5,
+    "getEpochIndex": 1,
+    "getCurrentPeriod": 0,
+    "members": [
+      "0xE1f02F7E90ea5F21D0AC6F12c659C3484c143B03",
+      "0x1a207bEefC754735871CEEb4C506686F044B1c41",
+      "0x4f370B4d03D2b46CcE26F1aEFE142708E03D7FFE",
+      "0x8be60fe9F7C8d940D8DA9d5dDD0D8E0c15A4288B",
+      "0xbF49B454818783D12Bf4f3375ff17C59015e66Cb"
+    ],
     "councilTokenName": "Synthetix Grants Council Token",
     "councilTokenSymbol": "SNX-GCT"
   },
@@ -29,6 +45,18 @@
     "getVotingPeriodStartDate": "2022-07-19T11:40:43.000Z",
     "getEpochEndDate": "2022-08-02T11:40:43.000Z",
     "getNextEpochSeatCount": 8,
+    "getEpochIndex": 1,
+    "getCurrentPeriod": 0,
+    "members": [
+      "0x45a10F35BeFa4aB841c77860204b133118B7CcAE",
+      "0x42f9134E9d3Bf7eEE1f8A5Ac2a4328B059E7468c",
+      "0xA9903BDA477b9A57BD795AdFf9922cB98DB65F04",
+      "0x0bc3668d2AaFa53eD5E5134bA13ec74ea195D000",
+      "0x656b7f17933eE35058d1Beb8b6c65B580E799440",
+      "0x1f2B0633BB0623dCCebE57932d6731Ae93f5213E",
+      "0xA41228DE09fD143727d6337585C6b02C698146BC",
+      "0xDF09B6BB09FdEe5f8d4c17C6642F0A54D6A7654A"
+    ],
     "councilTokenName": "Synthetix Spartan Council Token",
     "councilTokenSymbol": "SNX-SCT"
   },
@@ -40,6 +68,14 @@
     "getVotingPeriodStartDate": "2022-07-19T11:38:12.000Z",
     "getEpochEndDate": "2022-08-02T11:38:12.000Z",
     "getNextEpochSeatCount": 4,
+    "getEpochIndex": 1,
+    "getCurrentPeriod": 0,
+    "members": [
+      "0x604F127145CAC2467389124f0871227D3fD6F628",
+      "0xD09583bBf77D0Da34Cd02612Fe41aF4AE37ebC95",
+      "0xf04A6E38C6CFE0AcFbeB472888ed990787e69072",
+      "0x0e859372c72b01cc86BD4B6dF28Dd57E08226A1a"
+    ],
     "councilTokenName": "Synthetix Treasury Council Token",
     "councilTokenSymbol": "SNX-TCT"
   }

--- a/packages/scripts/data/councils-epoch-1.json
+++ b/packages/scripts/data/councils-epoch-1.json
@@ -9,7 +9,7 @@
     "getNextEpochSeatCount": 3,
     "getEpochIndex": 1,
     "getCurrentPeriod": 0,
-    "members": [
+    "getCouncilMembers": [
       "0x585639fBf797c1258eBA8875c080Eb63C833d252",
       "0x98Ab20307fdABa1ce8b16d69d22461c6dbe85459",
       "0xF68D2BfCecd7895BBa05a7451Dd09A1749026454"
@@ -27,7 +27,7 @@
     "getNextEpochSeatCount": 5,
     "getEpochIndex": 1,
     "getCurrentPeriod": 0,
-    "members": [
+    "getCouncilMembers": [
       "0xE1f02F7E90ea5F21D0AC6F12c659C3484c143B03",
       "0x1a207bEefC754735871CEEb4C506686F044B1c41",
       "0x4f370B4d03D2b46CcE26F1aEFE142708E03D7FFE",
@@ -47,7 +47,7 @@
     "getNextEpochSeatCount": 8,
     "getEpochIndex": 1,
     "getCurrentPeriod": 0,
-    "members": [
+    "getCouncilMembers": [
       "0x45a10F35BeFa4aB841c77860204b133118B7CcAE",
       "0x42f9134E9d3Bf7eEE1f8A5Ac2a4328B059E7468c",
       "0xA9903BDA477b9A57BD795AdFf9922cB98DB65F04",
@@ -70,7 +70,7 @@
     "getNextEpochSeatCount": 4,
     "getEpochIndex": 1,
     "getCurrentPeriod": 0,
-    "members": [
+    "getCouncilMembers": [
       "0x604F127145CAC2467389124f0871227D3fD6F628",
       "0xD09583bBf77D0Da34Cd02612Fe41aF4AE37ebC95",
       "0xf04A6E38C6CFE0AcFbeB472888ed990787e69072",

--- a/packages/scripts/internal/import-json.js
+++ b/packages/scripts/internal/import-json.js
@@ -1,0 +1,7 @@
+const fs = require('fs/promises');
+const path = require('path');
+
+module.exports = async function importJson(location) {
+  const data = await fs.readFile(path.resolve(location));
+  return JSON.parse(data.toString());
+};

--- a/packages/scripts/tasks/validate-councils.js
+++ b/packages/scripts/tasks/validate-councils.js
@@ -73,6 +73,8 @@ async function validateCouncil({ Proxy, Token, council, epoch }) {
   await expect(Proxy, 'getVotingPeriodStartDate', date(council.getVotingPeriodStartDate));
   await expect(Proxy, 'getEpochEndDate', date(council.getEpochEndDate));
   await expect(Proxy, 'getNextEpochSeatCount', council.getNextEpochSeatCount);
+  await expect(Proxy, 'getEpochIndex', council.getEpochIndex);
+  await expect(Proxy, 'getCurrentPeriod', council.getCurrentPeriod);
 
   if (council.getCouncilMembers) {
     await expect(Proxy, 'getCouncilMembers', council.getCouncilMembers);
@@ -113,7 +115,7 @@ async function expect(Contract, methodName, ...args) {
     }
 
     logger.success(`${methodName}(${paramsStr}) is ${JSON.stringify(actual)}`);
-  } catch (err) {
+  } catch (_) {
     logger.error(
       `${methodName}(${paramsStr}) expected ${JSON.stringify(expected)}, but got ${JSON.stringify(
         actual

--- a/packages/scripts/tasks/validate-councils.js
+++ b/packages/scripts/tasks/validate-councils.js
@@ -73,7 +73,10 @@ async function validateCouncil({ Proxy, Token, council, epoch }) {
   await expect(Proxy, 'getVotingPeriodStartDate', date(council.getVotingPeriodStartDate));
   await expect(Proxy, 'getEpochEndDate', date(council.getEpochEndDate));
   await expect(Proxy, 'getNextEpochSeatCount', council.getNextEpochSeatCount);
-  await expect(Proxy, 'getCouncilMembers', council.getCouncilMembers);
+
+  if (council.getCouncilMembers) {
+    await expect(Proxy, 'getCouncilMembers', council.getCouncilMembers);
+  }
 
   // Validate Council Token
   logger.log(chalk.gray('CouncilToken Validations:'));
@@ -101,6 +104,7 @@ async function expect(Contract, methodName, ...args) {
   const result = await Contract[methodName](...fnParams);
   const actual = typeof expected === 'number' ? Number(result) : result;
 
+  const paramsStr = fnParams.map(JSON.stringify).join(', ');
   try {
     if (['Array', 'Object'].includes(typeOf(expected))) {
       deepEqual(actual, expected);
@@ -108,9 +112,12 @@ async function expect(Contract, methodName, ...args) {
       equal(actual, expected);
     }
 
-    const params = fnParams.map(JSON.stringify).join(', ');
-    logger.success(`${methodName}(${params}) is ${JSON.stringify(expected)}`);
+    logger.success(`${methodName}(${paramsStr}) is ${JSON.stringify(actual)}`);
   } catch (err) {
-    logger.error(`Expected ${expected} for ${methodName}, but given ${actual}\n${err}`);
+    logger.error(
+      `${methodName}(${paramsStr}) expected ${JSON.stringify(expected)}, but got ${JSON.stringify(
+        actual
+      )}`
+    );
   }
 }


### PR DESCRIPTION
Closes https://github.com/Synthetixio/project-management/issues/77

This PR adds:
* The ability to validate different epochs (so we can validate a future epoch)
* Validates that all council members have one `CouncilToken`
* Moves data to validate to separate json files


## Notes
* This PR adds a check to confirm that all current council members own a `CouncilToken`. But, I was not able to validate that only exists the amount of `CouncilToken`'s equal to the amount of council members. This second case could by caused by a bug on the `ElectionModule.resolve()` function not burning old tokens.