### PR TITLE
Introduce isAuthorized function

### DIFF
--- a/packages/synthetix-main/contracts/interfaces/IAccountModule.sol
+++ b/packages/synthetix-main/contracts/interfaces/IAccountModule.sol
@@ -95,6 +95,15 @@ interface IAccountModule {
     ) external view returns (bool);
 
     /**
+     * @notice Returns `true` if `target` is authorized to `permission` for account `accountId`.
+     */
+    function isAuthorized(
+        uint accountId,
+        bytes32 permission,
+        address target
+    ) external view returns (bool);
+
+    /**
      * @notice Returns the address for the account token used by the module.
      */
     function getAccountTokenAddress() external view returns (address);

--- a/packages/synthetix-main/contracts/modules/core/AccountModule.sol
+++ b/packages/synthetix-main/contracts/modules/core/AccountModule.sol
@@ -71,6 +71,14 @@ contract AccountModule is IAccountModule, OwnableMixin, AccountRBACMixin, Associ
         return _hasPermission(accountId, permission, target);
     }
 
+    function isAuthorized(
+        uint256 accountId,
+        bytes32 permission,
+        address target
+    ) public view override returns (bool) {
+        return _authorized(accountId, permission, target);
+    }
+
     function grantPermission(
         uint accountId,
         bytes32 permission,

--- a/packages/synthetix-main/test/integration/modules/core/AccountModule/AccountModule.grant.test.ts
+++ b/packages/synthetix-main/test/integration/modules/core/AccountModule/AccountModule.grant.test.ts
@@ -40,6 +40,22 @@ describe('AccountModule', function () {
           false
         );
       });
+      it('shows that the owner is authorized', async function () {
+        assert.equal(
+          await systems().Core.isAuthorized(1, Permissions.ADMIN, await user1.getAddress()),
+          true
+        );
+      });
+      it('shows that the other uesr not authorized', async function () {
+        assert.equal(
+          await systems().Core.isAuthorized(1, Permissions.ADMIN, await user2.getAddress()),
+          false
+        );
+        assert.equal(
+          await systems().Core.isAuthorized(1, Permissions.DEPOSIT, await user2.getAddress()),
+          false
+        );
+      });
     });
 
     describe('when a non-authorized user attempts to grant permissions', async () => {
@@ -167,6 +183,29 @@ describe('AccountModule', function () {
       it('shows that the admin permission is granted by the owner', async function () {
         assert.equal(
           await systems().Core.hasPermission(1, Permissions.ADMIN, await user2.getAddress()),
+          true
+        );
+      });
+
+      it('shows that the admin is authorized to all permissions', async function () {
+        assert.equal(
+          await systems().Core.isAuthorized(1, Permissions.ADMIN, await user2.getAddress()),
+          true
+        );
+        assert.equal(
+          await systems().Core.isAuthorized(1, Permissions.DELEGATE, await user2.getAddress()),
+          true
+        );
+        assert.equal(
+          await systems().Core.isAuthorized(1, Permissions.DEPOSIT, await user2.getAddress()),
+          true
+        );
+        assert.equal(
+          await systems().Core.isAuthorized(1, Permissions.MINT, await user2.getAddress()),
+          true
+        );
+        assert.equal(
+          await systems().Core.isAuthorized(1, Permissions.WITHDRAW, await user2.getAddress()),
           true
         );
       });


### PR DESCRIPTION
https://gist.github.com/keanumaharaj/a95315730041559abfc608a4f4becdda

_authorized is not accessible and testable
[AccountRBACMixin.sol#L35](https://github.com/Synthetixio/synthetix-v3/blob/4bb9679d45709827fa2e46fc11e1e88cb09f08f0/packages/synthetix-main/contracts/mixins/AccountRBACMixin.sol#L35)

Description
The _authorized internal function should be exposed using an external view function to improve composability and allow the logic to be thoroughly tested. Currently, no unit tests exist that explicitly test all possible permutations of the _authorized function's logic.

Recommendation
Introduce isAuthorized() in a manner similiar to hasPermission() to the AccountModule.sol smart contract.