### PR TITLE
Moved Heap to core-contracts

### DIFF
--- a/packages/core-contracts/contracts/mocks/utils/HeapUtilMock.sol
+++ b/packages/core-contracts/contracts/mocks/utils/HeapUtilMock.sol
@@ -1,43 +1,44 @@
 // pragma solidity 0.4.24;
 pragma experimental ABIEncoderV2;
-import "../utils/Heap.sol";
+import "../../utils/HeapUtil.sol";
 
 // this is a simple contract that uses the heap library.
 // https://github.com/zmitton/eth-heap/blob/master/contracts/PublicHeap.sol
-contract MockHeap {
-    using Heap for Heap.Data;
-    Heap.Data public data;
+contract HeapUtilMock {
+    using HeapUtil for HeapUtil.Data;
+
+    HeapUtil.Data public data;
 
     constructor() public {
         data.init();
     }
 
-    function insert(uint128 id, int128 priority) public returns (Heap.Node memory) {
+    function insert(uint128 id, int128 priority) public returns (HeapUtil.Node memory) {
         return data.insert(id, priority);
     }
 
-    function extractMax() public returns (Heap.Node memory) {
+    function extractMax() public returns (HeapUtil.Node memory) {
         return data.extractMax();
     }
 
-    function extractById(uint128 id) public returns (Heap.Node memory) {
+    function extractById(uint128 id) public returns (HeapUtil.Node memory) {
         return data.extractById(id);
     }
 
     //view
-    function dump() public view returns (Heap.Node[] memory) {
+    function dump() public view returns (HeapUtil.Node[] memory) {
         return data.dump();
     }
 
-    function getMax() public view returns (Heap.Node memory) {
+    function getMax() public view returns (HeapUtil.Node memory) {
         return data.getMax();
     }
 
-    function getById(uint128 id) public view returns (Heap.Node memory) {
+    function getById(uint128 id) public view returns (HeapUtil.Node memory) {
         return data.getById(id);
     }
 
-    function getByIndex(uint i) public view returns (Heap.Node memory) {
+    function getByIndex(uint i) public view returns (HeapUtil.Node memory) {
         return data.getByIndex(i);
     }
 

--- a/packages/core-contracts/contracts/utils/HeapUtil.sol
+++ b/packages/core-contracts/contracts/utils/HeapUtil.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.0;
 // Author: Zac Mitton
 // License: MIT
 
-library Heap {
+library HeapUtil {
     // default max-heap
 
     uint private constant _ROOT_INDEX = 1;

--- a/packages/core-contracts/test/contracts/utils/HeapUtil.test.js
+++ b/packages/core-contracts/test/contracts/utils/HeapUtil.test.js
@@ -1,9 +1,8 @@
-import { ethers } from 'ethers';
-import hre from 'hardhat';
+const { ethers } = require('ethers');
+const hre = require('hardhat');
+const assertBn = require('@synthetixio/core-utils/utils/assertions/assert-bignumber');
 
-import assertBn from '@synthetixio/core-utils/utils/assertions/assert-bignumber';
-
-async function insertHeapData(heap: ethers.Contract, count: number, salt = 'salt') {
+async function insertHeapData(heap, count, salt = 'salt') {
   const vals = Array.from({ length: count }, (_, index) =>
     ethers.BigNumber.from(
       '0x' + ethers.utils.solidityKeccak256(['string'], [salt + index]).slice(64)
@@ -16,11 +15,11 @@ async function insertHeapData(heap: ethers.Contract, count: number, salt = 'salt
   return vals;
 }
 
-describe('Heap', async () => {
-  let heap: ethers.Contract;
+describe('HeapUtil', async () => {
+  let heap;
 
   beforeEach('initialize fresh heap', async () => {
-    heap = (await (await hre.ethers.getContractFactory('MockHeap')).deploy()).connect(
+    heap = (await (await hre.ethers.getContractFactory('HeapUtilMock')).deploy()).connect(
       (await hre.ethers.getSigners())[0]
     );
   });

--- a/packages/synthetix-main/contracts/mixins/MarketManagerMixin.sol
+++ b/packages/synthetix-main/contracts/mixins/MarketManagerMixin.sol
@@ -10,7 +10,7 @@ import "../storage/PoolModuleStorage.sol";
 contract MarketManagerMixin is MarketManagerStorage, PoolModuleStorage {
     using MathUtil for uint256;
     using SharesLibrary for SharesLibrary.Distribution;
-    using Heap for Heap.Data;
+    using HeapUtil for HeapUtil.Data;
 
     error MarketNotFound(uint marketId);
 
@@ -96,7 +96,7 @@ contract MarketManagerMixin is MarketManagerStorage, PoolModuleStorage {
                 i < maxIter;
             i++
         ) {
-            Heap.Node memory nextRemove = marketData.inRangePools.extractMax();
+            HeapUtil.Node memory nextRemove = marketData.inRangePools.extractMax();
 
             // distribute to limit
             int debtAmount = (int(int128(marketData.debtDist.totalShares)) *

--- a/packages/synthetix-main/contracts/storage/MarketManagerStorage.sol
+++ b/packages/synthetix-main/contracts/storage/MarketManagerStorage.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "../utils/SharesLibrary.sol";
-import "../utils/Heap.sol";
+import "@synthetixio/core-contracts/contracts/utils/HeapUtil.sol";
 
 contract MarketManagerStorage {
     struct MarketManagerStore {
@@ -21,9 +21,9 @@ contract MarketManagerStorage {
         /// @notice the amount of debt the last time the debt was distributed
         int128 lastMarketBalance;
         // used to disconnect pools from a market if it goes above a certain debt per debt share
-        Heap.Data inRangePools;
+        HeapUtil.Data inRangePools;
         // used to attach/reattach pools to a market if it goes below a certain debt per debt share
-        Heap.Data outRangePools;
+        HeapUtil.Data outRangePools;
         SharesLibrary.Distribution debtDist;
     }
 


### PR DESCRIPTION
Moved Heap.sol from synthetix-main to core-contracts, since its generic.

Note that it was renamed to HeapUtil.sol to stay consistent with other utils in core-contracts.