### PR TITLE
sip 305 liquidation final

### DIFF
--- a/packages/core-utils/utils/assertions/assert-bignumber.ts
+++ b/packages/core-utils/utils/assertions/assert-bignumber.ts
@@ -79,4 +79,24 @@ export = {
       });
     }
   },
+
+  /**
+   * Assert if `a` is within a small range of `b`
+   */
+  near: (a: BigNumberish, b: BigNumberish, tolerance: BigNumberish = 10000) => () => {
+    const abn = BigNumber.from(a);
+    const bbn = BigNumber.from(b);
+    const tolerancebn = BigNumber.from(tolerance);
+
+    const lower = bbn.sub(tolerancebn);
+    const upper = bbn.add(tolerancebn);
+
+    if (abn.lt(lower) || abn.gt(upper)) {
+      throw new BigNumberAssertionError({
+        actual: abn,
+        expected: bbn,
+        operator: 'near'
+      })
+    }
+  },
 };

--- a/packages/synthetix-main/contracts/interfaces/ICollateralModule.sol
+++ b/packages/synthetix-main/contracts/interfaces/ICollateralModule.sol
@@ -11,6 +11,7 @@ interface ICollateralModule {
         address priceFeed,
         uint targetCRatio,
         uint minimumCRatio,
+        uint liquidationReward,
         bool enabled
     ) external;
 

--- a/packages/synthetix-main/contracts/interfaces/ILiquidationModule.sol
+++ b/packages/synthetix-main/contracts/interfaces/ILiquidationModule.sol
@@ -18,10 +18,14 @@ interface ILiquidationModule {
         address collateralType
     ) external returns (uint amountRewarded, uint debtLiquidated, uint collateralLiquidated);
 
-    /// @notice liquidates an entire vault. can only be done if the vault itself is undercollateralized
+    /// @notice liquidates an entire vault. can only be done if the vault itself is undercollateralized. 
+    /// liquidateAsAccountId determines which account to deposit the siezed collateral into (this is necessary particularly if the collateral in the vault is vesting)
+    /// Will only liquidate a portion of the debt for the vault if `maxUsd` is supplied
     function liquidateVault(
         uint fundId,
-        address collateralType
+        address collateralType,
+        uint liquidateAsAccountId,
+        uint maxUsd
     ) external returns (uint amountRewarded, uint collateralLiquidated);
 
     /// @notice returns if the account is liquidable on the fundId - collateralType pair

--- a/packages/synthetix-main/contracts/interfaces/IVaultModule.sol
+++ b/packages/synthetix-main/contracts/interfaces/IVaultModule.sol
@@ -65,10 +65,4 @@ interface IVaultModule {
 
     /// @notice gets the total fund debtShares
     function totalVaultShares(uint fundId, address collateralType) external view returns (uint);
-
-    /// @notice gets the debt per share (USD value) for a fund
-    function debtPerShare(uint fundId, address collateralType) external returns (int);
-
-    /// @notice gets liquidityItem details for a liquidityItemId
-    function getLiquidityItem(bytes32 liquidityItemId) external view returns (FundVaultStorage.LiquidityItem memory liquidityItem);
 }

--- a/packages/synthetix-main/contracts/interfaces/IVaultModule.sol
+++ b/packages/synthetix-main/contracts/interfaces/IVaultModule.sol
@@ -33,7 +33,7 @@ interface IVaultModule {
         uint amount
     ) external;
 
