### PR TITLE
Fix lint warnings on non-tooling packages

### DIFF
--- a/packages/core-modules/contracts/modules/OwnerModule.sol
+++ b/packages/core-modules/contracts/modules/OwnerModule.sol
@@ -5,7 +5,6 @@ import "@synthetixio/core-contracts/contracts/ownership/Ownable.sol";
 import "@synthetixio/core-contracts/contracts/initializable/InitializableMixin.sol";
 import "../interfaces/IOwnerModule.sol";
 
-// solhint-disable-next-line no-empty-blocks
 contract OwnerModule is Ownable, IOwnerModule, InitializableMixin {
     function _isInitialized() internal view override returns (bool) {
         return _ownableStore().initialized;

--- a/packages/synthetix-main/contracts/mocks/AggregatorV3Mock.sol
+++ b/packages/synthetix-main/contracts/mocks/AggregatorV3Mock.sol
@@ -29,7 +29,7 @@ contract AggregatorV3Mock is IAggregatorV3Interface {
     // getRoundData and latestRoundData should both raise "No data present"
     // if they do not have data to report, instead of returning unset values
     // which could be misinterpreted as actual reported values.
-    function getRoundData(uint80 id)
+    function getRoundData(uint80)
         external
         view
         override

--- a/packages/synthetix-main/contracts/mocks/IAccountRBACMixinModuleMock.sol
+++ b/packages/synthetix-main/contracts/mocks/IAccountRBACMixinModuleMock.sol
@@ -2,11 +2,11 @@
 pragma solidity ^0.8.0;
 
 interface IAccountRBACMixinModuleMock {
-    function mock_AccountRBACMixin_deposit(uint accountId, uint newDepositMock) external;
+    function mockAccountRBACMixinDeposit(uint accountId, uint newDepositMock) external;
 
-    function mock_AccountRBACMixin_mint(uint accountId, uint newMintMock) external;
+    function mockAccountRBACMixinMint(uint accountId, uint newMintMock) external;
 
-    function mock_AccountRBACMixin_getDepositMock() external view returns (uint);
+    function mockAccountRBACMixinGetDepositMock() external view returns (uint);
 
-    function mock_AccountRBACMixin_getMintMock() external view returns (uint);
+    function mockAccountRBACMixinGetMintMock() external view returns (uint);
 }

--- a/packages/synthetix-main/contracts/modules/account/AccountTokenModule.sol
+++ b/packages/synthetix-main/contracts/modules/account/AccountTokenModule.sol
@@ -13,7 +13,7 @@ contract AccountTokenModule is IAccountTokenModule, NftModule {
     }
 
     function _postTransfer(
-        address from,
+        address, // from (unused)
         address to,
         uint256 tokenId
     ) internal virtual override {

--- a/packages/synthetix-main/contracts/modules/esnx/ESNXTokenModule.sol
+++ b/packages/synthetix-main/contracts/modules/esnx/ESNXTokenModule.sol
@@ -3,4 +3,7 @@ pragma solidity ^0.8.0;
 
 import "@synthetixio/core-modules/contracts/modules/TokenModule.sol";
 
-contract ESNXTokenModule is TokenModule {}
+// solhint-disable-next-line no-empty-blocks
+contract ESNXTokenModule is TokenModule {
+
+}

--- a/packages/synthetix-main/contracts/modules/mocks/AccountRBACMixinModuleMock.sol
+++ b/packages/synthetix-main/contracts/modules/mocks/AccountRBACMixinModuleMock.sol
@@ -6,7 +6,7 @@ import "../../mocks/IAccountRBACMixinModuleMock.sol";
 import "../../mocks/AccountRBACMixinModuleMockStorage.sol";
 
 contract AccountRBACMixinModuleMock is IAccountRBACMixinModuleMock, AccountRBACMixinModuleMockStorage, AccountRBACMixin {
-    function mock_AccountRBACMixin_deposit(uint accountId, uint newDepositMock)
+    function mockAccountRBACMixinDeposit(uint accountId, uint newDepositMock)
         external
         override
         onlyWithPermission(accountId, _DEPOSIT_PERMISSION)
@@ -14,7 +14,7 @@ contract AccountRBACMixinModuleMock is IAccountRBACMixinModuleMock, AccountRBACM
         _mixinModuleMockStore().depositMock = newDepositMock;
     }
 
-    function mock_AccountRBACMixin_mint(uint accountId, uint newMintMock)
+    function mockAccountRBACMixinMint(uint accountId, uint newMintMock)
         external
         override
         onlyWithPermission(accountId, _MINT_PERMISSION)
@@ -22,11 +22,11 @@ contract AccountRBACMixinModuleMock is IAccountRBACMixinModuleMock, AccountRBACM
         _mixinModuleMockStore().mintMock = newMintMock;
     }
 
-    function mock_AccountRBACMixin_getDepositMock() external view override returns (uint) {
+    function mockAccountRBACMixinGetDepositMock() external view override returns (uint) {
         return _mixinModuleMockStore().depositMock;
     }
 
-    function mock_AccountRBACMixin_getMintMock() external view override returns (uint) {
+    function mockAccountRBACMixinGetMintMock() external view override returns (uint) {
         return _mixinModuleMockStore().mintMock;
     }
 }

--- a/packages/synthetix-main/contracts/modules/snx/SNXTokenModule.sol
+++ b/packages/synthetix-main/contracts/modules/snx/SNXTokenModule.sol
@@ -3,4 +3,7 @@ pragma solidity ^0.8.0;
 
 import "@synthetixio/core-modules/contracts/modules/TokenModule.sol";
 
-contract SNXTokenModule is TokenModule {}
+// solhint-disable-next-line no-empty-blocks
+contract SNXTokenModule is TokenModule {
+
+}

--- a/packages/synthetix-main/contracts/modules/usd/USDTokenModule.sol
+++ b/packages/synthetix-main/contracts/modules/usd/USDTokenModule.sol
@@ -3,4 +3,7 @@ pragma solidity ^0.8.0;
 
 import "@synthetixio/core-modules/contracts/modules/TokenModule.sol";
 
-contract USDTokenModule is TokenModule {}
+// solhint-disable-next-line no-empty-blocks
+contract USDTokenModule is TokenModule {
+
+}

--- a/packages/synthetix-main/docs/theme/helpers.ts
+++ b/packages/synthetix-main/docs/theme/helpers.ts
@@ -37,7 +37,10 @@ export function hsection(this: unknown, hsublevel: number | HelperOptions, opts?
  */
 function getHLevel(hsublevel: number | HelperOptions, opts?: HelperOptions) {
   if (typeof hsublevel === 'number') {
-    opts = opts!;
+    if (!opts) {
+      throw new Error('Helper options not defined');
+    }
+
     hsublevel = Math.max(1, hsublevel);
   } else {
     opts = hsublevel;
@@ -78,7 +81,9 @@ export function inheritedItems(this: DocItemWithContext) {
   if (this.nodeType === 'ContractDefinition') {
     const { deref } = this.__item_context.build;
     const parents = this.linearizedBaseContracts.map(deref('ContractDefinition'));
-    return parents.reduce((prev: any, curr) => {
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return parents.reduce((prev: any, curr: any) => {
       return prev.concat(curr.nodes);
     }, []);
   }

--- a/packages/synthetix-main/test/integration/mixins/AccountRBACMixin.test.ts
+++ b/packages/synthetix-main/test/integration/mixins/AccountRBACMixin.test.ts
@@ -22,11 +22,11 @@ describe('AccountRBACMixin', function () {
       before('deposit', async function () {
         const signer = signers()[user];
 
-        await await systems().Core.connect(signer).mock_AccountRBACMixin_deposit(1, value);
+        await await systems().Core.connect(signer).mockAccountRBACMixinDeposit(1, value);
       });
 
       it('sets the mock value', async function () {
-        assertBn.equal(await systems().Core.mock_AccountRBACMixin_getDepositMock(), value);
+        assertBn.equal(await systems().Core.mockAccountRBACMixinGetDepositMock(), value);
       });
     });
   }
@@ -38,11 +38,11 @@ describe('AccountRBACMixin', function () {
       before('mint', async function () {
         const signer = signers()[user];
 
-        await await systems().Core.connect(signer).mock_AccountRBACMixin_mint(1, value);
+        await await systems().Core.connect(signer).mockAccountRBACMixinMint(1, value);
       });
 
       it('sets the mock value', async function () {
-        assertBn.equal(await systems().Core.mock_AccountRBACMixin_getMintMock(), value);
+        assertBn.equal(await systems().Core.mockAccountRBACMixinGetMintMock(), value);
       });
     });
   }
@@ -53,7 +53,7 @@ describe('AccountRBACMixin', function () {
         const signer = signers()[user];
 
         await assertRevert(
-          systems().Core.connect(signer).mock_AccountRBACMixin_deposit(1, 666),
+          systems().Core.connect(signer).mockAccountRBACMixinDeposit(1, 666),
           `PermissionDenied("1", "${Permissions.DEPOSIT}", "${await signer.getAddress()}")`,
           systems().Core
         );
@@ -67,7 +67,7 @@ describe('AccountRBACMixin', function () {
         const signer = signers()[user];
 
         await assertRevert(
-          systems().Core.connect(signer).mock_AccountRBACMixin_mint(1, 666),
+          systems().Core.connect(signer).mockAccountRBACMixinMint(1, 666),
           `PermissionDenied("1", "${Permissions.MINT}", "${await signer.getAddress()}")`,
           systems().Core
         );

--- a/packages/synthetix-main/test/integration/modules/LiquidationModule.test.ts
+++ b/packages/synthetix-main/test/integration/modules/LiquidationModule.test.ts
@@ -1,11 +1,8 @@
-import assert from 'assert/strict';
 import assertBn from '@synthetixio/core-utils/utils/assertions/assert-bignumber';
 import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
-import hre from 'hardhat';
 import { ethers } from 'ethers';
-import { findEvent } from '@synthetixio/core-utils/utils/ethers/events';
 
-import { bootstrap, bootstrapWithMockMarketAndPool } from '../bootstrap';
+import { bootstrapWithMockMarketAndPool } from '../bootstrap';
 
 describe('LiquidationModule', function () {
   const {
@@ -21,10 +18,10 @@ describe('LiquidationModule', function () {
     restore,
   } = bootstrapWithMockMarketAndPool();
 
-  let owner: ethers.Signer, user1: ethers.Signer, user2: ethers.Signer;
+  let user1: ethers.Signer, user2: ethers.Signer;
 
   before('identify signers', async () => {
-    [owner, user1, user2] = signers();
+    [, user1, user2] = signers();
   });
 
   describe('liquidate()', () => {

--- a/packages/synthetix-main/test/integration/modules/MarketManagerModule.test.ts
+++ b/packages/synthetix-main/test/integration/modules/MarketManagerModule.test.ts
@@ -1,8 +1,6 @@
-import assert from 'assert/strict';
 import assertBn from '@synthetixio/core-utils/utils/assertions/assert-bignumber';
 import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
 import assertEvent from '@synthetixio/core-utils/utils/assertions/assert-event';
-import hre from 'hardhat';
 import { ethers } from 'ethers';
 
 import { bootstrapWithMockMarketAndPool } from '../bootstrap';
@@ -12,7 +10,6 @@ describe('MarketManagerModule', function () {
     signers,
     systems,
     collateralAddress,
-    collateralContract,
     poolId,
     accountId,
     MockMarket,
@@ -25,6 +22,8 @@ describe('MarketManagerModule', function () {
   const Hundred = ethers.utils.parseEther('100');
 
   let owner: ethers.Signer, user1: ethers.Signer;
+
+  let txn: ethers.providers.TransactionResponse;
 
   before('identify signers', async () => {
     [owner, user1] = signers();
@@ -42,8 +41,6 @@ describe('MarketManagerModule', function () {
     });
 
     describe('successful', async () => {
-      let txn: ethers.providers.TransactionResponse;
-
       const expectedMarketId = marketId().add(1);
 
       before('register', async () => {
@@ -72,7 +69,6 @@ describe('MarketManagerModule', function () {
 
   describe('deposit()', async () => {
     before(restore);
-    let txn: ethers.providers.TransactionResponse;
 
     before('acquire USD', async () => {
       await systems().Core.connect(user1).mintUsd(accountId, poolId, collateralAddress(), One);
@@ -123,7 +119,6 @@ describe('MarketManagerModule', function () {
     before(restore);
 
     describe('deposit into the pool', async () => {
-      let txn: ethers.providers.TransactionResponse;
       before('mint USD to use market', async () => {
         await systems().Core.connect(user1).mintUsd(accountId, poolId, collateralAddress(), One);
         await systems().USD.connect(user1).approve(MockMarket().address, One);

--- a/packages/synthetix-main/test/integration/modules/PoolModuleFundAdmin.test.ts
+++ b/packages/synthetix-main/test/integration/modules/PoolModuleFundAdmin.test.ts
@@ -3,7 +3,6 @@ import assertBn from '@synthetixio/core-utils/utils/assertions/assert-bignumber'
 import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
 import hre from 'hardhat';
 import { ethers } from 'ethers';
-import { findEvent } from '@synthetixio/core-utils/utils/ethers/events';
 
 import { bootstrapWithMockMarketAndPool } from '../bootstrap';
 import { snapshotCheckpoint } from '../../utils';
@@ -22,12 +21,7 @@ describe('PoolModule Admin', function () {
     restore,
   } = bootstrapWithMockMarketAndPool();
 
-  let owner: ethers.Signer, user1: ethers.Signer, user2: ethers.Signer, user3: ethers.Signer;
-
-  let Collateral: ethers.Contract, AggregatorV3Mock: ethers.Contract;
-
-  const user2AccountId = 2;
-  const user3AccountId = 3;
+  let owner: ethers.Signer, user1: ethers.Signer, user2: ethers.Signer;
 
   const secondPoolId = 3384692;
 
@@ -35,7 +29,7 @@ describe('PoolModule Admin', function () {
   const Hundred = ethers.utils.parseEther('100');
 
   before('identify signers', async () => {
-    [owner, user1, user2, user3] = signers();
+    [owner, user1, user2] = signers();
   });
 
   describe('createPool()', async () => {
@@ -59,11 +53,7 @@ describe('PoolModule Admin', function () {
   });
 
   describe('setPoolConfiguration()', async () => {
-    let MockMarket2: ethers.Contract;
-    let MockMarket3: ethers.Contract;
-
     const marketId2 = 2;
-    const marketId3 = 3;
 
     before('set dummy markets', async () => {
       const factory = await hre.ethers.getContractFactory('MockMarket');

--- a/packages/synthetix-main/test/integration/modules/USDTokenModule.test.ts
+++ b/packages/synthetix-main/test/integration/modules/USDTokenModule.test.ts
@@ -3,13 +3,7 @@ import { bootstrap } from '../bootstrap';
 import { ethers } from 'ethers';
 
 describe('USDTokenModule', function () {
-  const { signers, systems } = bootstrap();
-
-  let owner: ethers.Signer, user1: ethers.Signer;
-
-  before('identify signers', async () => {
-    [owner, user1] = signers();
-  });
+  const { systems } = bootstrap();
 
   it('USD is deployed and registered', async () => {
     const info = await systems().Core.getAssociatedSystem(

--- a/packages/synthetix-main/test/integration/modules/UtilsModule.test.ts
+++ b/packages/synthetix-main/test/integration/modules/UtilsModule.test.ts
@@ -1,4 +1,3 @@
-import assert from 'assert/strict';
 import assertBn from '@synthetixio/core-utils/utils/assertions/assert-bignumber';
 import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
 import { ethers } from 'ethers';

--- a/packages/synthetix-main/test/integration/modules/core/CollateralModule/CollateralModule.helper.ts
+++ b/packages/synthetix-main/test/integration/modules/core/CollateralModule/CollateralModule.helper.ts
@@ -71,7 +71,7 @@ export async function verifyCollateralListed(
   const collaterals = await core.getCollateralConfigurations(hideDisabled);
 
   assert.equal(
-    collaterals.some((v: any) => v.tokenAddress === Collateral.address),
+    collaterals.some((v: { tokenAddress: string }) => v.tokenAddress === Collateral.address),
     listed
   );
 }

--- a/packages/synthetix-main/test/utils.ts
+++ b/packages/synthetix-main/test/utils.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers';
 
 export function snapshotCheckpoint(provider: () => ethers.providers.JsonRpcProvider) {
-  let snapshotId: any;
+  let snapshotId: number;
 
   before('snapshot', async () => {
     snapshotId = await provider().send('evm_snapshot', []);


### PR DESCRIPTION
Removes linter warnings from v3 packages.

If we do the same with the tooling packages, we can re-enable failure on warnings on our linters.