### PR TITLE
validate parameters on initialization of ERC721 tokens

### DIFF
--- a/packages/core-contracts/contracts/errors/InitError.sol
+++ b/packages/core-contracts/contracts/errors/InitError.sol
@@ -4,4 +4,5 @@ pragma solidity ^0.8.0;
 library InitError {
     error AlreadyInitialized();
     error NotInitialized();
+    error InvalidParameters();
 }

--- a/packages/core-contracts/contracts/token/ERC721.sol
+++ b/packages/core-contracts/contracts/token/ERC721.sol
@@ -32,6 +32,10 @@ contract ERC721 is IERC721, IERC721Metadata, ERC721Storage {
             revert InitError.AlreadyInitialized();
         }
 
+        if (bytes(tokenName).length == 0 || bytes(tokenSymbol).length == 0) {
+            revert InitError.InvalidParameters();
+        }
+
         store.name = tokenName;
         store.symbol = tokenSymbol;
         store.baseTokenURI = baseTokenURI;

--- a/packages/core-contracts/contracts/token/ERC721.sol
+++ b/packages/core-contracts/contracts/token/ERC721.sol
@@ -173,6 +173,10 @@ contract ERC721 is IERC721, IERC721Metadata, ERC721Storage {
             revert AddressError.ZeroAddress();
         }
 
+        if (tokenId == 0) {
+            revert InitError.InvalidParameters();
+        }
+
         if (_exists(tokenId)) {
             revert TokenAlreadyMinted(tokenId);
         }

