### PR TITLE
symmetric market max debt per share handling

### DIFF
--- a/packages/hardhat-router/src/tasks/deploy.ts
+++ b/packages/hardhat-router/src/tasks/deploy.ts
@@ -82,7 +82,7 @@ task(TASK_DEPLOY, 'Deploys the given modules behind a Proxy + Router architectur
     const modulesData = await deployContracts(contracts, hre);
 
     await hre.run(SUBTASK_GENERATE_ROUTER, {
-      router: /*_contractName(*/router/*)*/,
+      router: /*_contractName(*/ router /*)*/,
       template: routerTemplate,
       contracts: modulesData,
     });

--- a/packages/hardhat-router/src/tasks/deploy.ts
+++ b/packages/hardhat-router/src/tasks/deploy.ts
@@ -82,7 +82,7 @@ task(TASK_DEPLOY, 'Deploys the given modules behind a Proxy + Router architectur
     const modulesData = await deployContracts(contracts, hre);
 
     await hre.run(SUBTASK_GENERATE_ROUTER, {
-      router,
+      router: /*_contractName(*/router/*)*/,
       template: routerTemplate,
       contracts: modulesData,
     });

--- a/packages/synthetix-main/cannonfile.test.toml
+++ b/packages/synthetix-main/cannonfile.test.toml
@@ -103,6 +103,9 @@ artifact = "contracts/modules/test/TestableMarketModule.sol:TestableMarketModule
 [contract.TestableMarketConfigurationModule]
 artifact = "contracts/modules/test/TestableMarketConfigurationModule.sol:TestableMarketConfigurationModule"
 
+[contract.TestableMarketPoolInfoModule]
+artifact = "contracts/modules/test/TestableMarketPoolInfoModule.sol:TestableMarketPoolInfoModule"
+
 [contract.TestablePoolModule]
 artifact = "contracts/modules/test/TestablePoolModule.sol:TestablePoolModule"
 
@@ -166,6 +169,7 @@ depends = [
   "contract.TestableDistributionEntryModule",
   "contract.TestableMarketModule",
   "contract.TestableMarketConfigurationModule",
+  "contract.TestableMarketPoolInfoModule",
   "contract.TestablePoolModule",
   "contract.TestablePoolConfigurationModule",
   "contract.TestableRewardDistributionModule",
@@ -204,6 +208,7 @@ abiOf = [
   "TestableDistributionEntryModule",
   "TestableMarketModule",
   "TestableMarketConfigurationModule",
+  "TestableMarketPoolInfoModule",
   "TestablePoolModule",
   "TestablePoolConfigurationModule",
   "TestableRewardDistributionModule",

--- a/packages/synthetix-main/contracts/storage/MarketPoolInfo.sol
+++ b/packages/synthetix-main/contracts/storage/MarketPoolInfo.sol
@@ -1,0 +1,23 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @title Stores information for specific actors in a Distribution.
+ */
+library MarketPoolInfo {
+    struct Data {
+        /**
+         * @dev . Needed to re-add the pool to the distribution when going back in range
+         */
+        uint128 liquidityAmount;
+
+        uint128 _unused;
+
+        /**
+         * @dev The amount of debt the pool has which hasn't been passed down the debt distribution chain yet
+         */
+        uint128 pendingDebt;
+
+        uint128 _unused2;
+    }
+}

--- a/packages/synthetix-main/contracts/storage/MarketPoolInfo.sol
+++ b/packages/synthetix-main/contracts/storage/MarketPoolInfo.sol
@@ -10,14 +10,11 @@ library MarketPoolInfo {
          * @dev . Needed to re-add the pool to the distribution when going back in range
          */
         uint128 liquidityAmount;
-
-        uint128 _unused;
-
+        uint128 unused;
         /**
          * @dev The amount of debt the pool has which hasn't been passed down the debt distribution chain yet
          */
         uint128 pendingDebt;
-
-        uint128 _unused2;
+        uint128 unused2;
     }
 }

--- a/packages/synthetix-main/test/integration/modules/core/PoolModuleFundAdmin.test.ts
+++ b/packages/synthetix-main/test/integration/modules/core/PoolModuleFundAdmin.test.ts
@@ -461,7 +461,8 @@ describe('PoolModule Admin', function () {
 
           it('has accurate amount withdrawable usd', async () => {
             // should be exactly 102 (market2 2 + 100 deposit)
-            // (market1 assumes no new debt as a result of balance going down, but accounts/can pool can withdraw at a profit)
+            // (market1 assumes no new debt as a result of balance going down,
+            // but accounts/can pool can withdraw at a profit)
             assertBn.equal(
               await systems().Core.connect(owner).getWithdrawableUsd(marketId()),
               Hundred.add(One.mul(2))


### PR DESCRIPTION
the current `main` will only re-add a pool to a market when it gets pinged by a user in the market.

however, this can lead to a situation where a pool can be drained of its funds if the market is able to control the `reportedDebt` through some manipulation. to do this, the attacker would move the `reportedDebt` such that it surpasses the limit set by the pool, and then "bump" the pool, and then move back below the reportedDebt. After bumping again, The market will then effectively take the difference between the reduced reported debt and the market limit becuase.

To prevent this from happening, this PR changes it so that a pool can be both added and removed from a market by the specified limit.

notes:
* found one bug in `hardhat-router` recent merge which caused fully qualified path to be submitted for a module for some reason, so I added a check to use `_contractName` function to prevent it from spitting out a FQN
* new internal structure in `Market` is now required because an additional property, `liquidityAmount` must be stored for when a pool is re-added to a market. Otherwise, everything functions as before.
* the `Market.distributeDebt` function is now even more narly than before, but I really have no idea how to split it meaninfully in a way that reduces code duplication. The process followed by the first loop and the second loop has some significant alterations. @ajsantander suggestions?