### PR TITLE
rename “Assign” permission to “Delegate”

### DIFF
--- a/packages/synthetix-main/contracts/mixins/AccountRBACMixin.sol
+++ b/packages/synthetix-main/contracts/mixins/AccountRBACMixin.sol
@@ -10,7 +10,7 @@ contract AccountRBACMixin is AccountModuleStorage {
 
     bytes32 internal constant _DEPOSIT_PERMISSION = "DEPOSIT";
     bytes32 internal constant _WITHDRAW_PERMISSION = "WITHDRAW";
-    bytes32 internal constant _ASSIGN_PERMISSION = "ASSIGN";
+    bytes32 internal constant _DELEGATE_PERMISSION = "DELEGATE";
     bytes32 internal constant _MINT_PERMISSION = "MINT";
     bytes32 internal constant _ADMIN_PERMISSION = "ADMIN";
 

--- a/packages/synthetix-main/contracts/modules/core/VaultModule.sol
+++ b/packages/synthetix-main/contracts/modules/core/VaultModule.sol
@@ -38,7 +38,7 @@ contract VaultModule is IVaultModule, VaultStorage, AccountRBACMixin, OwnableMix
     )
         external
         override
-        onlyWithPermission(accountId, _ASSIGN_PERMISSION)
+        onlyWithPermission(accountId, _DELEGATE_PERMISSION)
         collateralEnabled(collateralType)
         poolExists(poolId)
     {

--- a/packages/synthetix-main/test/integration/mixins/AcccountRBACMixin.permissions.ts
+++ b/packages/synthetix-main/test/integration/mixins/AcccountRBACMixin.permissions.ts
@@ -5,5 +5,5 @@ export default {
   ADMIN: ethers.utils.formatBytes32String('ADMIN'),
   WITHDRAW: ethers.utils.formatBytes32String('WITHDRAW'),
   MINT: ethers.utils.formatBytes32String('MINT'),
-  ASSIGN: ethers.utils.formatBytes32String('ASSIGN'),
+  DELEGATE: ethers.utils.formatBytes32String('DELEGATE'),
 };

--- a/packages/synthetix-main/test/integration/modules/VaultModule.test.ts
+++ b/packages/synthetix-main/test/integration/modules/VaultModule.test.ts
@@ -114,7 +114,7 @@ describe('VaultModule', function () {
             depositAmount.mul(2),
             ethers.utils.parseEther('1')
           ),
-        `PermissionDenied("1", "${Permissions.ASSIGN}", "${await user2.getAddress()}")`,
+        `PermissionDenied("1", "${Permissions.DELEGATE}", "${await user2.getAddress()}")`,
         systems().Core
       );
     });


### PR DESCRIPTION
“Assign” permission to “Delegate” permission because it allows you to delegate collateral