--- a/packages/core-contracts/contracts/token/ERC721.sol
+++ b/packages/core-contracts/contracts/token/ERC721.sol
@@ -50,7 +50,7 @@ contract ERC721 is IERC721, IERC721Metadata, ERC721Storage {
 
     function balanceOf(address holder) public view virtual override returns (uint) {
         if (holder == address(0)) {
-            revert AddressError.ZeroAddress();
+            return 0;
         }
 
         return _erc721Store().balanceOf[holder];
@@ -58,7 +58,7 @@ contract ERC721 is IERC721, IERC721Metadata, ERC721Storage {
 
     function ownerOf(uint256 tokenId) public view virtual override returns (address) {
         if (!_exists(tokenId)) {
-            revert TokenDoesNotExist(tokenId);
+            return address(0);
         }
 
         return _erc721Store().ownerOf[tokenId];
@@ -74,7 +74,7 @@ contract ERC721 is IERC721, IERC721Metadata, ERC721Storage {
 
     function tokenURI(uint256 tokenId) external view virtual override returns (string memory) {
         if (!_exists(tokenId)) {
-            revert TokenDoesNotExist(tokenId);
+            return "";
         }
 
         string memory baseURI = _erc721Store().baseTokenURI;

--- a/packages/core-contracts/contracts/token/ERC721Enumerable.sol
+++ b/packages/core-contracts/contracts/token/ERC721Enumerable.sol
@@ -19,7 +19,7 @@ abstract contract ERC721Enumerable is ERC721, ERC721EnumerableStorage, IERC721En
         string memory baseTokenURI
     ) internal virtual override {
         super._initialize(tokenName, tokenSymbol, baseTokenURI);
-        if (_erc20EnumerableStore().allTokens.length > 0) {
+        if (_erc721EnumerableStore().allTokens.length > 0) {
             revert InitError.AlreadyInitialized();
         }
     }
@@ -32,14 +32,14 @@ abstract contract ERC721Enumerable is ERC721, ERC721EnumerableStorage, IERC721En
         if (ERC721.balanceOf(owner) <= index) {
             revert IndexOutOfBounds();
         }
-        return _erc20EnumerableStore().ownedTokens[owner][index];
+        return _erc721EnumerableStore().ownedTokens[owner][index];
     }
 
     /**
      * @dev Returns the total amount of tokens stored by the contract.
      */
     function totalSupply() public view virtual override returns (uint256) {
-        return _erc20EnumerableStore().allTokens.length;
+        return _erc721EnumerableStore().allTokens.length;
     }
 
     /**
@@ -50,7 +50,7 @@ abstract contract ERC721Enumerable is ERC721, ERC721EnumerableStorage, IERC721En
         if (index >= ERC721Enumerable.totalSupply()) {
             revert IndexOutOfBounds();
         }
-        return _erc20EnumerableStore().allTokens[index];
+        return _erc721EnumerableStore().allTokens[index];
     }
 
     function _beforeTransfer(
@@ -72,8 +72,8 @@ abstract contract ERC721Enumerable is ERC721, ERC721EnumerableStorage, IERC721En
 
     function _addTokenToOwnerEnumeration(address to, uint256 tokenId) private {
         uint256 length = ERC721.balanceOf(to);
-        _erc20EnumerableStore().ownedTokens[to][length] = tokenId;
-        _erc20EnumerableStore().ownedTokensIndex[tokenId] = length;
+        _erc721EnumerableStore().ownedTokens[to][length] = tokenId;
+        _erc721EnumerableStore().ownedTokensIndex[tokenId] = length;
     }
 
     /**
@@ -81,8 +81,8 @@ abstract contract ERC721Enumerable is ERC721, ERC721EnumerableStorage, IERC721En
      * @param tokenId uint256 ID of the token to be added to the tokens list
      */
     function _addTokenToAllTokensEnumeration(uint256 tokenId) private {
-        _erc20EnumerableStore().allTokensIndex[tokenId] = _erc20EnumerableStore().allTokens.length;
-        _erc20EnumerableStore().allTokens.push(tokenId);
+        _erc721EnumerableStore().allTokensIndex[tokenId] = _erc721EnumerableStore().allTokens.length;
+        _erc721EnumerableStore().allTokens.push(tokenId);
     }
 
     /**
@@ -98,19 +98,19 @@ abstract contract ERC721Enumerable is ERC721, ERC721EnumerableStorage, IERC721En
         // then delete the last slot (swap and pop).
 
         uint256 lastTokenIndex = ERC721.balanceOf(from) - 1;
-        uint256 tokenIndex = _erc20EnumerableStore().ownedTokensIndex[tokenId];
+        uint256 tokenIndex = _erc721EnumerableStore().ownedTokensIndex[tokenId];
 
         // When the token to delete is the last token, the swap operation is unnecessary
         if (tokenIndex != lastTokenIndex) {
-            uint256 lastTokenId = _erc20EnumerableStore().ownedTokens[from][lastTokenIndex];
+            uint256 lastTokenId = _erc721EnumerableStore().ownedTokens[from][lastTokenIndex];
 
-            _erc20EnumerableStore().ownedTokens[from][tokenIndex] = lastTokenId; // Move the last token to the slot of the to-delete token
-            _erc20EnumerableStore().ownedTokensIndex[lastTokenId] = tokenIndex; // Update the moved token's index
+            _erc721EnumerableStore().ownedTokens[from][tokenIndex] = lastTokenId; // Move the last token to the slot of the to-delete token
+            _erc721EnumerableStore().ownedTokensIndex[lastTokenId] = tokenIndex; // Update the moved token's index
         }
 
         // This also deletes the contents at the last position of the array
-        delete _erc20EnumerableStore().ownedTokensIndex[tokenId];
-        delete _erc20EnumerableStore().ownedTokens[from][lastTokenIndex];
+        delete _erc721EnumerableStore().ownedTokensIndex[tokenId];
+        delete _erc721EnumerableStore().ownedTokens[from][lastTokenIndex];
     }
 
     /**
@@ -122,19 +122,19 @@ abstract contract ERC721Enumerable is ERC721, ERC721EnumerableStorage, IERC721En
         // To prevent a gap in the tokens array, we store the last token in the index of the token to delete, and
         // then delete the last slot (swap and pop).
 
-        uint256 lastTokenIndex = _erc20EnumerableStore().allTokens.length - 1;
-        uint256 tokenIndex = _erc20EnumerableStore().allTokensIndex[tokenId];
+        uint256 lastTokenIndex = _erc721EnumerableStore().allTokens.length - 1;
+        uint256 tokenIndex = _erc721EnumerableStore().allTokensIndex[tokenId];
 
         // When the token to delete is the last token, the swap operation is unnecessary. However, since this occurs so
         // rarely (when the last minted token is burnt) that we still do the swap here to avoid the gas cost of adding
         // an 'if' statement (like in _removeTokenFromOwnerEnumeration)
-        uint256 lastTokenId = _erc20EnumerableStore().allTokens[lastTokenIndex];
+        uint256 lastTokenId = _erc721EnumerableStore().allTokens[lastTokenIndex];
 
-        _erc20EnumerableStore().allTokens[tokenIndex] = lastTokenId; // Move the last token to the slot of the to-delete token
-        _erc20EnumerableStore().allTokensIndex[lastTokenId] = tokenIndex; // Update the moved token's index
+        _erc721EnumerableStore().allTokens[tokenIndex] = lastTokenId; // Move the last token to the slot of the to-delete token
+        _erc721EnumerableStore().allTokensIndex[lastTokenId] = tokenIndex; // Update the moved token's index
 
         // This also deletes the contents at the last position of the array
-        delete _erc20EnumerableStore().allTokensIndex[tokenId];
-        _erc20EnumerableStore().allTokens.pop();
+        delete _erc721EnumerableStore().allTokensIndex[tokenId];
+        _erc721EnumerableStore().allTokens.pop();
     }
 }

--- a/packages/core-contracts/contracts/token/ERC721Enumerable.sol
+++ b/packages/core-contracts/contracts/token/ERC721Enumerable.sol
@@ -30,7 +30,7 @@ abstract contract ERC721Enumerable is ERC721, ERC721EnumerableStorage, IERC721En
      */
     function tokenOfOwnerByIndex(address owner, uint256 index) public view virtual override returns (uint256) {
         if (ERC721.balanceOf(owner) <= index) {
-            revert IndexOutOfBounds();
+            return 0;
         }
         return _erc721EnumerableStore().ownedTokens[owner][index];
     }
@@ -48,7 +48,7 @@ abstract contract ERC721Enumerable is ERC721, ERC721EnumerableStorage, IERC721En
      */
     function tokenByIndex(uint256 index) public view virtual override returns (uint256) {
         if (index >= ERC721Enumerable.totalSupply()) {
-            revert IndexOutOfBounds();
+            return 0;
         }
         return _erc721EnumerableStore().allTokens[index];
     }

--- a/packages/core-contracts/contracts/token/ERC721EnumerableStorage.sol
+++ b/packages/core-contracts/contracts/token/ERC721EnumerableStorage.sol
@@ -9,7 +9,7 @@ contract ERC721EnumerableStorage {
         uint256[] allTokens;
     }
 
-    function _erc20EnumerableStore() internal pure returns (ERC721EnumerableStore storage store) {
+    function _erc721EnumerableStore() internal pure returns (ERC721EnumerableStore storage store) {
         assembly {
             // bytes32(uint(keccak256("io.synthetix.ERC721Enumerable")) - 1)
             store.slot := 0xbb177151bccee46ca610917613ed7b9846647300a31f78f4e1d2108a85c87851

--- a/packages/core-contracts/test/contracts/token/ERC721.test.js
+++ b/packages/core-contracts/test/contracts/token/ERC721.test.js
@@ -546,4 +546,12 @@ describe('ERC721', () => {
       });
     });
   });
+
+  describe('When attempting to initialize it with invalid values', () => {
+    it('reverts', async () => {
+      const factory = await ethers.getContractFactory('ERC721Mock');
+      let ERC721 = await factory.deploy();
+      await assertRevert(ERC721.initialize('', '', ''), 'InvalidParameters()');
+    });
+  });
 });

--- a/packages/core-contracts/test/contracts/token/ERC721.test.js
+++ b/packages/core-contracts/test/contracts/token/ERC721.test.js
@@ -55,8 +55,8 @@ describe('ERC721', () => {
       assertBn.equal(await ERC721.balanceOf(user1.address), 0);
     });
 
-    it('reverts checking the balance of 0x0 address', async () => {
-      await assertRevert(ERC721.balanceOf(ethers.constants.AddressZero), 'ZeroAddress');
+    it('returns default 0 for balance of 0x0 address', async () => {
+      assertBn.equal(await ERC721.balanceOf(ethers.constants.AddressZero), 0);
     });
   });
 
@@ -87,8 +87,8 @@ describe('ERC721', () => {
       assert.equal(await ERC721.ownerOf(token42), user1.address);
     });
 
-    it('reverts checking the owner for a wrong NFT Id', async () => {
-      await assertRevert(ERC721.ownerOf(24), 'TokenDoesNotExist(24)');
+    it('returns default address zero for owner of a wrong NFT Id', async () => {
+      assert.equal(await ERC721.ownerOf(24), ethers.constants.AddressZero);
     });
 
     describe('when attempting to mint again an existent Token', async () => {
@@ -111,8 +111,8 @@ describe('ERC721', () => {
         assert.equal(await ERC721.tokenURI(token42), '');
       });
 
-      it('reverts for an invalid tokenID', async () => {
-        await assertRevert(ERC721.tokenURI(24), 'TokenDoesNotExist(24)');
+      it('returns default "" for an invalid tokenID', async () => {
+        assert.equal(await ERC721.tokenURI(24), '');
       });
     });
 

--- a/packages/core-contracts/test/contracts/token/ERC721Enumerable.test.js
+++ b/packages/core-contracts/test/contracts/token/ERC721Enumerable.test.js
@@ -1,6 +1,5 @@
 const { ethers } = hre;
 const assert = require('assert/strict');
-const { default: assertRevert } = require('@synthetixio/core-utils/utils/assertions/assert-revert');
 const assertBn = require('@synthetixio/core-utils/utils/assertions/assert-bignumber');
 
 describe('ERC721Enumerable', () => {
@@ -37,11 +36,7 @@ describe('ERC721Enumerable', () => {
       assertBn.equal(await ERC721Enumerable.tokenOfOwnerByIndex(user1.address, 0), 100);
       assertBn.equal(await ERC721Enumerable.tokenOfOwnerByIndex(user1.address, 1), 101);
       assertBn.equal(await ERC721Enumerable.tokenOfOwnerByIndex(user2.address, 0), 200);
-
-      await assertRevert(
-        ERC721Enumerable.tokenOfOwnerByIndex(user1.address, 2),
-        'IndexOutOfBounds()'
-      );
+      assertBn.equal(await ERC721Enumerable.tokenOfOwnerByIndex(user1.address, 2), 0);
     });
   });
 
@@ -52,10 +47,7 @@ describe('ERC721Enumerable', () => {
       await ERC721Enumerable.burn(301);
 
       assertBn.equal(await ERC721Enumerable.tokenOfOwnerByIndex(user1.address, 0), 300);
-      await assertRevert(
-        ERC721Enumerable.tokenOfOwnerByIndex(user1.address, 1),
-        'IndexOutOfBounds()'
-      );
+      assertBn.equal(await ERC721Enumerable.tokenOfOwnerByIndex(user1.address, 1), 0);
     });
   });
 
@@ -67,10 +59,7 @@ describe('ERC721Enumerable', () => {
 
       assertBn.equal(await ERC721Enumerable.tokenOfOwnerByIndex(user1.address, 0), 400);
       assertBn.equal(await ERC721Enumerable.tokenOfOwnerByIndex(user2.address, 0), 401);
-      await assertRevert(
-        ERC721Enumerable.tokenOfOwnerByIndex(user1.address, 1),
-        'IndexOutOfBounds()'
-      );
+      assertBn.equal(await ERC721Enumerable.tokenOfOwnerByIndex(user1.address, 1), 0);
     });
   });
 
@@ -86,7 +75,7 @@ describe('ERC721Enumerable', () => {
       assertBn.equal(await ERC721Enumerable.totalSupply(), 6);
       assertBn.equal(await ERC721Enumerable.tokenByIndex(0), 400);
       assertBn.equal(await ERC721Enumerable.tokenByIndex(5), 405);
-      await assertRevert(ERC721Enumerable.tokenByIndex(6), 'IndexOutOfBounds()');
+      assertBn.equal(await ERC721Enumerable.tokenByIndex(6), 0);
     });
   });
 });


