### PR TITLE
Rename Liqudation -> Liquidation

### DIFF
--- a/packages/synthetix-main/contracts/interfaces/ILiquidationModule.sol
+++ b/packages/synthetix-main/contracts/interfaces/ILiquidationModule.sol
@@ -22,7 +22,7 @@ interface ILiquidationModule {
         uint amountRewarded
     );
 
-    struct LiqudationInformation {
+    struct LiquidationInformation {
         CurvesLibrary.PolynomialCurve curve;
         mapping(uint => uint) initialAmount; // key is accountId, amount is accumulated when you entered the vault
         uint accumulated; // how much accumulation per debt share (updated before anyone enters/leaves the vaults)

--- a/packages/synthetix-main/docs/index.md
+++ b/packages/synthetix-main/docs/index.md
@@ -14,10 +14,10 @@ event Liquidation(uint256 accountId, uint256 poolId, address collateralType, uin
 event VaultLiquidation(uint256 poolId, address collateralType, uint256 debtLiquidated, uint256 collateralLiquidated, uint256 amountRewarded)
 ```
 
-### LiqudationInformation
+### LiquidationInformation
 
 ```solidity
-struct LiqudationInformation {
+struct LiquidationInformation {
   struct CurvesLibrary.PolynomialCurve curve;
   mapping(uint256 => uint256) initialAmount;
   uint256 accumulated;
@@ -62,10 +62,10 @@ event Liquidation(uint256 accountId, uint256 poolId, address collateralType, uin
 event VaultLiquidation(uint256 poolId, address collateralType, uint256 debtLiquidated, uint256 collateralLiquidated, uint256 amountRewarded)
 ```
 
-### LiqudationInformation
+### LiquidationInformation
 
 ```solidity
-struct LiqudationInformation {
+struct LiquidationInformation {
   struct CurvesLibrary.PolynomialCurve curve;
   mapping(uint256 => uint256) initialAmount;
   uint256 accumulated;
@@ -1315,10 +1315,10 @@ event Liquidation(uint256 accountId, uint256 poolId, address collateralType, uin
 event VaultLiquidation(uint256 poolId, address collateralType, uint256 debtLiquidated, uint256 collateralLiquidated, uint256 amountRewarded)
 ```
 
-### LiqudationInformation
+### LiquidationInformation
 
 ```solidity
-struct LiqudationInformation {
+struct LiquidationInformation {
   struct CurvesLibrary.PolynomialCurve curve;
   mapping(uint256 => uint256) initialAmount;
   uint256 accumulated;
@@ -1363,10 +1363,10 @@ event Liquidation(uint256 accountId, uint256 poolId, address collateralType, uin
 event VaultLiquidation(uint256 poolId, address collateralType, uint256 debtLiquidated, uint256 collateralLiquidated, uint256 amountRewarded)
 ```
 
-### LiqudationInformation
+### LiquidationInformation
 
 ```solidity
-struct LiqudationInformation {
+struct LiquidationInformation {
   struct CurvesLibrary.PolynomialCurve curve;
   mapping(uint256 => uint256) initialAmount;
   uint256 accumulated;


### PR DESCRIPTION
A really minor PR that resolves a typo in `LiqudationInformation`.