### PR TITLE
fix tests again

### DIFF
--- a/packages/synthetix-main/test/integration/bootstrap.ts
+++ b/packages/synthetix-main/test/integration/bootstrap.ts
@@ -60,6 +60,8 @@ export function bootstrap() {
       ),
     ];
 
+    await _provider.send('anvil_setBlockTimestampInterval', [1]);
+
     // Complete given signers with default hardhat wallets, to make sure
     // that we always have default accounts to test stuff
     for (const rawSigner of rawSigners) {

--- a/packages/synthetix-main/test/integration/modules/VaultRewardsModule.test.ts
+++ b/packages/synthetix-main/test/integration/modules/VaultRewardsModule.test.ts
@@ -376,8 +376,8 @@ describe('VaultRewardsModule', function () {
             accountId
           );
           // should have received only the one past reward
-          // 52 because block advances by exactly 1 second due to mine, and another 1 second for simulate
-          assertBn.equal(rewards[0], rewardAmount.add(rewardAmount.mul(52).div(100)));
+          // 51 because block advances by exactly 1 second due to mine
+          assertBn.equal(rewards[0], rewardAmount.add(rewardAmount.mul(51).div(100)));
         });
 
         describe('after time passes', () => {
@@ -392,7 +392,7 @@ describe('VaultRewardsModule', function () {
               accountId
             );
             // should have received only the one past reward + 1 second for simulate
-            assertBn.equal(rewards[0], rewardAmount.add(rewardAmount.mul(76).div(100)));
+            assertBn.equal(rewards[0], rewardAmount.add(rewardAmount.mul(75).div(100)));
           });
 
           describe('new distribution', () => {
@@ -425,7 +425,7 @@ describe('VaultRewardsModule', function () {
                 rewards[0],
                 rewardAmount
                   .add(rewardAmount.mul(76).div(100))
-                  .add(rewardAmount.mul(1000).mul(112).div(200))
+                  .add(rewardAmount.mul(1000).mul(111).div(200))
               );
             });
 

--- a/packages/synthetix-main/test/integration/modules/VaultRewardsModule.test.ts
+++ b/packages/synthetix-main/test/integration/modules/VaultRewardsModule.test.ts
@@ -376,8 +376,8 @@ describe('VaultRewardsModule', function () {
             accountId
           );
           // should have received only the one past reward
-          // 51 because block advances by exactly 1 second due to mine
-          assertBn.equal(rewards[0], rewardAmount.add(rewardAmount.mul(51).div(100)));
+          // 52 because block advances by exactly 1 second due to mine, and another 1 second for simulate
+          assertBn.equal(rewards[0], rewardAmount.add(rewardAmount.mul(52).div(100)));
         });
 
         describe('after time passes', () => {
@@ -391,8 +391,8 @@ describe('VaultRewardsModule', function () {
               collateralAddress(),
               accountId
             );
-            // should have received only the one past reward
-            assertBn.equal(rewards[0], rewardAmount.add(rewardAmount.mul(75).div(100)));
+            // should have received only the one past reward + 1 second for simulate
+            assertBn.equal(rewards[0], rewardAmount.add(rewardAmount.mul(76).div(100)));
           });
 
           describe('new distribution', () => {
@@ -425,7 +425,7 @@ describe('VaultRewardsModule', function () {
                 rewards[0],
                 rewardAmount
                   .add(rewardAmount.mul(76).div(100))
-                  .add(rewardAmount.mul(1000).mul(111).div(200))
+                  .add(rewardAmount.mul(1000).mul(112).div(200))
               );
             });
 
@@ -442,6 +442,7 @@ describe('VaultRewardsModule', function () {
                 );
                 // should have received only the one past reward
                 // +1 because block being mined by earlier txn
+                // +1 because the simulation adds an additional second
                 assertBn.equal(
                   rewards[0],
                   rewardAmount.mul(1001).add(rewardAmount.mul(76).div(100))


### PR DESCRIPTION
the rewards tests were still sometimes failing so this should ensure the timestamps are always deterministic, thereby allowing for perfect test outcomes for any time-based tests.

unfortunately anvil takes `0` seconds block timestamp interval to mean "disable" the block timestamp interval (or something) so we have to use `1` so it makes the test math a little more complicated but at least its consistent!

**note: these tests still fail with older versions of anvil**. This is because, it seems, an older version of anvil will. Please make sure you are up to date to `e947899` (or probably greater)