### PR DESCRIPTION
https://gist.github.com/keanumaharaj/a95315730041559abfc608a4f4becdda

Parameters not validated during initialization of ERC721 tokens

[ERC721.sol#35](https://github.com/Synthetixio/synthetix-v3/blob/4bb9679d45709827fa2e46fc11e1e88cb09f08f0/packages/core-contracts/contracts/token/ERC721.sol#L35)

Description
The ERC721 contract design uses either the token name, symbol, or baseUri to determine if it is initialized. Thus, if only one of these values were set on initialization, the others would be left unsettable. If the NFT is intended to be traded on secondary markets, then all three of these data fields may be mandatory, which would require a full redeployment of the system to correct.

Recommendation
During initialization, all of the token parameters (name, symbol, and baseUri) should be confirmed to be non-zero length bytes32 strings before completing initialization.

Storage function for enumerable ERC721 named incorrectly
[ERC721EnumerableStorage.sol#L12](https://github.com/Synthetixio/synthetix-v3/blob/4bb9679d45709827fa2e46fc11e1e88cb09f08f0/packages/core-contracts/contracts/token/ERC721EnumerableStorage.sol#L12)

Description
The function _erc20EnumerableStore() used to access the storage slot for ERC721EnumerableStorage is named incorrectly as the name reflects the wrong token standard.

Recommendation
The function _erc20EnumerableStore() should be renamed to _erc721EnumerableStore() to correctly represent the storage slot being accessed.


Token ID 0 should be reserved
[ERC721.sol#L166](https://github.com/Synthetixio/synthetix-v3/blob/4bb9679d45709827fa2e46fc11e1e88cb09f08f0/packages/core-contracts/contracts/token/ERC721.sol#L166)

Description
When minting a token, the tokenID of 0 should be disallowed. This is to prevent ambiguity of the value 0 when querying a mapping of tokenIDs or struct members.

Recommendation
Add validation to the start of _mint to ensure tokenID > 0.



View functions revert instead of returning safe defaults
[ERC721.sol](https://github.com/Synthetixio/synthetix-v3/blob/4bb9679d45709827fa2e46fc11e1e88cb09f08f0/packages/core-contracts/contracts/token/ERC721.sol), [ERC721Enumerable.sol](https://github.com/Synthetixio/synthetix-v3/blob/4bb9679d45709827fa2e46fc11e1e88cb09f08f0/packages/core-contracts/contracts/token/ERC721Enumerable.sol)

Description
It is considered best practice to not revert on view functions when a sensible and safe default value can be returned instead. Reverts in view functions often force calling functions to use the try-catch pattern, which increases gas costs and code complexity.