### PR TITLE
feat: validate permission on grant

### DIFF
--- a/packages/synthetix-main/contracts/mixins/AccountRBACMixin.sol
+++ b/packages/synthetix-main/contracts/mixins/AccountRBACMixin.sol
@@ -7,6 +7,7 @@ contract AccountRBACMixin is AccountModuleStorage {
     using SetUtil for SetUtil.Bytes32Set;
 
     error PermissionDenied(uint accountId, bytes32 permission, address target);
+    error InvalidPermission(bytes32 permission);
 
     bytes32 internal constant _DEPOSIT_PERMISSION = "DEPOSIT";
     bytes32 internal constant _WITHDRAW_PERMISSION = "WITHDRAW";
@@ -17,6 +18,20 @@ contract AccountRBACMixin is AccountModuleStorage {
     modifier onlyWithPermission(uint accountId, bytes32 permission) {
         if (!_authorized(accountId, permission, msg.sender)) {
             revert PermissionDenied(accountId, permission, msg.sender);
+        }
+
+        _;
+    }
+
+    modifier isPermissionValid(bytes32 permission) {
+        if (
+            permission != _DEPOSIT_PERMISSION &&
+            permission != _WITHDRAW_PERMISSION &&
+            permission != _DELEGATE_PERMISSION &&
+            permission != _MINT_PERMISSION &&
+            permission != _ADMIN_PERMISSION
+        ) {
+            revert InvalidPermission(permission);
         }
 
         _;

--- a/packages/synthetix-main/contracts/modules/core/AccountModule.sol
+++ b/packages/synthetix-main/contracts/modules/core/AccountModule.sol
@@ -18,7 +18,6 @@ contract AccountModule is IAccountModule, OwnableMixin, AccountRBACMixin, Associ
     using SetUtil for SetUtil.Bytes32Set;
 
     error OnlyAccountTokenProxy(address origin);
-    error InvalidPermission();
     error PermissionNotGranted(uint accountId, bytes32 permission, address target);
 
     modifier onlyAccountToken() {
@@ -75,13 +74,9 @@ contract AccountModule is IAccountModule, OwnableMixin, AccountRBACMixin, Associ
         uint accountId,
         bytes32 permission,
         address target
-    ) external override onlyWithPermission(accountId, _ADMIN_PERMISSION) {
+    ) external override onlyWithPermission(accountId, _ADMIN_PERMISSION) isPermissionValid(permission) {
         if (target == address(0)) {
             revert AddressError.ZeroAddress();
-        }
-
-        if (permission == "") {
-            revert InvalidPermission();
         }
 
         AccountRBAC storage accountRbac = _accountModuleStore().accountsRBAC[accountId];

--- a/packages/synthetix-main/test/integration/modules/core/AccountModule/AccountModule.grant.test.ts
+++ b/packages/synthetix-main/test/integration/modules/core/AccountModule/AccountModule.grant.test.ts
@@ -54,6 +54,19 @@ describe('AccountModule', function () {
       });
     });
 
+    describe('when a an authorized user attempts to grant an invalid permission', async () => {
+      it('reverts', async () => {
+        const invalidPermission = ethers.utils.formatBytes32String('INVALID');
+        await assertRevert(
+          systems()
+            .Core.connect(user1)
+            .grantPermission(1, invalidPermission, await user2.getAddress()),
+          `InvalidPermission("${invalidPermission}")`,
+          systems().Core
+        );
+      });
+    });
+
     describe('when a permission is granted by the owner', function () {
       before('grant the permission', async function () {
         const tx = await systems()


### PR DESCRIPTION
grantPermission does not ensure the validity of granted permissions

Description
When granting a permission to a user, the caller can submit any bytes32 string as the permission parameter. This string is not validated before use, which could allow the caller to submit a malicious string that may be injected into front-end components when they access the data. Such an issue could be leveraged to perform front-end attacks such as cross-site scripting (XSS) against users accessing the malicious string through a website vulnerable to XSS.

Recommendation
The function should confirm that the submitted permission is valid before storing the data. A further improvement would be the implementation of a bitmask to handle permissions, as this would remove the use of strings and simplify the system.

https://gist.github.com/keanumaharaj/a95315730041559abfc608a4f4becdda
