### PR TITLE
fix vault rewards module tests

### DIFF
--- a/packages/core-utils/src/utils/hardhat/rpc.ts
+++ b/packages/core-utils/src/utils/hardhat/rpc.ts
@@ -21,13 +21,9 @@ export async function fastForward(seconds: number, provider: ethers.providers.Js
 }
 
 export async function fastForwardTo(time: number, provider: ethers.providers.JsonRpcProvider) {
-  const now = await getTime(provider);
+  await provider.send('evm_setNextBlockTimestamp', [time]);
 
-  if (time < now) {
-    throw 'Cannot fast forward to a past date.';
-  }
-
-  await fastForward(time - now, provider);
+  await mineBlock(provider);
 }
 
 export async function getTime(provider: ethers.providers.JsonRpcProvider) {

--- a/packages/core-utils/test/utils/hardhat/rpc.test.ts
+++ b/packages/core-utils/test/utils/hardhat/rpc.test.ts
@@ -102,16 +102,6 @@ describe('utils/hardhat/rpc.js', () => {
   });
 
   describe('when calling fastForwardTo', () => {
-    describe('to the past', function () {
-      it('throws', async function () {
-        try {
-          await fastForwardTo(1000, provider);
-        } catch (err) {
-          assert.ok((err as Error).toString().includes('Cannot fast forward to a past date'));
-        }
-      });
-    });
-
     describe('to the future', function () {
       before('clear spy history', () => {
         provider.send.resetHistory();
@@ -126,8 +116,8 @@ describe('utils/hardhat/rpc.js', () => {
       });
 
       it('calls the provider.send with the right params', () => {
-        assert.equal(provider.send.getCall(0).args[0], 'evm_increaseTime');
-        assert.deepEqual(provider.send.getCall(0).args[1], [10000 - 1337]);
+        assert.equal(provider.send.getCall(0).args[0], 'evm_setNextBlockTimestamp');
+        assert.deepEqual(provider.send.getCall(0).args[1], [10000]);
 
         assert.equal(provider.send.getCall(1).args[0], 'evm_mine');
       });

--- a/packages/synthetix-main/contracts/mixins/CollateralMixin.sol
+++ b/packages/synthetix-main/contracts/mixins/CollateralMixin.sol
@@ -68,9 +68,7 @@ contract CollateralMixin is CollateralStorage, PoolVaultStorage {
         for (uint i = 0; i < stakedCollateral.pools.length; i++) {
             uint poolIdx = stakedCollateral.pools[i];
 
-            PoolVaultStorage.VaultData storage vaultData = _poolVaultStore().poolVaults[poolIdx][
-                collateralType
-            ];
+            PoolVaultStorage.VaultData storage vaultData = _poolVaultStore().poolVaults[poolIdx][collateralType];
 
             totalAssigned += uint(vaultData.epochData[vaultData.epoch].collateralDist.getActorValue(bytes32(accountId)));
         }

--- a/packages/synthetix-main/test/integration/modules/VaultRewardsModule.test.ts
+++ b/packages/synthetix-main/test/integration/modules/VaultRewardsModule.test.ts
@@ -158,7 +158,7 @@ describe('VaultRewardsModule', function () {
               rewardAmount,
               startTime + 30, // timestamp
               0
-            );
+          );
         });
 
         it('is not distributed future yet', async () => {
@@ -364,7 +364,7 @@ describe('VaultRewardsModule', function () {
               0,
               systems().Core.address, // rewards are distributed by the rewards distributor on self
               rewardAmount,
-              startTime - 50, // timestamp
+              startTime - 50, // timestamp (time advances exactly 1 second due to block being mined)
               100
             );
         });
@@ -376,7 +376,8 @@ describe('VaultRewardsModule', function () {
             accountId
           );
           // should have received only the one past reward
-          assertBn.equal(rewards[0], rewardAmount.add(rewardAmount.mul(50).div(100)));
+          // 51 because block advances by exactly 1 second due to mine
+          assertBn.equal(rewards[0], rewardAmount.add(rewardAmount.mul(51).div(100)));
         });
 
         describe('after time passes', () => {
@@ -405,7 +406,7 @@ describe('VaultRewardsModule', function () {
                   collateralAddress(),
                   0,
                   systems().Core.address, // rewards are distributed by the rewards distributor on self
-                  rewardAmount,
+                  rewardAmount.mul(1000),
                   startTime - 110, // timestamp
                   200
                 );
@@ -413,7 +414,7 @@ describe('VaultRewardsModule', function () {
 
             // this test is skipped for now because, among all
             // the other tests, it does not behave as expected
-            it.skip('distributes portion of rewards immediately', async () => {
+            it('distributes portion of rewards immediately', async () => {
               const rewards = await systems().Core.callStatic.getAvailableRewards(
                 poolId,
                 collateralAddress(),
@@ -422,7 +423,7 @@ describe('VaultRewardsModule', function () {
               // should have received only the one past reward
               assertBn.equal(
                 rewards[0],
-                rewardAmount.add(rewardAmount.mul(75).div(100)).add(rewardAmount.mul(110).div(200))
+                rewardAmount.add(rewardAmount.mul(76).div(100)).add(rewardAmount.mul(1000).mul(111).div(200))
               );
             });
 
@@ -438,7 +439,8 @@ describe('VaultRewardsModule', function () {
                   accountId
                 );
                 // should have received only the one past reward
-                assertBn.equal(rewards[0], rewardAmount.mul(2).add(rewardAmount.mul(75).div(100)));
+                // +1 because block being mined by earlier txn
+                assertBn.equal(rewards[0], rewardAmount.mul(1001).add(rewardAmount.mul(76).div(100)));
               });
             });
           });

--- a/packages/synthetix-main/test/integration/modules/VaultRewardsModule.test.ts
+++ b/packages/synthetix-main/test/integration/modules/VaultRewardsModule.test.ts
@@ -158,7 +158,7 @@ describe('VaultRewardsModule', function () {
               rewardAmount,
               startTime + 30, // timestamp
               0
-          );
+            );
         });
 
         it('is not distributed future yet', async () => {
@@ -423,7 +423,9 @@ describe('VaultRewardsModule', function () {
               // should have received only the one past reward
               assertBn.equal(
                 rewards[0],
-                rewardAmount.add(rewardAmount.mul(76).div(100)).add(rewardAmount.mul(1000).mul(111).div(200))
+                rewardAmount
+                  .add(rewardAmount.mul(76).div(100))
+                  .add(rewardAmount.mul(1000).mul(111).div(200))
               );
             });
 
@@ -440,7 +442,10 @@ describe('VaultRewardsModule', function () {
                 );
                 // should have received only the one past reward
                 // +1 because block being mined by earlier txn
-                assertBn.equal(rewards[0], rewardAmount.mul(1001).add(rewardAmount.mul(76).div(100)));
+                assertBn.equal(
+                  rewards[0],
+                  rewardAmount.mul(1001).add(rewardAmount.mul(76).div(100))
+                );
               });
             });
           });


### PR DESCRIPTION
fixes boil down to:
* using `evm_setNextBlockTimestamp` instead of just `fastForward` within
  `fastForwardTo`-- ensures exact timestamp is delivered
* recognition that `evm_mine` always causse the block timestamp to
  incraese by 1 second, so we should be able to account for this in the test to get
the exact time

also btw the refactoring of these tests was not exactly the same as
before, which is part of the reason why the tests were failing when they
succeeded before