### PR TITLE
Remove market manager test

### DIFF
--- a/packages/synthetix-main/test/integration/modules/MarketManagerModule.test.ts
+++ b/packages/synthetix-main/test/integration/modules/MarketManagerModule.test.ts
@@ -32,14 +32,6 @@ describe('MarketManagerModule', function () {
   describe('registerMarket()', async () => {
     before(restore);
 
-    it('fails if market is already registered', async () => {
-      await assertRevert(
-        systems().Core.connect(owner).registerMarket(MockMarket().address),
-        `MarketAlreadyRegistered("${MockMarket().address}", "${marketId()}")`,
-        systems().Core
-      );
-    });
-
     describe('successful', async () => {
       const expectedMarketId = marketId().add(1);
 


### PR DESCRIPTION
Multiple markets can be registered by the same address, so this test is no longer relevant.