### PR TITLE
Change feature flag mechanism to auto restrict

### DIFF
--- a/packages/common-config/hardhat.config.ts
+++ b/packages/common-config/hardhat.config.ts
@@ -69,15 +69,15 @@ const config = {
   contractSizer: {
     strict: true,
   },
-  // etherscan: {
-  //   apiKey: {
-  //     mainnet: process.env.ETHERSCAN_API_KEY,
-  //     rinkeby: process.env.ETHERSCAN_API_KEY,
-  //     optimisticEthereum: process.env.OVM_ETHERSCAN_API_KEY,
-  //     optimisticGoerli: process.env.OVM_ETHERSCAN_API_KEY,
-  //     avalancheFujiTestnet: process.env.ETHERSCAN_API_KEY,
-  //   },
-  // },
+  etherscan: {
+    apiKey: {
+      mainnet: process.env.ETHERSCAN_API_KEY,
+      rinkeby: process.env.ETHERSCAN_API_KEY,
+      optimisticEthereum: process.env.OVM_ETHERSCAN_API_KEY,
+      optimisticGoerli: process.env.OVM_ETHERSCAN_API_KEY,
+      avalancheFujiTestnet: process.env.ETHERSCAN_API_KEY,
+    },
+  },
   tenderly: {
     project: 'synthetix',
     username: 'synthetix-services',

--- a/packages/common-config/hardhat.config.ts
+++ b/packages/common-config/hardhat.config.ts
@@ -69,15 +69,15 @@ const config = {
   contractSizer: {
     strict: true,
   },
-  etherscan: {
-    apiKey: {
-      mainnet: process.env.ETHERSCAN_API_KEY,
-      rinkeby: process.env.ETHERSCAN_API_KEY,
-      optimisticEthereum: process.env.OVM_ETHERSCAN_API_KEY,
-      optimisticGoerli: process.env.OVM_ETHERSCAN_API_KEY,
-      avalancheFujiTestnet: process.env.ETHERSCAN_API_KEY,
-    },
-  },
+  // etherscan: {
+  //   apiKey: {
+  //     mainnet: process.env.ETHERSCAN_API_KEY,
+  //     rinkeby: process.env.ETHERSCAN_API_KEY,
+  //     optimisticEthereum: process.env.OVM_ETHERSCAN_API_KEY,
+  //     optimisticGoerli: process.env.OVM_ETHERSCAN_API_KEY,
+  //     avalancheFujiTestnet: process.env.ETHERSCAN_API_KEY,
+  //   },
+  // },
   tenderly: {
     project: 'synthetix',
     username: 'synthetix-services',

--- a/packages/core-modules/contracts/interfaces/IFeatureFlagModule.sol
+++ b/packages/core-modules/contracts/interfaces/IFeatureFlagModule.sol
@@ -12,8 +12,8 @@ interface IFeatureFlagModule {
     /// @notice Remove an address and remove its permission for a feature flag
     function removeFromFeatureFlag(bytes32 feature, address permissioned) external;
 
-    /// @notice Returns if feature flag is enabled
-    function isFeatureFlagEnabled(bytes32 feature) external view returns (bool);
+    /// @notice Returns if feature flag is active
+    function isFeatureFlagActive(bytes32 feature) external view returns (bool);
 
     /// @notice Returns the addresses that have permission for a feature flag
     function getFeatureFlagAddresses(bytes32 feature) external view returns (address[] memory);

--- a/packages/core-modules/contracts/interfaces/IFeatureFlagModule.sol
+++ b/packages/core-modules/contracts/interfaces/IFeatureFlagModule.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 /// @title Interface for feature flags
 interface IFeatureFlagModule {
     /// @notice Set a feature flag to either allow all or not
-    function setFeatureFlagAllowAll(bytes32 feature, bool value) external;
+    function setFeatureFlagAllowAll(bytes32 feature, bool allowAll) external;
 
     /// @notice Add an address and give it permission for a feature flag
     function addToFeatureFlagAllowlist(bytes32 feature, address permissioned) external;

--- a/packages/core-modules/contracts/interfaces/IFeatureFlagModule.sol
+++ b/packages/core-modules/contracts/interfaces/IFeatureFlagModule.sol
@@ -10,7 +10,7 @@ interface IFeatureFlagModule {
     function addToFeatureFlagAllowlist(bytes32 feature, address permissioned) external;
 
     /// @notice Remove an address and remove its permission for a feature flag
-    function removeFromFreatureFlagAllowlist(bytes32 feature, address permissioned) external;
+    function removeFromFeatureFlagAllowlist(bytes32 feature, address permissioned) external;
 
     /// @notice Returns allowAll boolean value for a feature flag
     function getFeatureFlagAllowAll(bytes32 feature) external view returns (bool);

--- a/packages/core-modules/contracts/interfaces/IFeatureFlagModule.sol
+++ b/packages/core-modules/contracts/interfaces/IFeatureFlagModule.sol
@@ -3,18 +3,21 @@ pragma solidity ^0.8.0;
 
 /// @title Interface for feature flags
 interface IFeatureFlagModule {
-    /// @notice Set a feature flag
-    function setFeatureFlag(bytes32 feature, bool value) external;
+    /// @notice Set a feature flag to either allow all or not
+    function setFeatureFlagAllowAll(bytes32 feature, bool value) external;
 
     /// @notice Add an address and give it permission for a feature flag
-    function addToFeatureFlag(bytes32 feature, address permissioned) external;
+    function addToFeatureFlagAllowlist(bytes32 feature, address permissioned) external;
 
     /// @notice Remove an address and remove its permission for a feature flag
-    function removeFromFeatureFlag(bytes32 feature, address permissioned) external;
+    function removeFromFreatureFlagAllowlist(bytes32 feature, address permissioned) external;
 
-    /// @notice Returns if feature flag is active
-    function isFeatureFlagActive(bytes32 feature) external view returns (bool);
+    /// @notice Returns allowAll boolean value for a feature flag
+    function getFeatureFlagAllowAll(bytes32 feature) external view returns (bool);
 
     /// @notice Returns the addresses that have permission for a feature flag
-    function getFeatureFlagAddresses(bytes32 feature) external view returns (address[] memory);
+    function getFeatureFlagAllowlist(bytes32 feature) external view returns (address[] memory);
+
+    /// @notice Check if address has access to feature
+    function isFeatureAllowed(bytes32 feature, address addressToCheck) external view returns (bool);
 }

--- a/packages/core-modules/contracts/modules/FeatureFlagModule.sol
+++ b/packages/core-modules/contracts/modules/FeatureFlagModule.sol
@@ -11,7 +11,7 @@ contract FeatureFlagModule is IFeatureFlagModule {
 
     event FeatureFlagAllowAllSet(bytes32 feature, bool value);
     event FeatureFlagAllowlistAdded(bytes32 feature, address account);
-    event FeatureFlagAllowListRemoved(bytes32 feature, address account);
+    event FeatureFlagAllowlistRemoved(bytes32 feature, address account);
 
     function setFeatureFlagAllowAll(bytes32 feature, bool allowAll) external override {
         OwnableStorage.onlyOwner();
@@ -31,7 +31,7 @@ contract FeatureFlagModule is IFeatureFlagModule {
         OwnableStorage.onlyOwner();
         FeatureFlag.load(feature).permissionedAddresses.remove(permissioned);
 
-        emit FeatureFlagAllowListRemoved(feature, permissioned);
+        emit FeatureFlagAllowlistRemoved(feature, permissioned);
     }
 
     function getFeatureFlagAllowAll(bytes32 feature) external view override returns (bool) {

--- a/packages/core-modules/contracts/modules/FeatureFlagModule.sol
+++ b/packages/core-modules/contracts/modules/FeatureFlagModule.sol
@@ -9,29 +9,29 @@ import "../interfaces/IFeatureFlagModule.sol";
 contract FeatureFlagModule is IFeatureFlagModule {
     using SetUtil for SetUtil.AddressSet;
 
-    event FeatureFlagSet(bytes32 feature, bool value);
-    event FeatureFlagAddressAdded(bytes32 feature, address account);
-    event FeatureFlagAddressRemoved(bytes32 feature, address account);
+    event FeatureFlagAllowAllSet(bytes32 feature, bool value);
+    event FeatureFlagAllowlistAdded(bytes32 feature, address account);
+    event FeatureFlagAllowListRemoved(bytes32 feature, address account);
 
     function setFeatureFlagAllowAll(bytes32 feature, bool allowAll) external override {
         OwnableStorage.onlyOwner();
         FeatureFlag.load(feature).allowAll = allowAll;
 
-        emit FeatureFlagSet(feature, allowAll);
+        emit FeatureFlagAllowAllSet(feature, allowAll);
     }
 
     function addToFeatureFlagAllowlist(bytes32 feature, address permissioned) external override {
         OwnableStorage.onlyOwner();
         FeatureFlag.load(feature).permissionedAddresses.add(permissioned);
 
-        emit FeatureFlagAddressAdded(feature, permissioned);
+        emit FeatureFlagAllowlistAdded(feature, permissioned);
     }
 
-    function removeFromFreatureFlagAllowlist(bytes32 feature, address permissioned) external override {
+    function removeFromFeatureFlagAllowlist(bytes32 feature, address permissioned) external override {
         OwnableStorage.onlyOwner();
         FeatureFlag.load(feature).permissionedAddresses.remove(permissioned);
 
-        emit FeatureFlagAddressRemoved(feature, permissioned);
+        emit FeatureFlagAllowListRemoved(feature, permissioned);
     }
 
     function getFeatureFlagAllowAll(bytes32 feature) external view override returns (bool) {

--- a/packages/core-modules/contracts/modules/FeatureFlagModule.sol
+++ b/packages/core-modules/contracts/modules/FeatureFlagModule.sol
@@ -13,11 +13,11 @@ contract FeatureFlagModule is IFeatureFlagModule {
     event FeatureFlagAddressAdded(bytes32 feature, address account);
     event FeatureFlagAddressRemoved(bytes32 feature, address account);
 
-    function setFeatureFlag(bytes32 feature, bool value) external override {
+    function setFeatureFlag(bytes32 feature, bool allowAll) external override {
         OwnableStorage.onlyOwner();
-        FeatureFlag.load(feature).enabled = value;
+        FeatureFlag.load(feature).allowAll = allowAll;
 
-        emit FeatureFlagSet(feature, value);
+        emit FeatureFlagSet(feature, allowAll);
     }
 
     function addToFeatureFlag(bytes32 feature, address permissioned) external override {
@@ -34,8 +34,8 @@ contract FeatureFlagModule is IFeatureFlagModule {
         emit FeatureFlagAddressRemoved(feature, permissioned);
     }
 
-    function isFeatureFlagEnabled(bytes32 feature) external view override returns (bool) {
-        return FeatureFlag.load(feature).enabled;
+    function isFeatureFlagActive(bytes32 feature) external view override returns (bool) {
+        return !FeatureFlag.load(feature).allowAll;
     }
 
     function getFeatureFlagAddresses(bytes32 feature) external view override returns (address[] memory) {

--- a/packages/core-modules/contracts/modules/FeatureFlagModule.sol
+++ b/packages/core-modules/contracts/modules/FeatureFlagModule.sol
@@ -13,32 +13,36 @@ contract FeatureFlagModule is IFeatureFlagModule {
     event FeatureFlagAddressAdded(bytes32 feature, address account);
     event FeatureFlagAddressRemoved(bytes32 feature, address account);
 
-    function setFeatureFlag(bytes32 feature, bool allowAll) external override {
+    function setFeatureFlagAllowAll(bytes32 feature, bool allowAll) external override {
         OwnableStorage.onlyOwner();
         FeatureFlag.load(feature).allowAll = allowAll;
 
         emit FeatureFlagSet(feature, allowAll);
     }
 
-    function addToFeatureFlag(bytes32 feature, address permissioned) external override {
+    function addToFeatureFlagAllowlist(bytes32 feature, address permissioned) external override {
         OwnableStorage.onlyOwner();
         FeatureFlag.load(feature).permissionedAddresses.add(permissioned);
 
         emit FeatureFlagAddressAdded(feature, permissioned);
     }
 
-    function removeFromFeatureFlag(bytes32 feature, address permissioned) external override {
+    function removeFromFreatureFlagAllowlist(bytes32 feature, address permissioned) external override {
         OwnableStorage.onlyOwner();
         FeatureFlag.load(feature).permissionedAddresses.remove(permissioned);
 
         emit FeatureFlagAddressRemoved(feature, permissioned);
     }
 
-    function isFeatureFlagActive(bytes32 feature) external view override returns (bool) {
-        return !FeatureFlag.load(feature).allowAll;
+    function getFeatureFlagAllowAll(bytes32 feature) external view override returns (bool) {
+        return FeatureFlag.load(feature).allowAll;
     }
 
-    function getFeatureFlagAddresses(bytes32 feature) external view override returns (address[] memory) {
+    function getFeatureFlagAllowlist(bytes32 feature) external view override returns (address[] memory) {
         return FeatureFlag.load(feature).permissionedAddresses.values();
+    }
+
+    function isFeatureAllowed(bytes32 feature, address addressToCheck) external view override returns (bool) {
+        return FeatureFlag.hasAccess(feature, addressToCheck);
     }
 }

--- a/packages/core-modules/contracts/modules/mocks/SampleFeatureFlagModule.sol
+++ b/packages/core-modules/contracts/modules/mocks/SampleFeatureFlagModule.sol
@@ -7,7 +7,7 @@ import "../../storage/FeatureFlag.sol";
 
 contract SampleFeatureFlagModule is ISampleFeatureFlagModule {
     function setFeatureFlaggedValue(uint valueToSet) external {
-        FeatureFlag.ensureEnabled("SAMPLE_FEATURE");
+        FeatureFlag.ensureAccessToFeature("SAMPLE_FEATURE");
         SampleStorage.load().someValue = valueToSet;
     }
 

--- a/packages/core-modules/contracts/storage/FeatureFlag.sol
+++ b/packages/core-modules/contracts/storage/FeatureFlag.sol
@@ -1,15 +1,16 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "@synthetixio/core-contracts/contracts/errors/AccessError.sol";
 import "@synthetixio/core-contracts/contracts/utils/SetUtil.sol";
 
 library FeatureFlag {
     using SetUtil for SetUtil.AddressSet;
 
+    error FeatureUnavailable();
+
     struct Data {
         bytes32 name;
-        bool enabled;
+        bool allowAll;
         SetUtil.AddressSet permissionedAddresses;
     }
 
@@ -20,11 +21,11 @@ library FeatureFlag {
         }
     }
 
-    function ensureEnabled(bytes32 feature) internal view {
+    function ensureAccessToFeature(bytes32 feature) internal view {
         Data storage store = FeatureFlag.load(feature);
 
-        if (store.enabled && !store.permissionedAddresses.contains(msg.sender)) {
-            revert AccessError.Unauthorized(msg.sender);
+        if (!store.allowAll && !store.permissionedAddresses.contains(msg.sender)) {
+            revert FeatureUnavailable();
         }
     }
 }

--- a/packages/core-modules/contracts/storage/FeatureFlag.sol
+++ b/packages/core-modules/contracts/storage/FeatureFlag.sol
@@ -22,10 +22,14 @@ library FeatureFlag {
     }
 
     function ensureAccessToFeature(bytes32 feature) internal view {
-        Data storage store = FeatureFlag.load(feature);
-
-        if (!store.allowAll && !store.permissionedAddresses.contains(msg.sender)) {
+        if (!hasAccess(feature, msg.sender)) {
             revert FeatureUnavailable();
         }
+    }
+
+    function hasAccess(bytes32 feature, address value) internal view returns (bool) {
+        Data storage store = FeatureFlag.load(feature);
+
+        return store.allowAll || store.permissionedAddresses.contains(value);
     }
 }

--- a/packages/core-modules/test/contracts/modules/FeatureFlagModule.test.js
+++ b/packages/core-modules/test/contracts/modules/FeatureFlagModule.test.js
@@ -6,7 +6,7 @@ const { default: assertRevert } = require('@synthetixio/core-utils/utils/asserti
 const { bootstrap } = require('@synthetixio/hardhat-router/dist/utils/tests');
 const initializer = require('@synthetixio/core-modules/test/helpers/initializer');
 
-describe.only('FeatureFlagModule', () => {
+describe('FeatureFlagModule', () => {
   const { proxyAddress } = bootstrap(initializer, {
     modules: '.*(FeatureFlagModule|SampleFeatureFlagModule|Owner|Upgrade).*',
   });

--- a/packages/core-modules/test/contracts/modules/FeatureFlagModule.test.js
+++ b/packages/core-modules/test/contracts/modules/FeatureFlagModule.test.js
@@ -54,7 +54,7 @@ describe('FeatureFlagModule', () => {
     it('emits event for adding address', async () => {
       await assertEvent(
         addAddressTx,
-        `FeatureFlagAddressAdded("${FEATURE_FLAG_NAME}", "${permissionedUser.address}")`,
+        `FeatureFlagAllowlistAdded("${FEATURE_FLAG_NAME}", "${permissionedUser.address}")`,
         FeatureFlagModule
       );
     });
@@ -76,7 +76,7 @@ describe('FeatureFlagModule', () => {
 
   it('does not allow non-owners to remove feature flag addresses', async () => {
     await assertRevert(
-      FeatureFlagModule.connect(user).removeFromFreatureFlagAllowlist(
+      FeatureFlagModule.connect(user).removeFromFeatureFlagAllowlist(
         FEATURE_FLAG_NAME,
         permissionedUser.address
       ),
@@ -84,7 +84,7 @@ describe('FeatureFlagModule', () => {
     );
 
     await assertRevert(
-      FeatureFlagModule.connect(permissionedUser).removeFromFreatureFlagAllowlist(
+      FeatureFlagModule.connect(permissionedUser).removeFromFeatureFlagAllowlist(
         FEATURE_FLAG_NAME,
         permissionedUser.address
       ),
@@ -96,7 +96,7 @@ describe('FeatureFlagModule', () => {
     let removeAddressTx;
 
     before('remove user', async () => {
-      removeAddressTx = await FeatureFlagModule.connect(owner).removeFromFreatureFlagAllowlist(
+      removeAddressTx = await FeatureFlagModule.connect(owner).removeFromFeatureFlagAllowlist(
         FEATURE_FLAG_NAME,
         permissionedUser.address
       );
@@ -128,7 +128,11 @@ describe('FeatureFlagModule', () => {
     });
 
     it('emits event', async () => {
-      await assertEvent(setupTx, `FeatureFlagSet("${FEATURE_FLAG_NAME}", true)`, FeatureFlagModule);
+      await assertEvent(
+        setupTx,
+        `FeatureFlagAllowAllSet("${FEATURE_FLAG_NAME}", true)`,
+        FeatureFlagModule
+      );
     });
 
     it('reverts when feature flag is disabled', async () => {

--- a/packages/core-modules/test/contracts/modules/FeatureFlagModule.test.js
+++ b/packages/core-modules/test/contracts/modules/FeatureFlagModule.test.js
@@ -25,50 +25,46 @@ describe('FeatureFlagModule', () => {
     SampleFeatureFlagModule = await ethers.getContractAt('SampleFeatureFlagModule', proxyAddress());
   });
 
-  it('does not allow non-owners to set feature flags', async () => {
-    await assertRevert(
-      FeatureFlagModule.connect(user).setFeatureFlag(FEATURE_FLAG_NAME, true),
-      'Unauthorized'
-    );
-  });
+  describe('when a feature flag is enabled', async () => {
+    let addAddressTx;
+    before('setup permissioned user for feature flag', async () => {
+      addAddressTx = await FeatureFlagModule.connect(owner).addToFeatureFlag(
+        FEATURE_FLAG_NAME,
+        permissionedUser.address
+      );
+    });
 
-  let setupTx;
-  before('setup feature flag', async () => {
-    setupTx = await FeatureFlagModule.connect(owner).setFeatureFlag(FEATURE_FLAG_NAME, true);
-  });
+    it('does not allow non-owners to set feature flags', async () => {
+      await assertRevert(
+        FeatureFlagModule.connect(user).setFeatureFlag(FEATURE_FLAG_NAME, true),
+        'Unauthorized'
+      );
+    });
 
-  it('emits event', async () => {
-    await assertEvent(setupTx, `FeatureFlagSet("${FEATURE_FLAG_NAME}", true)`, FeatureFlagModule);
-  });
+    it('does not allow non-owners to set feature flag addresses', async () => {
+      await assertRevert(
+        FeatureFlagModule.connect(user).addToFeatureFlag(
+          FEATURE_FLAG_NAME,
+          permissionedUser.address
+        ),
+        'FeatureUnavailable'
+      );
+    });
 
-  it('does not allow non-owners to set feature flag addresses', async () => {
-    await assertRevert(
-      FeatureFlagModule.connect(user).addToFeatureFlag(FEATURE_FLAG_NAME, permissionedUser.address),
-      'Unauthorized'
-    );
-  });
-
-  let addAddressTx;
-  before('setup permissioned user for feature flag', async () => {
-    addAddressTx = await FeatureFlagModule.connect(owner).addToFeatureFlag(
-      FEATURE_FLAG_NAME,
-      permissionedUser.address
-    );
-  });
-
-  it('emits event for adding address', async () => {
-    await assertEvent(
-      addAddressTx,
-      `FeatureFlagAddressAdded("${FEATURE_FLAG_NAME}", "${permissionedUser.address}")`,
-      FeatureFlagModule
-    );
+    it('emits event for adding address', async () => {
+      await assertEvent(
+        addAddressTx,
+        `FeatureFlagAddressAdded("${FEATURE_FLAG_NAME}", "${permissionedUser.address}")`,
+        FeatureFlagModule
+      );
+    });
   });
 
   describe('call function behind feature flag', async () => {
     it('reverts when user does not have permission', async () => {
       await assertRevert(
         SampleFeatureFlagModule.connect(user).setFeatureFlaggedValue(15),
-        'Unauthorized'
+        'FeatureUnavailable'
       );
     });
 
@@ -84,7 +80,7 @@ describe('FeatureFlagModule', () => {
         FEATURE_FLAG_NAME,
         permissionedUser.address
       ),
-      'Unauthorized'
+      'FeatureUnavailable'
     );
 
     await assertRevert(
@@ -92,7 +88,7 @@ describe('FeatureFlagModule', () => {
         FEATURE_FLAG_NAME,
         permissionedUser.address
       ),
-      'Unauthorized'
+      'FeatureUnavailable'
     );
   });
 
@@ -117,14 +113,19 @@ describe('FeatureFlagModule', () => {
     it('does not allow removed permissionedUser to set value', async () => {
       await assertRevert(
         SampleFeatureFlagModule.connect(permissionedUser).setFeatureFlaggedValue(25),
-        'Unauthorized'
+        'FeatureUnavailable'
       );
     });
   });
 
   describe('enable feature for all', async () => {
-    before('disable feature flag', async () => {
-      await FeatureFlagModule.connect(owner).setFeatureFlag(FEATURE_FLAG_NAME, false);
+    let setupTx;
+    before('allow all', async () => {
+      setupTx = await FeatureFlagModule.connect(owner).setFeatureFlag(FEATURE_FLAG_NAME, true);
+    });
+
+    it('emits event', async () => {
+      await assertEvent(setupTx, `FeatureFlagSet("${FEATURE_FLAG_NAME}", true)`, FeatureFlagModule);
     });
 
     it('reverts when feature flag is disabled', async () => {

--- a/packages/core-modules/test/contracts/modules/FeatureFlagModule.test.js
+++ b/packages/core-modules/test/contracts/modules/FeatureFlagModule.test.js
@@ -6,7 +6,7 @@ const { default: assertRevert } = require('@synthetixio/core-utils/utils/asserti
 const { bootstrap } = require('@synthetixio/hardhat-router/dist/utils/tests');
 const initializer = require('@synthetixio/core-modules/test/helpers/initializer');
 
-describe('FeatureFlagModule', () => {
+describe.only('FeatureFlagModule', () => {
   const { proxyAddress } = bootstrap(initializer, {
     modules: '.*(FeatureFlagModule|SampleFeatureFlagModule|Owner|Upgrade).*',
   });
@@ -28,7 +28,7 @@ describe('FeatureFlagModule', () => {
   describe('when a feature flag is enabled', async () => {
     let addAddressTx;
     before('setup permissioned user for feature flag', async () => {
-      addAddressTx = await FeatureFlagModule.connect(owner).addToFeatureFlag(
+      addAddressTx = await FeatureFlagModule.connect(owner).addToFeatureFlagAllowlist(
         FEATURE_FLAG_NAME,
         permissionedUser.address
       );
@@ -36,18 +36,18 @@ describe('FeatureFlagModule', () => {
 
     it('does not allow non-owners to set feature flags', async () => {
       await assertRevert(
-        FeatureFlagModule.connect(user).setFeatureFlag(FEATURE_FLAG_NAME, true),
+        FeatureFlagModule.connect(user).setFeatureFlagAllowAll(FEATURE_FLAG_NAME, true),
         'Unauthorized'
       );
     });
 
     it('does not allow non-owners to set feature flag addresses', async () => {
       await assertRevert(
-        FeatureFlagModule.connect(user).addToFeatureFlag(
+        FeatureFlagModule.connect(user).addToFeatureFlagAllowlist(
           FEATURE_FLAG_NAME,
           permissionedUser.address
         ),
-        'FeatureUnavailable'
+        'Unauthorized'
       );
     });
 
@@ -76,19 +76,19 @@ describe('FeatureFlagModule', () => {
 
   it('does not allow non-owners to remove feature flag addresses', async () => {
     await assertRevert(
-      FeatureFlagModule.connect(user).removeFromFeatureFlag(
+      FeatureFlagModule.connect(user).removeFromFreatureFlagAllowlist(
         FEATURE_FLAG_NAME,
         permissionedUser.address
       ),
-      'FeatureUnavailable'
+      'Unauthorized'
     );
 
     await assertRevert(
-      FeatureFlagModule.connect(permissionedUser).removeFromFeatureFlag(
+      FeatureFlagModule.connect(permissionedUser).removeFromFreatureFlagAllowlist(
         FEATURE_FLAG_NAME,
         permissionedUser.address
       ),
-      'FeatureUnavailable'
+      'Unauthorized'
     );
   });
 
@@ -96,7 +96,7 @@ describe('FeatureFlagModule', () => {
     let removeAddressTx;
 
     before('remove user', async () => {
-      removeAddressTx = await FeatureFlagModule.connect(owner).removeFromFeatureFlag(
+      removeAddressTx = await FeatureFlagModule.connect(owner).removeFromFreatureFlagAllowlist(
         FEATURE_FLAG_NAME,
         permissionedUser.address
       );
@@ -121,7 +121,10 @@ describe('FeatureFlagModule', () => {
   describe('enable feature for all', async () => {
     let setupTx;
     before('allow all', async () => {
-      setupTx = await FeatureFlagModule.connect(owner).setFeatureFlag(FEATURE_FLAG_NAME, true);
+      setupTx = await FeatureFlagModule.connect(owner).setFeatureFlagAllowAll(
+        FEATURE_FLAG_NAME,
+        true
+      );
     });
 
     it('emits event', async () => {

--- a/packages/synthetix-main/cannonfile.toml
+++ b/packages/synthetix-main/cannonfile.toml
@@ -218,20 +218,6 @@ depends = ["run.usd_generate_router"]
 
 # Post stuff
 
-[invoke.enablePoolCreation]
-target = ["CoreProxy"]
-func = "setFeatureFlag"
-args = ["0x637265617465506f6f6c00000000000000000000000000000000000000000000", true] # formatBytes32String("createPool")
-fromCall.func = "owner"
-depends = ["invoke.upgrade_core_proxy"]
-
-[invoke.enableMarketCreation]
-target = ["CoreProxy"]
-func = "setFeatureFlag"
-args = ["0x72656769737465724d61726b6574000000000000000000000000000000000000", true] # formatBytes32String("registerMarket")
-fromCall.func = "owner"
-depends = ["invoke.upgrade_core_proxy"]
-
 [invoke.init_account]
 target = ["CoreProxy"]
 from = "<%= settings.owner %>"

--- a/packages/synthetix-main/contracts/modules/core/MarketManagerModule.sol
+++ b/packages/synthetix-main/contracts/modules/core/MarketManagerModule.sol
@@ -25,7 +25,7 @@ contract MarketManagerModule is IMarketManagerModule {
     error MarketDepositNotApproved(address market, address from, uint requestedAmount, uint approvedAmount);
 
     function registerMarket(address market) external override returns (uint128 marketId) {
-        FeatureFlag.ensureEnabled(_MARKET_FEATURE_FLAG);
+        FeatureFlag.ensureAccessToFeature(_MARKET_FEATURE_FLAG);
         // Can we verify that `market` conforms to the IMarket interface here? (i.e. has a `balance()` function?)
 
         marketId = Market.create(market).id;

--- a/packages/synthetix-main/contracts/modules/core/PoolModule.sol
+++ b/packages/synthetix-main/contracts/modules/core/PoolModule.sol
@@ -20,7 +20,7 @@ contract PoolModule is IPoolModule {
     bytes32 private constant _POOL_FEATURE_FLAG = "createPool";
 
     function createPool(uint128 requestedPoolId, address owner) external override {
-        FeatureFlag.ensureEnabled(_POOL_FEATURE_FLAG);
+        FeatureFlag.ensureAccessToFeature(_POOL_FEATURE_FLAG);
 
         if (owner == address(0)) {
             revert AddressError.ZeroAddress();

--- a/packages/synthetix-main/test/integration/bootstrap.ts
+++ b/packages/synthetix-main/test/integration/bootstrap.ts
@@ -73,8 +73,11 @@ export function bootstrap() {
 
   before('give owner permission to create pools and markets', async () => {
     const owner = signers[0];
-    await systems.Core.connect(owner).addToFeatureFlag(POOL_FEATURE_FLAG, await owner.getAddress());
-    await systems.Core.connect(owner).addToFeatureFlag(
+    await systems.Core.connect(owner).addToFeatureFlagAllowlist(
+      POOL_FEATURE_FLAG,
+      await owner.getAddress()
+    );
+    await systems.Core.connect(owner).addToFeatureFlagAllowlist(
       MARKET_FEATURE_FLAG,
       await owner.getAddress()
     );
@@ -193,7 +196,10 @@ export function bootstrapWithMockMarketAndPool() {
     MockMarket = await factory.connect(owner).deploy();
 
     // give user1 permission to register market
-    await r.systems().Core.connect(owner).addToFeatureFlag(MARKET_FEATURE_FLAG, user1.getAddress());
+    await r
+      .systems()
+      .Core.connect(owner)
+      .addToFeatureFlagAllowlist(MARKET_FEATURE_FLAG, user1.getAddress());
 
     marketId = await r.systems().Core.connect(user1).callStatic.registerMarket(MockMarket.address);
 

--- a/packages/synthetix-main/test/integration/modules/core/MarketManagerModule.test.ts
+++ b/packages/synthetix-main/test/integration/modules/core/MarketManagerModule.test.ts
@@ -35,7 +35,7 @@ describe('MarketManagerModule', function () {
     it('does not allow non-permissioned user to register market', async () => {
       await assertRevert(
         systems().Core.connect(user2).registerMarket(user1.getAddress()),
-        'Unauthorized'
+        'FeatureUnavailable'
       );
     });
 

--- a/packages/synthetix-main/test/integration/modules/core/PoolConfigurationModule/PoolConfigurationModule.test.ts
+++ b/packages/synthetix-main/test/integration/modules/core/PoolConfigurationModule/PoolConfigurationModule.test.ts
@@ -30,7 +30,10 @@ describe('PoolConfigurationModule', function () {
       before('give user1 permission to create pools', async () => {
         await systems()
           .Core.connect(owner)
-          .addToFeatureFlag(Ethers.utils.formatBytes32String('createPool'), user1.getAddress());
+          .addToFeatureFlagAllowlist(
+            Ethers.utils.formatBytes32String('createPool'),
+            user1.getAddress()
+          );
       });
 
       before('create', async () => {

--- a/packages/synthetix-main/test/integration/modules/core/PoolModuleFundAdmin.test.ts
+++ b/packages/synthetix-main/test/integration/modules/core/PoolModuleFundAdmin.test.ts
@@ -42,7 +42,10 @@ describe('PoolModule Admin', function () {
     before('give user1 permission to create pool', async () => {
       await systems()
         .Core.connect(owner)
-        .addToFeatureFlag(ethers.utils.formatBytes32String('createPool'), user1.getAddress());
+        .addToFeatureFlagAllowlist(
+          ethers.utils.formatBytes32String('createPool'),
+          user1.getAddress()
+        );
     });
 
     before('create a pool', async () => {

--- a/packages/synthetix-main/test/integration/modules/core/PoolModuleOwnership.test.ts
+++ b/packages/synthetix-main/test/integration/modules/core/PoolModuleOwnership.test.ts
@@ -29,7 +29,10 @@ describe('PoolModule Create / Ownership', function () {
     before('give user1 permission', async () => {
       await systems()
         .Core.connect(owner)
-        .addToFeatureFlag(ethers.utils.formatBytes32String('createPool'), user1.getAddress());
+        .addToFeatureFlagAllowlist(
+          ethers.utils.formatBytes32String('createPool'),
+          user1.getAddress()
+        );
     });
 
     before('create a pool', async () => {
@@ -51,7 +54,10 @@ describe('PoolModule Create / Ownership', function () {
       before('give user2 permission', async () => {
         await systems()
           .Core.connect(owner)
-          .addToFeatureFlag(ethers.utils.formatBytes32String('createPool'), user2.getAddress());
+          .addToFeatureFlagAllowlist(
+            ethers.utils.formatBytes32String('createPool'),
+            user2.getAddress()
+          );
       });
 
       it('reverts', async () => {

--- a/packages/synthetix-main/test/integration/modules/core/PoolModuleOwnership.test.ts
+++ b/packages/synthetix-main/test/integration/modules/core/PoolModuleOwnership.test.ts
@@ -19,7 +19,7 @@ describe('PoolModule Create / Ownership', function () {
       systems()
         .Core.connect(user1)
         .createPool(1, await user1.getAddress()),
-      'Unauthorized'
+      'FeatureUnavailable'
     );
   });
 

--- a/packages/synthetix-main/test/integration/modules/core/VaultModule.test.ts
+++ b/packages/synthetix-main/test/integration/modules/core/VaultModule.test.ts
@@ -30,7 +30,7 @@ describe('VaultModule', function () {
   before('give user1 permission to register market', async () => {
     await systems()
       .Core.connect(owner)
-      .addToFeatureFlag(
+      .addToFeatureFlagAllowlist(
         ethers.utils.formatBytes32String('registerMarket'),
         await user1.getAddress()
       );


### PR DESCRIPTION
- change `enabled` to `allowAll` in `FeatureFlag` storage.  This allows feature flags to be auto restricted without having to explicit set them to be restricted.
- change error from `Unauthorized` -> `FeatureUnavailable` to reduce confusion for why revert occurs.