### PR TITLE
Fix some tests and remove high level skips

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
       - run: npm ci
       - run: npm run build
       - name: Execute tests
-        run: npm run --workspace=./packages/synthetix-main test
+        run: DEBUG=cannon* npm run --workspace=./packages/synthetix-main test
 
   test-cli:
     runs-on: ubuntu-latest

--- a/packages/core-modules/test/contracts/modules/NftModule.test.js
+++ b/packages/core-modules/test/contracts/modules/NftModule.test.js
@@ -4,6 +4,8 @@ const { default: assertRevert } = require('@synthetixio/core-utils/utils/asserti
 const { bootstrap } = require('@synthetixio/hardhat-router/utils/tests');
 const initializer = require('@synthetixio/core-modules/test/helpers/initializer');
 
+// TODO: We can probably delete NftModule at this point.
+// It no longer has a mint function, and is thus pretty much a direct wrapper of ERC721Enumerable
 describe.skip('NftModule', () => {
   const { proxyAddress } = bootstrap(initializer, { modules: '.*(Owner|Upgrade|Nft).*' });
 

--- a/packages/synthetix-main/test/integration/modules/VaultModule.test.ts
+++ b/packages/synthetix-main/test/integration/modules/VaultModule.test.ts
@@ -348,7 +348,7 @@ describe('VaultModule', function () {
           before('repay debt', async () => {
             await systems()
               .Core.connect(user2)
-              .burnUSD(user2AccountId, poolId, collateralAddress(), depositAmount.div(100));
+              .burnUsd(user2AccountId, poolId, collateralAddress(), depositAmount.div(100));
           });
 
           before('delegate', async () => {
@@ -506,7 +506,7 @@ describe('VaultModule', function () {
       before('other account burn', async () => {
         await systems()
           .Core.connect(user2)
-          .burnUSD(accountId, poolId, collateralAddress(), depositAmount.div(10));
+          .burnUsd(accountId, poolId, collateralAddress(), depositAmount.div(10));
       });
 
       it('has correct debt', verifyAccountState(accountId, poolId, depositAmount, 0));

--- a/packages/synthetix-main/test/integration/modules/VaultRewardsModule.test.ts
+++ b/packages/synthetix-main/test/integration/modules/VaultRewardsModule.test.ts
@@ -7,7 +7,7 @@ import { getBlockTimestamp } from '@synthetixio/core-utils/utils/ethers/provider
 
 import { bootstrapWithStakedPool } from '../bootstrap';
 
-describe.only('VaultRewardsModule', function () {
+describe('VaultRewardsModule', function () {
   const { provider, signers, systems, poolId, collateralAddress, accountId, restore } =
     bootstrapWithStakedPool();
 

--- a/packages/synthetix-main/test/integration/modules/VaultRewardsModule.test.ts
+++ b/packages/synthetix-main/test/integration/modules/VaultRewardsModule.test.ts
@@ -3,10 +3,11 @@ import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert
 import hre from 'hardhat';
 import { ethers } from 'ethers';
 import { getBlockTimestamp } from '@synthetixio/core-utils/utils/ethers/provider';
+import { fastForward } from '@synthetixio/core-utils/utils/hardhat/rpc';
 
 import { bootstrapWithStakedPool } from '../bootstrap';
 
-describe.skip('VaultRewardsModule', function () {
+describe('VaultRewardsModule', function () {
   const { provider, signers, systems, poolId, collateralAddress, accountId, restore } =
     bootstrapWithStakedPool();
 
@@ -49,7 +50,7 @@ describe.skip('VaultRewardsModule', function () {
         before(restore);
         before(async () => {
           // distribute rewards multiple times to see what happens
-          // of many distributions happen in the past
+          // if many distributions happen in the past
           await systems().Core.connect(owner).distributeRewards(
             poolId,
             collateralAddress(),
@@ -169,7 +170,7 @@ describe.skip('VaultRewardsModule', function () {
 
         describe('after time passes', () => {
           before(async () => {
-            await provider().send('evm_increaseTime', [30]);
+            await fastForward(30, provider());
           });
 
           it('is distributed', async () => {
@@ -302,7 +303,7 @@ describe.skip('VaultRewardsModule', function () {
 
         describe('after time passes', () => {
           before(async () => {
-            await provider().send('evm_increaseTime', [200]);
+            await fastForward(200, provider());
           });
 
           it('is fully distributed', async () => {
@@ -357,7 +358,7 @@ describe.skip('VaultRewardsModule', function () {
 
         describe('after time passes', () => {
           before(async () => {
-            await provider().send('evm_increaseTime', [25]);
+            await fastForward(25, provider());
           });
 
           it('distributes more portion of rewards', async () => {
@@ -402,7 +403,7 @@ describe.skip('VaultRewardsModule', function () {
 
             describe('after more time', () => {
               before(async () => {
-                await provider().send('evm_increaseTime', [100]);
+                await fastForward(100, provider());
               });
 
               it('distributes more portion of rewards', async () => {

--- a/packages/synthetix-main/test/integration/modules/VaultRewardsModule.test.ts
+++ b/packages/synthetix-main/test/integration/modules/VaultRewardsModule.test.ts
@@ -2,12 +2,12 @@ import assertBn from '@synthetixio/core-utils/utils/assertions/assert-bignumber'
 import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
 import hre from 'hardhat';
 import { ethers } from 'ethers';
-import { getBlockTimestamp } from '@synthetixio/core-utils/utils/ethers/provider';
 import { fastForward } from '@synthetixio/core-utils/utils/hardhat/rpc';
+import { getBlockTimestamp } from '@synthetixio/core-utils/utils/ethers/provider';
 
 import { bootstrapWithStakedPool } from '../bootstrap';
 
-describe('VaultRewardsModule', function () {
+describe.only('VaultRewardsModule', function () {
   const { provider, signers, systems, poolId, collateralAddress, accountId, restore } =
     bootstrapWithStakedPool();
 

--- a/packages/synthetix-main/test/integration/modules/core/AccountModule/AccountModule.create.test.ts
+++ b/packages/synthetix-main/test/integration/modules/core/AccountModule/AccountModule.create.test.ts
@@ -1,9 +1,10 @@
 import assert from 'assert/strict';
 import assertBn from '@synthetixio/core-utils/utils/assertions/assert-bignumber';
+import assertEvent from '@synthetixio/core-utils/utils/assertions/assert-event';
 import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
 import { ethers } from 'ethers';
+
 import { bootstrap } from '../../../bootstrap';
-import assertEvent from '@synthetixio/core-utils/utils/assertions/assert-event';
 
 describe('AccountModule', function () {
   const { signers, systems } = bootstrap();
@@ -25,11 +26,7 @@ describe('AccountModule', function () {
       });
 
       it('emitted an AccountCreated event', async function () {
-        assertEvent(
-          receipt,
-          `AccountCreated(${await user1.getAddress()}, "1")`,
-          systems().Core
-        );
+        assertEvent(receipt, `AccountCreated(${await user1.getAddress()}, "1")`, systems().Core);
       });
 
       it('emitted a Mint event', async function () {

--- a/packages/synthetix-main/test/integration/modules/core/AccountModule/AccountModule.create.test.ts
+++ b/packages/synthetix-main/test/integration/modules/core/AccountModule/AccountModule.create.test.ts
@@ -2,8 +2,8 @@ import assert from 'assert/strict';
 import assertBn from '@synthetixio/core-utils/utils/assertions/assert-bignumber';
 import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
 import { ethers } from 'ethers';
-import { findEvent } from '@synthetixio/core-utils/utils/ethers/events';
 import { bootstrap } from '../../../bootstrap';
+import assertEvent from '@synthetixio/core-utils/utils/assertions/assert-event';
 
 describe('AccountModule', function () {
   const { signers, systems } = bootstrap();
@@ -25,25 +25,19 @@ describe('AccountModule', function () {
       });
 
       it('emitted an AccountCreated event', async function () {
-        const event = findEvent({
+        assertEvent(
           receipt,
-          eventName: 'AccountCreated',
-        });
-
-        assert.equal(event.args.sender, await user1.getAddress());
-        assertBn.equal(event.args.accountId, 1);
+          `AccountCreated(${await user1.getAddress()}, "1")`,
+          systems().Core
+        );
       });
 
-      // TODO: Fix bug in util - fails to find event
-      it.skip('emitted a Mint event', async function () {
-        const event = findEvent({
+      it('emitted a Mint event', async function () {
+        assertEvent(
           receipt,
-          eventName: 'Mint',
-          contract: systems().Account,
-        });
-
-        assert.equal(event.args.owner, await user1.getAddress());
-        assertBn.equal(event.args.tokenId, 1);
+          `Transfer("0x0000000000000000000000000000000000000000", ${await user1.getAddress()}, "1")`,
+          systems().Core
+        );
       });
 
       it('records the owner in the account system', async function () {

--- a/packages/synthetix-main/test/integration/modules/core/AccountModule/AccountModule.create.test.ts
+++ b/packages/synthetix-main/test/integration/modules/core/AccountModule/AccountModule.create.test.ts
@@ -52,7 +52,7 @@ describe('AccountModule', function () {
       });
 
       it('records the owner in the core system', async function () {
-        assert.equal(await systems().Core.accountOwner(1), await user1.getAddress());
+        assert.equal(await systems().Core.getAccountOwner(1), await user1.getAddress());
       });
 
       describe('when a user tries to create an acccount with an accountId that already exists', () => {

--- a/packages/synthetix-main/test/integration/modules/core/AccountModule/AccountModule.transfer.test.ts
+++ b/packages/synthetix-main/test/integration/modules/core/AccountModule/AccountModule.transfer.test.ts
@@ -33,7 +33,7 @@ describe('AccountModule', function () {
       });
 
       it('records the new owner in the core system', async function () {
-        assert.equal(await systems().Core.accountOwner(1), await user2.getAddress());
+        assert.equal(await systems().Core.getAccountOwner(1), await user2.getAddress());
       });
     });
   });


### PR DESCRIPTION
This PR fixes some tests that were failing, and removes all file level usages of `skip` in tests.

Note that some `skip`s still exist in the tests, but they are justified with an adjacent comment. We should remove these on a different PR.