-    /// @notice gets the CRatio for an account/collateral in a fund
+    /// @notice gets the account collateral value divided by the latest vault debt
     function accountCollateralRatio(
         uint accountId,
         uint fundId,
@@ -59,6 +59,9 @@ interface IVaultModule {
 
     /// @notice gets total vault collateral and its value
     function vaultCollateral(uint fundId, address collateralType) external returns (uint amount, uint value);
+
+    /// @notice gets the vault collateral value divided by latest vault debt
+    function vaultCollateralRatio(uint fundId, address collateralType) external returns (uint);
 
     /// @notice gets the total fund debtShares
     function totalVaultShares(uint fundId, address collateralType) external view returns (uint);

--- a/packages/synthetix-main/contracts/mixins/CollateralMixin.sol
+++ b/packages/synthetix-main/contracts/mixins/CollateralMixin.sol
@@ -84,4 +84,18 @@ contract CollateralMixin is CollateralStorage {
     function _getCollateralLiquidationReward(address collateralType) internal view returns (uint) {
         return _collateralStore().collateralsData[collateralType].liquidationReward;
     }
+
+    function _depositCollateral(uint accountId, address collateralType, uint amount) internal {
+        StakedCollateralData storage collateralData = _collateralStore().stakedCollateralsDataByAccountId[accountId][
+            collateralType
+        ];
+
+        if (!collateralData.isSet) {
+            // new collateral
+            collateralData.isSet = true;
+            collateralData.amount = amount;
+        } else {
+            collateralData.amount += amount;
+        }
+    }
 }

--- a/packages/synthetix-main/contracts/mixins/MarketManagerMixin.sol
+++ b/packages/synthetix-main/contracts/mixins/MarketManagerMixin.sol
@@ -36,7 +36,7 @@ contract MarketManagerMixin is MarketManagerStorage {
         uint oldLiquidity = marketData.debtDist.getActorShares(bytes32(fundId));
         int oldFundMaxDebtShareValue = -marketData.fundMaxDebtShares.getById(uint128(fundId)).priority;
         uint oldTotalLiquidity = marketData.debtDist.totalShares;
-        debtChange = marketData.debtDist.updateDistributionActor(bytes32(fundId), newLiquidity);
+        debtChange = marketData.debtDist.updateActorShares(bytes32(fundId), newLiquidity);
 
         // recalculate max market debt share
         int newMarketMaxShareValue = newFundMaxShareValue;
@@ -84,7 +84,7 @@ contract MarketManagerMixin is MarketManagerStorage {
 
 
             // detach market from fund
-            marketData.debtDist.updateDistributionActor(bytes32(uint(nextRemove.id)), 0);
+            marketData.debtDist.updateActorShares(bytes32(uint(nextRemove.id)), 0);
         }
 
         // todo: loop for putting funds back in as well?

--- a/packages/synthetix-main/contracts/modules/core/LiquidationModule.sol
+++ b/packages/synthetix-main/contracts/modules/core/LiquidationModule.sol
@@ -6,19 +6,27 @@ import "../../storage/LiquidationModuleStorage.sol";
 
 import "../../mixins/CollateralMixin.sol";
 import "../../mixins/FundMixin.sol";
+import "../../mixins/AccountRBACMixin.sol";
+import "@synthetixio/core-modules/contracts/mixins/AssociatedSystemsMixin.sol";
 
 import "../../utils/ERC20Helper.sol";
 import "../../utils/SharesLibrary.sol";
 
-contract LiquidationsModule is ILiquidationModule, LiquidationModuleStorage, CollateralMixin, FundMixin {
+
+contract LiquidationsModule is ILiquidationModule, LiquidationModuleStorage, AssociatedSystemsMixin, CollateralMixin, FundMixin, AccountRBACMixin {
 
     using MathUtil for uint;
     using ERC20Helper for address;
     using SharesLibrary for SharesLibrary.Distribution;
 
     event Liquidation(uint indexed accountId, uint indexed fundId, address indexed collateralType, uint debtLiquidated, uint collateralLiquidated, uint amountRewarded);
+    event VaultLiquidation(uint indexed fundId, address indexed collateralType, uint debtLiquidated, uint collateralLiquidated, uint amountRewarded);
 
     error IneligibleForLiquidation(uint collateralValue, uint debt, uint currentCRatio, uint cratio);
+
+    error MustBeVaultLiquidated();
+
+    bytes32 private constant _USD_TOKEN = "USDToken";
 
     function liquidate(
         uint accountId,
@@ -35,7 +43,7 @@ contract LiquidationsModule is ILiquidationModule, LiquidationModuleStorage, Col
             revert IneligibleForLiquidation(
                 collateralValue, 
                 debtLiquidated, 
-                collateralValue.divDecimal(debtLiquidated), 
+                debtLiquidated == 0 ? 0 : collateralValue.divDecimal(debtLiquidated), 
                 _getCollateralMinimumCRatio(collateralType)
             );
         }
@@ -48,18 +56,21 @@ contract LiquidationsModule is ILiquidationModule, LiquidationModuleStorage, Col
             _getLiquidityItemId(accountId, fundId, collateralType)
         ];
 
+        uint oldShares = vaultData.debtDist.getActorShares(bytes32(accountId));
+
+        if (vaultData.debtDist.totalShares == oldShares) {
+            // will be left with 0 shares, which can't be socialized
+            revert MustBeVaultLiquidated();
+        }
+
         // take away all the user's shares. by not giving the user back their portion of collateral, it will be
         // auto split proportionally between all debt holders
-        uint oldShares = vaultData.debtDist.getActorShares(bytes32(accountId));
         vaultData.debtDist.updateDistributionActor(bytes32(accountId), 0);
         
         // feed the debt back into the vault
         vaultData.debtDist.distribute(int(debtLiquidated));
 
-        // update debt adjustments
-        vaultData.sharesMultiplier = uint128(uint(vaultData.sharesMultiplier).mulDecimal(
-            (oldShares + vaultData.debtDist.totalShares) / vaultData.debtDist.totalShares
-        ));
+        _applyLiquidationToMultiplier(fundId, collateralType, oldShares);
 
         // TODO: adjust global rewards curve to temp lock user's acquired assets
 
@@ -72,9 +83,10 @@ contract LiquidationsModule is ILiquidationModule, LiquidationModuleStorage, Col
 
         // send reward
         amountRewarded = _getCollateralLiquidationReward(collateralType);
+        vaultData.totalCollateral -= uint128(amountRewarded);
         collateralType.safeTransfer(msg.sender, amountRewarded);
 
-        // TODO: send any remaining collateral to the liquidated account
+        // TODO: send any remaining collateral to the liquidated account? need to have a liquidation penalty setting or something
 
         emit Liquidation(accountId, fundId, collateralType, debtLiquidated, collateralLiquidated, amountRewarded);
     }
@@ -82,9 +94,61 @@ contract LiquidationsModule is ILiquidationModule, LiquidationModuleStorage, Col
 
     function liquidateVault(
         uint fundId,
-        address collateralType
-    ) external override returns (uint amountRewarded, uint collateralLiquidated) {
-        // 'classic' style liquidation for entire value, partial liquidation allow
+        address collateralType,
+        uint liquidateAsAccountId,
+        uint maxUsd
+    ) external override returns (uint amountLiquidated, uint collateralRewarded) {
+        if (_accountOwner(liquidateAsAccountId) == address(0)) {
+            revert InvalidParameters("liquidateAsAccountId", "account is not created");
+        }
+
+        if (maxUsd == 0) {
+            revert InvalidParameters("maxUsd", "must be higher than 0");
+        }
+
+        VaultData storage vaultData = _fundVaultStore().fundVaults[fundId][collateralType];
+
+        int rawVaultDebt = _vaultDebt(fundId, collateralType);
+        
+        uint vaultDebt = rawVaultDebt < 0 ? 0 : uint(rawVaultDebt);
+        
+        uint collateralValue = uint(vaultData.totalCollateral).mulDecimal(_getCollateralValue(collateralType));
+
+        if (!_isLiquidatable(collateralType, vaultDebt, collateralValue)) {
+            revert IneligibleForLiquidation(
+                collateralValue, 
+                vaultDebt, 
+                vaultDebt > 0 ? collateralValue.divDecimal(vaultDebt) : 0, 
+                _getCollateralMinimumCRatio(collateralType)
+            );
+        }
+
+        amountLiquidated = vaultDebt < maxUsd ? vaultDebt : maxUsd;
+        collateralRewarded = vaultData.totalCollateral * amountLiquidated / vaultDebt;
+
+        // pull in USD
+        _getToken(_USD_TOKEN).burn(msg.sender, amountLiquidated);
+
+
+        // repay the debt
+        vaultData.debtDist.distribute(-int(amountLiquidated));
+        vaultData.totalDebt = vaultData.totalDebt - int128(int(amountLiquidated));
+
+        // take away the collateral
+        vaultData.totalCollateral -= uint128(collateralRewarded);
+
+        // award the collateral that was just taken to the specified account
+        _depositCollateral(liquidateAsAccountId, collateralType, collateralRewarded);
+
+        // final fund cleanup
+        if (vaultData.totalCollateral == 0) {
+            vaultData.debtDist.totalShares = 0;
+            vaultData.liquidityMultiplier = 0;
+        }
+
+        // TODO: apply locking curve
+
+        emit VaultLiquidation(fundId, collateralType, amountLiquidated, collateralRewarded, collateralRewarded);
     }
 
     function _isLiquidatable(
@@ -92,6 +156,10 @@ contract LiquidationsModule is ILiquidationModule, LiquidationModuleStorage, Col
         uint debt, 
         uint collateralValue
     ) internal view returns (bool) {
+        if (debt == 0) {
+            return false;
+        }
+
         return collateralValue.divDecimal(debt) < _getCollateralMinimumCRatio(collateralType);
     }
 
@@ -103,5 +171,24 @@ contract LiquidationsModule is ILiquidationModule, LiquidationModuleStorage, Col
         int rawDebt = _updateAccountDebt(accountId, fundId, collateralType);
         (,uint collateralValue,) = _accountCollateral(accountId, fundId, collateralType);
         return rawDebt >= 0 &&  _isLiquidatable(collateralType, uint(rawDebt), collateralValue);
+    }
+
+    function _applyLiquidationToMultiplier(uint fundId, address collateralType, uint liquidatedShares) internal {
+        VaultData storage vaultData = _fundVaultStore().fundVaults[fundId][collateralType];
+
+        uint oldTotalShares = liquidatedShares + vaultData.debtDist.totalShares;
+
+        uint newliquidityMultiplier = uint(vaultData.liquidityMultiplier).mulDecimal(
+            oldTotalShares / vaultData.debtDist.totalShares
+        );
+
+        // update totalLiquidity (to stay exact)
+        _fundModuleStore().funds[fundId].totalLiquidity = 
+            uint128(uint(_fundModuleStore().funds[fundId].totalLiquidity) +
+            uint(vaultData.debtDist.totalShares).mulDecimal(newliquidityMultiplier) -
+            oldTotalShares.mulDecimal(vaultData.liquidityMultiplier));
+
+        // update debt adjustments
+        vaultData.liquidityMultiplier = uint128(newliquidityMultiplier);
     }
 }

--- a/packages/synthetix-main/contracts/storage/FundModuleStorage.sol
+++ b/packages/synthetix-main/contracts/storage/FundModuleStorage.sol
@@ -1,12 +1,16 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import "../utils/SharesLibrary.sol";
+
 contract FundModuleStorage {
     struct FundModuleStore {
         mapping(uint256 => FundData) funds; // fund metadata by fundId
     }
 
     struct FundData {
+        /// @dev fund name
+        string name;
         /// @dev fund owner
         address owner;
         /// @dev nominated fund owner
@@ -15,8 +19,16 @@ contract FundModuleStorage {
         uint256 totalWeights; // sum of distribution weights
         /// @dev fund distribution
         MarketDistribution[] fundDistribution;
-        /// @dev fund name
-        string name;
+
+        /// @dev tracks debt for the fund
+        SharesLibrary.Distribution debtDist;
+
+        /// @dev tracks USD liquidity provided by connected vaults. Unfortunately this value has to be computed/updated separately from shares
+        /// because liquidations can cause share count to deviate from actual liquidity.
+        uint128 totalLiquidity;
+
+        // we might want to use this in the future, can be renamed when that time comes, possibly liquidation related
+        uint128 unused;
     }
 
     /**

--- a/packages/synthetix-main/contracts/storage/FundVaultStorage.sol
+++ b/packages/synthetix-main/contracts/storage/FundVaultStorage.sol
@@ -17,9 +17,6 @@ contract FundVaultStorage {
         
         /// @dev fund vaults (per collateral)
         mapping(uint256 => mapping(address => VaultData)) fundVaults;
-
-        /// @dev tracks debt for each fund
-        mapping(uint256 => SharesLibrary.Distribution) fundDists;
     }
     
     /// @notice LiquidityItem struct definition. Account/CollateralType/FundId uniquiely identifies it
@@ -31,10 +28,13 @@ contract FundVaultStorage {
     }
 
     struct VaultData {
+        /// @dev if vault is fully liquidated, this will be incremented to indicate reset shares
+        uint epoch;
+
         /// @dev cached collateral price
         uint128 collateralPrice;
         /// @dev if there are liquidations, this value will be multiplied by any share counts to determine the value of the shares wrt the rest of the fund
-        uint128 sharesMultiplier;
+        uint128 liquidityMultiplier;
 
         /// @dev the amount of debt accrued. starts at 0. this is technically a cached value, but it is needed for liquidations
         int128 totalDebt;
@@ -42,16 +42,14 @@ contract FundVaultStorage {
         /// @dev total liquidity delegated to this vault
         uint128 totalCollateral;
 
-        /// @dev total USD minted
-
-        /// @dev LiquidityItem ids in this fund
-        SetUtil.Bytes32Set liquidityItemIds;
-
         /// @dev tracks debt for each user
         SharesLibrary.Distribution debtDist;
 
         /// @dev rewards
         RewardDistribution[] rewards;
+
+        /// @dev last epoch which an account was seen for. If this differs from , shares are reset
+        mapping (uint256 => uint) lastEpoch;
     }
 
     struct RewardDistribution {

--- a/packages/synthetix-main/contracts/storage/FundVaultStorage.sol
+++ b/packages/synthetix-main/contracts/storage/FundVaultStorage.sol
@@ -9,8 +9,6 @@ import "../utils/SharesLibrary.sol";
 
 contract FundVaultStorage {
     struct FundVaultStore {
-        /// @dev liquidity items data
-        mapping(bytes32 => LiquidityItem) liquidityItems;
 
         /// @dev collaterals which are currently deposited in the fund
         mapping(uint256 => SetUtil.AddressSet) fundCollateralTypes;
@@ -18,13 +16,22 @@ contract FundVaultStorage {
         /// @dev fund vaults (per collateral)
         mapping(uint256 => mapping(address => VaultData)) fundVaults;
     }
-    
-    /// @notice LiquidityItem struct definition. Account/CollateralType/FundId uniquiely identifies it
-    struct LiquidityItem {
-        uint128 usdMinted;
-        int128 cumulativeDebt;
 
-        uint128 leverage;
+    struct VaultEpochData {
+        /// @dev amount of debt which has not been rolled into `usdDebtDist`. Needed to keep track of overall vaultDebt
+        int128 unclaimedDebt;
+
+        /// @dev if there are liquidations, this value will be multiplied by any share counts to determine the value of the shares wrt the rest of the fund
+        uint128 liquidityMultiplier;
+
+        /// @dev tracks debt for each user
+        SharesLibrary.Distribution debtDist;
+
+        /// @dev tracks collateral for each user
+        SharesLibrary.Distribution collateralDist;
+
+        /// @dev tracks usd for each user
+        SharesLibrary.Distribution usdDebtDist;
     }
 
     struct VaultData {
@@ -33,23 +40,12 @@ contract FundVaultStorage {
 
         /// @dev cached collateral price
         uint128 collateralPrice;
-        /// @dev if there are liquidations, this value will be multiplied by any share counts to determine the value of the shares wrt the rest of the fund
-        uint128 liquidityMultiplier;
-
-        /// @dev the amount of debt accrued. starts at 0. this is technically a cached value, but it is needed for liquidations
-        int128 totalDebt;
-
-        /// @dev total liquidity delegated to this vault
-        uint128 totalCollateral;
 
         /// @dev tracks debt for each user
-        SharesLibrary.Distribution debtDist;
+        mapping(uint => VaultEpochData) epochData;
 
         /// @dev rewards
         RewardDistribution[] rewards;
-
-        /// @dev last epoch which an account was seen for. If this differs from , shares are reset
-        mapping (uint256 => uint) lastEpoch;
     }
 
     struct RewardDistribution {

--- a/packages/synthetix-main/contracts/submodules/FundEventAndErrors.sol
+++ b/packages/synthetix-main/contracts/submodules/FundEventAndErrors.sol
@@ -31,7 +31,6 @@ contract FundEventAndErrors {
 
     event FundPositionSet(uint fundId, uint[] markets, uint[] weights, address executedBy);
     event DelegationUpdated(
-        bytes32 liquidityItemId,
         uint accountId,
         uint fundId,
         address collateralType,

--- a/packages/synthetix-main/contracts/utils/SharesLibrary.sol
+++ b/packages/synthetix-main/contracts/utils/SharesLibrary.sol
@@ -22,9 +22,10 @@ library SharesLibrary {
     }
 
     struct Distribution {
+        // total number of shares
+        uint128 totalShares;
         // total amount of the distribution
         int128 valuePerShare;
-        uint128 totalShares;
 
         // used for tracking individual user ids within 
         mapping(bytes32 => DistributionActor) actorInfo;
@@ -49,7 +50,7 @@ library SharesLibrary {
 
         // instant distribution--immediately disperse amount
         dist.valuePerShare = int128(dist.valuePerShare) + 
-            int128(amount * 1e18 / int(totalShares));
+            int128(amount * 1e27 / int(totalShares));
     }
 
     /**
@@ -74,13 +75,13 @@ library SharesLibrary {
         int curTime = int128(int(block.timestamp));
 
         // ensure any previously active distribution has applied
-        diff += updateDistributionEntry(entry, dist.totalShares);
+        diff += updateEntry(entry, dist.totalShares);
 
         if (start + duration <= uint(curTime)) {
             // update any rewards which may have accrued since last run
 
             // instant distribution--immediately disperse amount
-            diff += amount * 1e18 / int(totalShares);
+            diff += amount * 1e27 / int(totalShares);
 
             entry.lastUpdate = 0;
             entry.start = 0;
@@ -96,18 +97,18 @@ library SharesLibrary {
             // the amount is actually the amount distributed already *plus* whatever has been specified now
             entry.lastUpdate = 0;
 
-            diff += updateDistributionEntry(entry, dist.totalShares);
+            diff += updateEntry(entry, dist.totalShares);
         }
     }
 
     /**
      * call every time before `totalShares` changes
      */
-    function updateDistributionEntry(
+    function updateEntry(
         DistributionEntry storage entry,
-        uint totalShares
+        uint totalSharesAmount
     ) internal returns (int128) {
-        if (entry.scheduledValue == 0 || totalShares == 0) {
+        if (entry.scheduledValue == 0 || totalSharesAmount == 0) {
             // cannot process distributed rewards if a pool is empty.
             return 0;
         }
@@ -123,7 +124,7 @@ library SharesLibrary {
         
         // determine whether this is an instant distribution or a delayed distribution
         if (entry.duration == 0 && entry.lastUpdate < entry.start) {
-            valuePerShareChange = int(entry.scheduledValue) * 1e18 / int(totalShares);
+            valuePerShareChange = int(entry.scheduledValue) * 1e27 / int(totalSharesAmount);
         } else if (entry.lastUpdate < entry.start + entry.duration) {
             // find out what is "newly" distributed
             int lastUpdateDistributed = entry.lastUpdate < entry.start ? 
@@ -137,7 +138,7 @@ library SharesLibrary {
                 curUpdateDistributed = curUpdateDistributed * (curTime - entry.start) / entry.duration;
             }
 
-            valuePerShareChange = int(curUpdateDistributed - lastUpdateDistributed) * 1e18 / int(totalShares);
+            valuePerShareChange = int(curUpdateDistributed - lastUpdateDistributed) * 1e27 / int(totalSharesAmount);
         }
 
         entry.lastUpdate = int32(curTime);
@@ -145,15 +146,21 @@ library SharesLibrary {
         return int128(valuePerShareChange);
     }
 
-    function updateDistributionActor(
+    /**
+     * call this if your actor is "crowding in" to a distribution i.e. they are not contributing anything of their own
+     * in terms of the value fo this. Example uses:
+     * * measuring debt over time
+     * * staking rewards
+     */
+    function updateActorShares(
         Distribution storage dist,
         bytes32 actorId,
         uint shares
-    ) internal returns (int changedAmount) {
+    ) internal returns (int changedValue) {
         DistributionActor storage actor = dist.actorInfo[actorId];
 
         // use the previous number of shares when calculating the changed amount
-        changedAmount = int(dist.valuePerShare - actor.lastValuePerShare) * int(int128(actor.shares)) / 1e18;
+        changedValue = int(dist.valuePerShare - actor.lastValuePerShare) * int(int128(actor.shares)) / 1e27;
 
         dist.totalShares = uint128(dist.totalShares + shares - actor.shares);
 
@@ -161,18 +168,80 @@ library SharesLibrary {
         actor.shares = uint128(shares);
     }
 
-    function getActorValue(
+    /**
+     * same as `updateActorShares`, but doesn't alter the number of shares for the actor
+     */
+    function accumulateActor(
         Distribution storage dist,
         bytes32 actorId
-    ) internal view returns (int value) {
-        return int(dist.valuePerShare) * int128(dist.actorInfo[actorId].shares) / 1e18;
+    ) internal returns (int changedValue) {
+        return updateActorShares(
+            dist,
+            actorId,
+            getActorShares(dist, actorId)
+        );
     }
 
+    /**
+     * call this if your actor is "joining the ride" i.e. they are contributing some value. good use cases for this:
+     * * amount of collateral (ex. when the total collateral amount might change over time)
+     * note: if you do not expect the global value to be scaled/modified, you might choose to store it as the shares in another crowdin distribution instead
+     */
+    function updateActorValue(
+        Distribution storage dist,
+        bytes32 actorId,
+        int value
+    ) internal returns (uint shares) {
+        if (dist.valuePerShare == 0 && dist.totalShares != 0) {
+            revert InvalidParameters("valuePerShare", "shares still exist when no value per share remains");
+        }
+
+        if (dist.totalShares == 0) {
+            dist.valuePerShare = 1e27;
+            shares = uint(value > 0 ? value : -value);
+        }
+        else {
+            shares = uint((value * int128(dist.totalShares)) / totalValue(dist));
+        }
+
+        DistributionActor storage actor = dist.actorInfo[actorId];
+
+        dist.totalShares = uint128(dist.totalShares + shares - actor.shares);
+
+        actor.shares = uint128(shares);
+        // lastValuePerShare remains unset because they contributed
+        
+    }
+
+    /**
+     * get the number of shares recorded for an actor
+     */
     function getActorShares(
         Distribution storage dist,
         bytes32 actorId
     ) internal view returns (uint shares) {
         return dist.actorInfo[actorId].shares;
+    }
+
+    /**
+     * get the total value of the stake
+     * note: if you are trying to calculate accumulation i.e. change in staking value, use `updateActorDistribution` instead
+     */
+    function getActorValue(
+        Distribution storage dist,
+        bytes32 actorId
+    ) internal view returns (int value) {
+        return int(dist.valuePerShare) * int128(dist.actorInfo[actorId].shares) / 1e27;
+    }
+
+    /**
+     * get the total value stored in this pool (that is, dist * )
+     * note: this value means nothing if you are using a "crowding in" pool scheme. store this value outside if you need it.
+     */
+    function totalValue(
+        Distribution storage dist
+    ) internal view returns (int value) {
+        return (int(dist.valuePerShare) * int128(dist.totalShares)) / 1e27;
     }
 
     // returns the number of shares a user should be entitled to if they join an existing distribution with the given
@@ -185,6 +254,6 @@ library SharesLibrary {
             revert InvalidParameters("value", "results in negative shares");
         }
 
-        return uint(value * 1e18 / dist.valuePerShare);
+        return uint(value * 1e27 / dist.valuePerShare);
     }
 }

--- a/packages/synthetix-main/contracts/utils/SharesLibrary.sol
+++ b/packages/synthetix-main/contracts/utils/SharesLibrary.sol
@@ -81,7 +81,7 @@ library SharesLibrary {
             // update any rewards which may have accrued since last run
 
             // instant distribution--immediately disperse amount
-            diff += amount * 1e27 / int(totalShares);
+            diff += amount * 1e18 / int(totalShares);
 
             entry.lastUpdate = 0;
             entry.start = 0;
@@ -124,7 +124,7 @@ library SharesLibrary {
         
         // determine whether this is an instant distribution or a delayed distribution
         if (entry.duration == 0 && entry.lastUpdate < entry.start) {
-            valuePerShareChange = int(entry.scheduledValue) * 1e27 / int(totalSharesAmount);
+            valuePerShareChange = int(entry.scheduledValue) * 1e18 / int(totalSharesAmount);
         } else if (entry.lastUpdate < entry.start + entry.duration) {
             // find out what is "newly" distributed
             int lastUpdateDistributed = entry.lastUpdate < entry.start ? 
@@ -138,7 +138,7 @@ library SharesLibrary {
                 curUpdateDistributed = curUpdateDistributed * (curTime - entry.start) / entry.duration;
             }
 
-            valuePerShareChange = int(curUpdateDistributed - lastUpdateDistributed) * 1e27 / int(totalSharesAmount);
+            valuePerShareChange = int(curUpdateDistributed - lastUpdateDistributed) * 1e18 / int(totalSharesAmount);
         }
 
         entry.lastUpdate = int32(curTime);

--- a/packages/synthetix-main/test/integration/bootstrap.ts
+++ b/packages/synthetix-main/test/integration/bootstrap.ts
@@ -166,7 +166,7 @@ export function bootstrapWithMockMarketAndFund() {
         r.fundId,
         [marketId],
         [ethers.utils.parseEther('1')],
-        [ethers.utils.parseEther('10000000')]
+        [ethers.utils.parseEther('10000000000000000')]
       );
   });
 

--- a/packages/synthetix-main/test/integration/modules/CollateralModuleConfiguration.test.ts
+++ b/packages/synthetix-main/test/integration/modules/CollateralModuleConfiguration.test.ts
@@ -34,7 +34,7 @@ describe('CollateralManagerConfiguration (SCCP)', function () {
     await (
       await systems()
         .Core.connect(systemOwner)
-        .adjustCollateralType(Collateral.address, CollateralPriceFeed.address, 400, 200, false)
+        .adjustCollateralType(Collateral.address, CollateralPriceFeed.address, 400, 200, 0, false)
     ).wait();
   });
 

--- a/packages/synthetix-main/test/integration/modules/CollateralModuleConfiguration.test.ts
+++ b/packages/synthetix-main/test/integration/modules/CollateralModuleConfiguration.test.ts
@@ -76,6 +76,7 @@ describe('CollateralManagerConfiguration (SCCP)', function () {
           AnotherCollateralPriceFeed.address,
           400,
           200,
+          0,
           false
         );
       await tx.wait();
@@ -103,6 +104,7 @@ describe('CollateralManagerConfiguration (SCCP)', function () {
             AnotherCollateralPriceFeed.address,
             300,
             250,
+            0,
             false
           );
         await tx.wait();
@@ -126,6 +128,7 @@ describe('CollateralManagerConfiguration (SCCP)', function () {
             AnotherCollateralPriceFeed.address,
             400,
             200,
+            0,
             false
           );
         await tx.wait();
@@ -178,6 +181,7 @@ describe('CollateralManagerConfiguration (SCCP)', function () {
             OtherCollateralPriceFeed.address,
             400,
             200,
+            0,
             false
           ),
         `Unauthorized("${await user1.getAddress()}")`,
@@ -189,7 +193,7 @@ describe('CollateralManagerConfiguration (SCCP)', function () {
       await assertRevert(
         systems()
           .Core.connect(user1)
-          .adjustCollateralType(Collateral.address, CollateralPriceFeed.address, 300, 250, false),
+          .adjustCollateralType(Collateral.address, CollateralPriceFeed.address, 300, 250, 0, false),
         `Unauthorized("${await user1.getAddress()}")`,
         systems().Core
       );

--- a/packages/synthetix-main/test/integration/modules/CollateralModuleStake.test.ts
+++ b/packages/synthetix-main/test/integration/modules/CollateralModuleStake.test.ts
@@ -37,7 +37,7 @@ describe('CollateralModule Stake', function () {
     await (
       await systems()
         .Core.connect(owner)
-        .adjustCollateralType(Collateral.address, CollateralPriceFeed.address, 400, 200, true)
+        .adjustCollateralType(Collateral.address, CollateralPriceFeed.address, 400, 200, 0, true)
     ).wait();
   });
 

--- a/packages/synthetix-main/test/integration/modules/FundModuleFundAdmin.test.ts
+++ b/packages/synthetix-main/test/integration/modules/FundModuleFundAdmin.test.ts
@@ -34,7 +34,7 @@ describe('FundModule Admin', function () {
     await (
       await systems()
         .Core.connect(owner)
-        .adjustCollateralType(Collateral.address, AggregatorV3Mock.address, 400, 200, true)
+        .adjustCollateralType(Collateral.address, AggregatorV3Mock.address, 400, 200, 0, true)
     ).wait();
   });
 

--- a/packages/synthetix-main/test/integration/modules/LiquidationModule.test.ts
+++ b/packages/synthetix-main/test/integration/modules/LiquidationModule.test.ts
@@ -1,0 +1,270 @@
+import assert from 'assert/strict';
+import assertBn from '@synthetixio/core-utils/dist/utils/assertions/assert-bignumber';
+import assertRevert from '@synthetixio/core-utils/dist/utils/assertions/assert-revert';
+import hre from 'hardhat';
+import { ethers } from 'ethers';
+import { findEvent } from '@synthetixio/core-utils/dist/utils/ethers/events';
+
+import { bootstrap, bootstrapWithMockMarketAndFund } from '../bootstrap';
+
+describe.only('LiquidationModule', function () {
+  const {
+    signers,
+    systems,
+    collateralAddress,
+    collateralContract,
+    fundId,
+    accountId,
+    MockMarket,
+    depositAmount,
+    restore
+  } = bootstrapWithMockMarketAndFund();
+
+  let owner: ethers.Signer, user1: ethers.Signer, user2: ethers.Signer;
+
+  before('identify signers', async () => {
+    [owner, user1, user2] = signers();
+  });
+
+  describe('liquidate()', () => {
+    before(restore);
+
+
+    it('does not allow liquidation of account with healthy c-ratio', async () => {
+      await assertRevert(
+        systems().Core.connect(user1).liquidate(
+          accountId,
+          fundId,
+          collateralAddress(),
+        ),
+        'IneligibleForLiquidation("1000000000000000000000", "0", "0", "1500000000000000000")',
+        systems().Core
+      );
+    });
+
+    describe('account goes into debt', () => {
+      // this should put us very close to 110% c-ratio
+      const debtAmount = depositAmount.mul(ethers.utils.parseEther('1')).div(ethers.utils.parseEther('1.1'));
+
+      before('going into debt', async () => {
+        await MockMarket().connect(user1).setBalance(
+          debtAmount
+        );
+
+        // sanity
+        assertBn.gt(await systems().Core.callStatic.vaultDebt(fundId, collateralAddress()), debtAmount.sub(10000));
+        assertBn.lt(await systems().Core.callStatic.vaultDebt(fundId, collateralAddress()), debtAmount.add(10000));
+      });
+
+      it('cannot liquidate when its the only account in the pool', async () => {
+        assertRevert(
+          systems().Core.connect(user2).liquidate(
+            accountId,
+            fundId,
+            collateralAddress(),
+          ),
+          'MustBeVaultLiquidated()',
+          systems().Core
+        )
+      });
+
+      // a second account is required to "absorb" the debt which is coming from the first account
+      describe('another account joins', () => {
+        const accountId2 = 56857923;
+
+        // this is just the default from elsewhere
+        const liquidationReward = ethers.utils.parseEther('20');
+
+        before('add another account', async () => {
+          await collateralContract().connect(user1).transfer(await user2.getAddress(), depositAmount.mul(10));
+          await collateralContract().connect(user2).approve(systems().Core.address, depositAmount.mul(10));
+          await systems().Core.connect(user2).createAccount(accountId2);
+          await systems().Core.connect(user2).stake(accountId2, collateralAddress(), depositAmount.mul(10));
+
+          // use the zero fund to get minted USD
+          await systems().Core.connect(user2).delegateCollateral(
+            accountId2,
+            fundId,
+            collateralAddress(),
+            depositAmount.mul(10),
+            ethers.utils.parseEther('1')
+          );
+        });
+
+        before('liquidate', async () => {
+          await systems().Core.connect(user2).liquidate(
+            accountId,
+            fundId,
+            collateralAddress(),
+          );
+        });
+
+        it('erases the liquidated account', async () => {
+          assertBn.isZero((await systems().Core.callStatic.accountVaultCollateral(accountId, fundId, collateralAddress()))[0]);
+          assertBn.isZero(await systems().Core.callStatic.accountVaultDebt(accountId, fundId, collateralAddress()));
+        });
+  
+        it('sends correct reward to liquidating address', async () => {
+          assertBn.equal(await collateralContract().balanceOf(await user2.getAddress()), liquidationReward);
+        });
+  
+        it('redistributes debt among remaining staker', async () => {
+          // vault should stilel have same amounts (minus collateral from reward)
+          assertBn.equal((await systems().Core.callStatic.vaultCollateral(fundId, collateralAddress()))[0], depositAmount.mul(11).sub(liquidationReward));
+          assertBn.equal(await systems().Core.callStatic.vaultDebt(fundId, collateralAddress()), debtAmount);
+        });
+
+        it('has correct amount of total liquidity registered to the market', async () => {
+
+        });
+
+        it('emits correct event', async () => {
+
+        });
+      });
+    })
+  });
+
+  describe('liquidateVault()', () => {
+    before(restore);
+
+    it('does not allow liquidation with 0 max usd', async () => {
+      await assertRevert(
+        systems().Core.connect(user1).liquidateVault(
+          fundId,
+          collateralAddress(),
+          accountId,
+          0
+        ),
+        'InvalidParameters("maxUsd',
+        systems().Core
+      );
+    });
+
+    it('does not allow liquidation with an uninitialized account', async () => {
+      await assertRevert(
+        systems().Core.connect(user1).liquidateVault(
+          fundId,
+          collateralAddress(),
+          382387423936,
+          ethers.utils.parseEther('1')
+        ),
+        'InvalidParameters("liquidateAsAccountId',
+        systems().Core
+      )
+    });
+
+    it('does not allow liquidation of vault with healthy c-ratio', async () => {
+      await assertRevert(
+        systems().Core.connect(user1).liquidateVault(
+          fundId,
+          collateralAddress(),
+          accountId,
+          ethers.utils.parseEther('1')
+        ),
+        'IneligibleForLiquidation("1000000000000000000000", "0", "0", "1500000000000000000")',
+        systems().Core
+      );
+    });
+
+    describe('account goes into debt', () => {
+      // this should put us very close to 110% c-ratio
+      const debtAmount = depositAmount.mul(ethers.utils.parseEther('1')).div(ethers.utils.parseEther('1.1'));
+
+      before('going into debt', async () => {
+        await MockMarket().connect(user1).setBalance(
+          debtAmount
+        );
+
+        // sanity
+        assertBn.near(await systems().Core.callStatic.vaultDebt(fundId, collateralAddress()), debtAmount, 10000);
+      });
+
+      describe('successful partial liquidation', () => {
+        const liquidatorAccountId = 384572397362837;
+
+        const liquidatorAccountStartingBalance = debtAmount;
+
+        let preCollateralRatio: ethers.BigNumber;
+
+        before('create liquidator account', async () => {
+          await systems().Core.connect(user2).createAccount(liquidatorAccountId);
+        });
+
+        before('fund liquidator account', async () => {
+          await collateralContract().connect(user1).transfer(await user2.getAddress(), depositAmount.mul(50));
+          await collateralContract().connect(user2).approve(systems().Core.address, depositAmount.mul(50));
+          await systems().Core.connect(user2).stake(liquidatorAccountId, collateralAddress(), depositAmount.mul(50));
+
+          // use the zero fund to get minted USD
+          await systems().Core.connect(user2).delegateCollateral(
+            liquidatorAccountId,
+            0,
+            collateralAddress(),
+            depositAmount.mul(50),
+            ethers.utils.parseEther('1')
+          );
+
+          await systems().Core.connect(user2).mintUSD(liquidatorAccountId, 0, collateralAddress(), liquidatorAccountStartingBalance);
+        });
+
+        before('record collateral ratio', async () => {
+          preCollateralRatio = await systems().Core.callStatic.vaultCollateralRatio(fundId, collateralAddress());
+        });
+
+        before('liquidate', async () => {
+          await systems().Core.connect(user2).liquidateVault(
+            fundId,
+            collateralAddress(),
+            liquidatorAccountId,
+            debtAmount.div(4)
+          );
+        });
+
+        it('deducts USD from the caller', async () => {
+          assertBn.equal(await systems().USD.balanceOf(await user2.getAddress()), liquidatorAccountStartingBalance.sub(debtAmount.div(4)));
+        });
+
+        it('transfers some of vault collateral amount', async () => {
+          const sentAmount = depositAmount.sub((await systems().Core.vaultCollateral(fundId, collateralAddress()))[0]);
+
+          assertBn.near(sentAmount, depositAmount.div(4));
+          assertBn.equal((await systems().Core.getAccountCollateralTotals(liquidatorAccountId, collateralAddress()))[0] , sentAmount.add(depositAmount.mul(50)));
+        });
+
+
+        it('keeps market c-ratio the same', async () => {
+          assertBn.equal(await systems().Core.callStatic.vaultCollateralRatio(fundId, collateralAddress()), preCollateralRatio);
+        });
+
+        it('emits correct event', async () => {
+
+        });
+
+        describe('succesful full liquidation', () => {
+          before('liquidate', async () => {
+            await systems().Core.connect(user2).liquidateVault(
+              fundId,
+              collateralAddress(),
+              liquidatorAccountId,
+              debtAmount,
+            );
+          });
+
+          it('sends collateral to the requested accountId', async() => {
+            assertBn.equal((await systems().Core.getAccountCollateralTotals(liquidatorAccountId, collateralAddress()))[0] , depositAmount.mul(51));
+          });
+
+          it('vault is reset', async () => {
+            assertBn.isZero((await systems().Core.vaultCollateral(fundId, collateralAddress()))[0]);
+            assertBn.isZero(await systems().Core.callStatic.vaultDebt(fundId, collateralAddress()));
+          });
+
+          it('emits correct event', async () => {
+  
+          });
+        });
+      });
+    });
+  });
+});

--- a/packages/synthetix-main/test/integration/modules/LiquidationModule.test.ts
+++ b/packages/synthetix-main/test/integration/modules/LiquidationModule.test.ts
@@ -7,7 +7,7 @@ import { findEvent } from '@synthetixio/core-utils/dist/utils/ethers/events';
 
 import { bootstrap, bootstrapWithMockMarketAndFund } from '../bootstrap';
 
-describe.only('LiquidationModule', function () {
+describe('LiquidationModule', function () {
   const {
     signers,
     systems,

--- a/packages/synthetix-main/test/integration/modules/VaultModule.test.ts
+++ b/packages/synthetix-main/test/integration/modules/VaultModule.test.ts
@@ -48,7 +48,7 @@ describe('VaultModule', function () {
         fundId,
         [marketId],
         [ethers.utils.parseEther('1')],
-        [ethers.utils.parseEther('10000000')]
+        [ethers.utils.parseEther('10000000000000000')]
       );
   });
 
@@ -72,6 +72,29 @@ describe('VaultModule', function () {
       );
     };
   }
+
+  describe('fresh vault', async () => {
+    it('returns 0 debt', async () => {
+      assertBn.equal(
+        await systems().Core.callStatic.vaultDebt(0, collateralAddress()),
+        0
+      );
+    });
+
+    it('returns 0 collateral', async () => {
+      assertBn.equal(
+        (await systems().Core.callStatic.vaultCollateral(0, collateralAddress()))[0],
+        0
+      );
+    });
+
+    it('returns 0 collateral ratio', async () => {
+      assertBn.equal(
+        await systems().Core.callStatic.vaultCollateralRatio(0, collateralAddress()),
+        0
+      );
+    })
+  });
 
   describe('delegateCollateral()', async () => {
     it(
@@ -157,6 +180,7 @@ describe('VaultModule', function () {
           await systems()
             .Core.connect(user2)
             .stake(user2AccountId, collateralAddress(), depositAmount.mul(2));
+          
           await systems().Core.connect(user2).delegateCollateral(
             user2AccountId,
             fundId,
@@ -365,7 +389,7 @@ describe('VaultModule', function () {
     describe('first user leaves', async () => {
       before(restore);
       before('erase debt', async () => {
-        await MockMarket.connect(user1).setBalance(-100);
+        await MockMarket.connect(user1).setBalance(0);
       });
 
       before('undelegate', async () => {


### PR DESCRIPTION
this adds remaining tests and mostly finalized fixes to have working liquidation module 305.

Note that reward curve locks processing has not been added yet. This can be simply added when reward curves have been finalized (see todos).

possible remaining edge cases:
* a user attacking the system could tamper with the valuePerShares value to be too small (by, ex. vault liquidating 99.9999999999% of the fund).
reccomendation: add check to `SharesLibrary` functions to verify valuePerShares has sufficient remaining precision excess (tbd)

notes:
* includes a large refactor of the distributor module. besides improving liquidation support with the vault, it also
significantly trims and streamlines the vault module code as well
* one test is disabled until we have suite of tests verifying market module (because its hard to debug cause otherwise)
