### PR TITLE
add tests (and fix bugs) for pools

### DIFF
--- a/packages/synthetix-main/contracts/storage/Pool.sol
+++ b/packages/synthetix-main/contracts/storage/Pool.sol
@@ -70,12 +70,10 @@ library Pool {
          * Reciprocally, this pro-rata share also determines how much the pool is exposed to each market's debt.
          */
         uint128 totalWeightsD18;
-
         /**
          * @dev Accumulated cache value of all vault collateral debts
          */
         int128 totalVaultDebtsD18;
-
         /**
          * @dev Array of markets connected to this pool, and their configurations. I.e. weight, etc.
          *
@@ -167,7 +165,12 @@ library Pool {
 
             // Contain the pool imposed market's maximum debt share value.
             // Imposed by system.
-            int effectiveMaxShareValueD18 = getSystemMaxValuePerShare(self, marketData.id, marketCreditCapacityD18, marketDebtD18);
+            int effectiveMaxShareValueD18 = getSystemMaxValuePerShare(
+                self,
+                marketData.id,
+                marketCreditCapacityD18,
+                marketDebtD18
+            );
             // Imposed by pool.
             int configuredMaxShareValueD18 = marketConfiguration.maxDebtShareValueD18;
             effectiveMaxShareValueD18 = effectiveMaxShareValueD18 < configuredMaxShareValueD18
@@ -218,20 +221,23 @@ library Pool {
             // margin = credit / systemLimit, per share
             return valuePerShare;
         } else {
-
-            uint marginD18 = creditCapacityD18.divDecimal(minLiquidityRatioD18).divDecimal(
-                totalSharesD18
-            );
+            uint marginD18 = creditCapacityD18.divDecimal(minLiquidityRatioD18).divDecimal(totalSharesD18);
 
             console.log("vps", uint(marketData.poolsDebtDistribution.getValuePerShare()));
             console.log("margin", marginD18);
             console.log("debt", uint(debtD18));
-            console.log("final", uint(marketData.poolsDebtDistribution.getValuePerShare() + 
-                marginD18.toInt() - 
-                debtD18.divDecimal(totalSharesD18.toInt())));
+            console.log(
+                "final",
+                uint(
+                    marketData.poolsDebtDistribution.getValuePerShare() +
+                        marginD18.toInt() -
+                        debtD18.divDecimal(totalSharesD18.toInt())
+                )
+            );
 
-            return marketData.poolsDebtDistribution.getValuePerShare() + 
-                marginD18.toInt() - 
+            return
+                marketData.poolsDebtDistribution.getValuePerShare() +
+                marginD18.toInt() -
                 debtD18.divDecimal(totalSharesD18.toInt());
         }
     }
@@ -284,8 +290,7 @@ library Pool {
         (uint usdWeightD18, , int deltaDebtD18) = self.vaults[collateralType].updateCreditCapacity(collateralPriceD18);
         if (deltaDebtD18 >= 0) {
             console.log("DELTA DEB", uint(deltaDebtD18));
-        }
-        else {
+        } else {
             console.log("DELTA DEB -", uint(-deltaDebtD18));
         }
 

--- a/packages/synthetix-main/contracts/storage/Pool.sol
+++ b/packages/synthetix-main/contracts/storage/Pool.sol
@@ -253,7 +253,7 @@ library Pool {
         collateralPriceD18 = CollateralConfiguration.load(collateralType).getCollateralPrice();
 
         // Changes in price update the corresponding vault's total collateral value as well as its liquidity (collateral - debt).
-        (uint usdWeightD18, , int deltaLiquidityD18) = self.vaults[collateralType].updateLiquidity(collateralPriceD18);
+        (uint usdWeightD18, , int deltaLiquidityD18) = self.vaults[collateralType].updateCreditCapacity(collateralPriceD18);
 
         // Update the vault's shares in the pool's debt distribution, according to the value of its collateral.
         bytes32 actorId = bytes32(uint(uint160(collateralType)));

--- a/packages/synthetix-main/contracts/storage/Pool.sol
+++ b/packages/synthetix-main/contracts/storage/Pool.sol
@@ -11,6 +11,8 @@ import "@synthetixio/core-contracts/contracts/errors/AccessError.sol";
 
 import "@synthetixio/core-contracts/contracts/utils/SafeCast.sol";
 
+import "hardhat/console.sol";
+
 /**
  * @title Aggregates collateral from multiple users in order to provide liquidity to a configurable set of markets.
  *
@@ -24,6 +26,7 @@ library Pool {
     using Vault for Vault.Data;
     using Distribution for Distribution.Data;
     using DecimalMath for uint256;
+    using DecimalMath for int256;
     using DecimalMath for int128;
 
     using SafeCastU128 for uint128;
@@ -67,10 +70,12 @@ library Pool {
          * Reciprocally, this pro-rata share also determines how much the pool is exposed to each market's debt.
          */
         uint128 totalWeightsD18;
+
         /**
-         * @dev Accumulated cache value of all vault liquidities, i.e. their collateral value minus their debt.
+         * @dev Accumulated cache value of all vault collateral debts
          */
-        uint128 unusedCreditCapacityD18;
+        int128 totalVaultDebtsD18;
+
         /**
          * @dev Array of markets connected to this pool, and their configurations. I.e. weight, etc.
          *
@@ -141,7 +146,7 @@ library Pool {
         // Read from storage once, before entering the loop below.
         // These values should not change while iterating through each market.
         uint totalCreditCapacityD18 = self.vaultsDebtDistribution.totalSharesD18;
-        uint128 unusedCreditCapacityD18 = self.unusedCreditCapacityD18;
+        int128 totalDebtD18 = self.totalVaultDebtsD18;
 
         int cumulativeDebtChangeD18 = 0;
 
@@ -156,18 +161,20 @@ library Pool {
             // Note: the factor `(weight / totalWeights)` is not deduped in the operations below to maintain numeric precision.
 
             uint marketCreditCapacityD18 = (totalCreditCapacityD18 * weightD18) / totalWeightsD18;
-            uint marketUnusedCreditCapacityD18 = (unusedCreditCapacityD18 * weightD18) / totalWeightsD18;
+            int marketDebtD18 = (totalDebtD18 * weightD18.toInt()) / totalWeightsD18.toInt();
 
             Market.Data storage marketData = Market.load(marketConfiguration.marketId);
 
             // Contain the pool imposed market's maximum debt share value.
             // Imposed by system.
-            int effectiveMaxShareValueD18 = getSystemMaxValuePerShare(self, marketData, marketUnusedCreditCapacityD18);
+            int effectiveMaxShareValueD18 = getSystemMaxValuePerShare(self, marketData.id, marketCreditCapacityD18, marketDebtD18);
             // Imposed by pool.
             int configuredMaxShareValueD18 = marketConfiguration.maxDebtShareValueD18;
             effectiveMaxShareValueD18 = effectiveMaxShareValueD18 < configuredMaxShareValueD18
                 ? effectiveMaxShareValueD18
                 : configuredMaxShareValueD18;
+
+            console.log("EFFECTIVE msv", uint(effectiveMaxShareValueD18));
 
             // Update each market's corresponding credit capacity.
             // The returned value represents how much the market's debt changed after changing the shares of this pool actor, which is aggregated to later be passed on the pools debt distribution.
@@ -192,24 +199,41 @@ library Pool {
      */
     function getSystemMaxValuePerShare(
         Data storage self,
-        Market.Data storage marketData,
-        uint unusedCreditCapacityD18
+        uint128 marketId, // we are keeping this value as a uint128 for now for testability reasons
+        uint creditCapacityD18,
+        int debtD18
     ) internal view returns (int) {
+        Market.Data storage marketData = Market.load(marketId);
+
         uint minLiquidityRatioD18 = PoolConfiguration.load().minLiquidityRatioD18;
 
         // Calculate the margin of debt that the market could incur to hit the system wide limit.
-        uint marginD18;
+        uint totalSharesD18 = self.vaultsDebtDistribution.totalSharesD18;
+        int valuePerShare = marketData.poolsDebtDistribution.getValuePerShare();
+
         if (minLiquidityRatioD18 == 0) {
             // If minLiquidityRatioD18 is zero, then set limit to 100%.
-            marginD18 = DecimalMath.UNIT;
+            return valuePerShare + int(DecimalMath.UNIT);
+        } else if (totalSharesD18 == 0) {
+            // margin = credit / systemLimit, per share
+            return valuePerShare;
         } else {
-            // margin = unusedCredit / systemLimit, per share
-            marginD18 = unusedCreditCapacityD18.divDecimal(minLiquidityRatioD18).divDecimal(
-                self.vaultsDebtDistribution.totalSharesD18
-            );
-        }
 
-        return marketData.poolsDebtDistribution.getValuePerShare() + marginD18.toInt();
+            uint marginD18 = creditCapacityD18.divDecimal(minLiquidityRatioD18).divDecimal(
+                totalSharesD18
+            );
+
+            console.log("vps", uint(marketData.poolsDebtDistribution.getValuePerShare()));
+            console.log("margin", marginD18);
+            console.log("debt", uint(debtD18));
+            console.log("final", uint(marketData.poolsDebtDistribution.getValuePerShare() + 
+                marginD18.toInt() - 
+                debtD18.divDecimal(totalSharesD18.toInt())));
+
+            return marketData.poolsDebtDistribution.getValuePerShare() + 
+                marginD18.toInt() - 
+                debtD18.divDecimal(totalSharesD18.toInt());
+        }
     }
 
     /**
@@ -249,23 +273,29 @@ library Pool {
         // Update each market's pro-rata liquidity and collect accumulated debt into the pool's debt distribution.
         distributeDebtToVaults(self);
 
+        // Transfer the debt change from the pool into the vault.
+        bytes32 actorId = bytes32(uint(uint160(collateralType)));
+        self.vaults[collateralType].distributeDebtToAccounts(self.vaultsDebtDistribution.accumulateActor(actorId));
+
         // Get the latest collateral price.
         collateralPriceD18 = CollateralConfiguration.load(collateralType).getCollateralPrice();
 
         // Changes in price update the corresponding vault's total collateral value as well as its liquidity (collateral - debt).
-        (uint usdWeightD18, , int deltaLiquidityD18) = self.vaults[collateralType].updateCreditCapacity(collateralPriceD18);
+        (uint usdWeightD18, , int deltaDebtD18) = self.vaults[collateralType].updateCreditCapacity(collateralPriceD18);
+        if (deltaDebtD18 >= 0) {
+            console.log("DELTA DEB", uint(deltaDebtD18));
+        }
+        else {
+            console.log("DELTA DEB -", uint(-deltaDebtD18));
+        }
 
         // Update the vault's shares in the pool's debt distribution, according to the value of its collateral.
-        bytes32 actorId = bytes32(uint(uint160(collateralType)));
-        int debtChangeD18 = self.vaultsDebtDistribution.setActorShares(actorId, usdWeightD18);
+        self.vaultsDebtDistribution.setActorShares(actorId, usdWeightD18);
 
         // Accumulate the change in total liquidity, from the vault, into the pool.
-        self.unusedCreditCapacityD18 = (self.unusedCreditCapacityD18.toInt() + deltaLiquidityD18.to128()).toUint();
+        self.totalVaultDebtsD18 = self.totalVaultDebtsD18 + deltaDebtD18.to128();
 
-        // Transfer the debt change from the pool into the vault.
-        self.vaults[collateralType].distributeDebtToAccounts(debtChangeD18);
-
-        // Distribute debt again because the unused credit capacity has been updated, and this information needs to be propagated immediately.
+        // Distribute debt again because the market credit capacity may have changed, so we should ensure the vaults have the most up to date capacities
         distributeDebtToVaults(self);
     }
 

--- a/packages/synthetix-main/contracts/storage/Pool.sol
+++ b/packages/synthetix-main/contracts/storage/Pool.sol
@@ -207,14 +207,14 @@ library Pool {
 
         // Calculate the margin of debt that the market could incur to hit the system wide limit.
         uint totalSharesD18 = self.vaultsDebtDistribution.totalSharesD18;
-        int valuePerShare = marketData.poolsDebtDistribution.getValuePerShare();
+        int valuePerShareD18 = marketData.poolsDebtDistribution.getValuePerShare();
 
         if (minLiquidityRatioD18 == 0) {
             // If minLiquidityRatioD18 is zero, then set limit to 100%.
-            return valuePerShare + int(DecimalMath.UNIT);
+            return valuePerShareD18 + int(DecimalMath.UNIT);
         } else if (totalSharesD18 == 0) {
             // margin = credit / systemLimit, per share
-            return valuePerShare;
+            return valuePerShareD18;
         } else {
             uint marginD18 = creditCapacityD18.divDecimal(minLiquidityRatioD18).divDecimal(totalSharesD18);
 

--- a/packages/synthetix-main/contracts/storage/Pool.sol
+++ b/packages/synthetix-main/contracts/storage/Pool.sol
@@ -11,8 +11,6 @@ import "@synthetixio/core-contracts/contracts/errors/AccessError.sol";
 
 import "@synthetixio/core-contracts/contracts/utils/SafeCast.sol";
 
-import "hardhat/console.sol";
-
 /**
  * @title Aggregates collateral from multiple users in order to provide liquidity to a configurable set of markets.
  *
@@ -177,8 +175,6 @@ library Pool {
                 ? effectiveMaxShareValueD18
                 : configuredMaxShareValueD18;
 
-            console.log("EFFECTIVE msv", uint(effectiveMaxShareValueD18));
-
             // Update each market's corresponding credit capacity.
             // The returned value represents how much the market's debt changed after changing the shares of this pool actor, which is aggregated to later be passed on the pools debt distribution.
             cumulativeDebtChangeD18 += Market.rebalancePools(
@@ -222,18 +218,6 @@ library Pool {
             return valuePerShare;
         } else {
             uint marginD18 = creditCapacityD18.divDecimal(minLiquidityRatioD18).divDecimal(totalSharesD18);
-
-            console.log("vps", uint(marketData.poolsDebtDistribution.getValuePerShare()));
-            console.log("margin", marginD18);
-            console.log("debt", uint(debtD18));
-            console.log(
-                "final",
-                uint(
-                    marketData.poolsDebtDistribution.getValuePerShare() +
-                        marginD18.toInt() -
-                        debtD18.divDecimal(totalSharesD18.toInt())
-                )
-            );
 
             return
                 marketData.poolsDebtDistribution.getValuePerShare() +
@@ -288,11 +272,6 @@ library Pool {
 
         // Changes in price update the corresponding vault's total collateral value as well as its liquidity (collateral - debt).
         (uint usdWeightD18, , int deltaDebtD18) = self.vaults[collateralType].updateCreditCapacity(collateralPriceD18);
-        if (deltaDebtD18 >= 0) {
-            console.log("DELTA DEB", uint(deltaDebtD18));
-        } else {
-            console.log("DELTA DEB -", uint(-deltaDebtD18));
-        }
 
         // Update the vault's shares in the pool's debt distribution, according to the value of its collateral.
         self.vaultsDebtDistribution.setActorShares(actorId, usdWeightD18);

--- a/packages/synthetix-main/contracts/storage/Vault.sol
+++ b/packages/synthetix-main/contracts/storage/Vault.sol
@@ -45,7 +45,7 @@ library Vault {
         // solhint-disable-next-line private-vars-leading-underscore
         uint128 __unused;
         /**
-         * @dev The previous credit capacity of the vault (collateral - debt), when the system was last interacted with.
+         * @dev The previous debt of the vault, when `updateCreditCapacity` was last called by the Pool.
          */
         int128 prevTotalDebtD18;
         /**

--- a/packages/synthetix-main/contracts/storage/Vault.sol
+++ b/packages/synthetix-main/contracts/storage/Vault.sol
@@ -47,7 +47,7 @@ library Vault {
         /**
          * @dev The previous credit capacity of the vault (collateral - debt), when the system was last interacted with.
          */
-        uint128 prevRemainingCreditCapacityD18;
+        int128 prevTotalDebtD18;
         /**
          * @dev Vault data for all the liquidation cycles divided into epochs.
          */
@@ -81,8 +81,8 @@ library Vault {
         internal
         returns (
             uint usdWeightD18,
-            uint remainingCreditCapacityD18,
-            int deltaRemainingCreditCapacityD18
+            int totalDebtD18,
+            int deltaDebtD18
         )
     {
         VaultEpoch.Data storage epochData = currentEpoch(self);
@@ -92,14 +92,12 @@ library Vault {
         int vaultDepositedValueD18 = epochData.collateralAmounts.totalAmount().toInt().mulDecimal(
             collateralPriceD18.toInt()
         );
-        int vaultAccruedDebtD18 = epochData.totalDebt();
-        remainingCreditCapacityD18 = vaultDepositedValueD18 > vaultAccruedDebtD18
-            ? (vaultDepositedValueD18 - vaultAccruedDebtD18).toUint()
-            : 0;
 
-        deltaRemainingCreditCapacityD18 = remainingCreditCapacityD18.toInt() - self.prevRemainingCreditCapacityD18.toInt();
+        totalDebtD18 = epochData.totalDebt();
 
-        self.prevRemainingCreditCapacityD18 = remainingCreditCapacityD18.to128();
+        deltaDebtD18 = totalDebtD18 - self.prevTotalDebtD18;
+
+        self.prevTotalDebtD18 = totalDebtD18.to128();
     }
 
     /**

--- a/packages/synthetix-main/contracts/storage/Vault.sol
+++ b/packages/synthetix-main/contracts/storage/Vault.sol
@@ -45,9 +45,9 @@ library Vault {
         // solhint-disable-next-line private-vars-leading-underscore
         uint128 __unused;
         /**
-         * @dev The previous liquidity of the vault (collateral - debt), when the system was last interacted with.
+         * @dev The previous credit capacity of the vault (collateral - debt), when the system was last interacted with.
          */
-        uint128 prevRemainingLiquidityD18;
+        uint128 prevRemainingCreditCapacityD18;
         /**
          * @dev Vault data for all the liquidation cycles divided into epochs.
          */
@@ -70,21 +70,19 @@ library Vault {
     }
 
     /**
-     * @dev Updates the vault's liquidity as the value of its collateral minus its debt.
+     * @dev Updates the vault's credit capacity as the value of its collateral minus its debt.
      *
      * Called as a ticker when users interact with pools, allowing pools to set
-     * vaults' liquidity shares within the them.
+     * vaults' credit capacity shares within the them.
      *
      * Returns the amount of collateral that this vault is providing in net USD terms.
-     *
-     * TODO: Consider renaming to updateCreditCapacity?
      */
-    function updateLiquidity(Data storage self, uint collateralPriceD18)
+    function updateCreditCapacity(Data storage self, uint collateralPriceD18)
         internal
         returns (
             uint usdWeightD18,
-            uint remainingLiquidityD18,
-            int deltaRemainingLiquidityD18
+            uint remainingCreditCapacityD18,
+            int deltaRemainingCreditCapacityD18
         )
     {
         VaultEpoch.Data storage epochData = currentEpoch(self);
@@ -95,13 +93,13 @@ library Vault {
             collateralPriceD18.toInt()
         );
         int vaultAccruedDebtD18 = epochData.totalDebt();
-        remainingLiquidityD18 = vaultDepositedValueD18 > vaultAccruedDebtD18
+        remainingCreditCapacityD18 = vaultDepositedValueD18 > vaultAccruedDebtD18
             ? (vaultDepositedValueD18 - vaultAccruedDebtD18).toUint()
             : 0;
 
-        deltaRemainingLiquidityD18 = remainingLiquidityD18.toInt() - self.prevRemainingLiquidityD18.toInt();
+        deltaRemainingCreditCapacityD18 = remainingCreditCapacityD18.toInt() - self.prevRemainingCreditCapacityD18.toInt();
 
-        self.prevRemainingLiquidityD18 = remainingLiquidityD18.to128();
+        self.prevRemainingCreditCapacityD18 = remainingCreditCapacityD18.to128();
     }
 
     /**

--- a/packages/synthetix-main/contracts/storage/Vault.sol
+++ b/packages/synthetix-main/contracts/storage/Vault.sol
@@ -89,10 +89,6 @@ library Vault {
 
         usdWeightD18 = uint(epochData.accountsDebtDistribution.totalSharesD18).mulDecimal(collateralPriceD18);
 
-        int vaultDepositedValueD18 = epochData.collateralAmounts.totalAmount().toInt().mulDecimal(
-            collateralPriceD18.toInt()
-        );
-
         totalDebtD18 = epochData.totalDebt();
 
         deltaDebtD18 = totalDebtD18 - self.prevTotalDebtD18;

--- a/packages/synthetix-main/contracts/storage/VaultEpoch.sol
+++ b/packages/synthetix-main/contracts/storage/VaultEpoch.sol
@@ -5,6 +5,7 @@ import "./Distribution.sol";
 import "./ScalableMapping.sol";
 
 import "@synthetixio/core-contracts/contracts/utils/SafeCast.sol";
+import "hardhat/console.sol";
 
 /**
  * @title Tracks collateral and debt distributions in a pool, for a specific collateral type, in a given epoch.

--- a/packages/synthetix-main/contracts/storage/VaultEpoch.sol
+++ b/packages/synthetix-main/contracts/storage/VaultEpoch.sol
@@ -5,7 +5,6 @@ import "./Distribution.sol";
 import "./ScalableMapping.sol";
 
 import "@synthetixio/core-contracts/contracts/utils/SafeCast.sol";
-import "hardhat/console.sol";
 
 /**
  * @title Tracks collateral and debt distributions in a pool, for a specific collateral type, in a given epoch.

--- a/packages/synthetix-main/test/integration/bootstrap.ts
+++ b/packages/synthetix-main/test/integration/bootstrap.ts
@@ -6,6 +6,8 @@ import { snapshotCheckpoint } from '../utils';
 import { runTypeChain, glob } from 'typechain';
 import { AccountProxy, CoreProxy, SNXProxy, USDProxy } from '../generated/typechain';
 
+import { MockMarket } from '../../typechain-types/contracts/mocks/MockMarket';
+
 const POOL_FEATURE_FLAG = ethers.utils.formatBytes32String('createPool');
 const MARKET_FEATURE_FLAG = ethers.utils.formatBytes32String('registerMarket');
 
@@ -211,7 +213,7 @@ export function bootstrapWithStakedPool() {
 export function bootstrapWithMockMarketAndPool() {
   const r = bootstrapWithStakedPool();
 
-  let MockMarket: ethers.Contract;
+  let MockMarket: MockMarket;
   let marketId: ethers.BigNumber;
 
   before('deploy and connect fake market', async () => {

--- a/packages/synthetix-main/test/integration/storage/Pool.test.ts
+++ b/packages/synthetix-main/test/integration/storage/Pool.test.ts
@@ -1,0 +1,210 @@
+import assertBn from '@synthetixio/core-utils/utils/assertions/assert-bignumber';
+import { bootstrapWithMockMarketAndPool } from '../bootstrap';
+import { ethers } from 'ethers';
+import { snapshotCheckpoint } from '../../utils';
+
+describe('Pool', function () {
+  const {
+    systems, 
+    provider, 
+    signers, 
+    marketId, 
+    poolId, 
+    accountId,
+    MockMarket, 
+    depositAmount, 
+    collateralAddress 
+  } = bootstrapWithMockMarketAndPool();
+
+  const One = ethers.utils.parseEther('1');
+
+  let owner: ethers.Signer, user1: ethers.Signer;
+
+  const secondaryPoolId = 9877;
+
+  before('init', async () => {
+    [owner, user1] = signers();
+
+    // create a basic pool
+    /*await systems().Core.connect(owner).createPool(poolId, await owner.getAddress());
+
+    await systems().Core.connect(owner).setPoolConfiguration(poolId, [
+      {
+        marketId: marketId(),
+        weightD18: 1,
+        maxDebtShareValueD18: ethers.utils.parseEther('10000')
+      }
+    ]);*/
+
+    // create a secondary pool for testing cases of having multiple pools for one market
+    await systems().Core.connect(owner).createPool(secondaryPoolId, await owner.getAddress());
+
+    await systems().Core.connect(owner).setPoolConfiguration(secondaryPoolId, [
+      {
+        marketId: marketId(),
+        weightD18: 1,
+        maxDebtShareValueD18: ethers.utils.parseEther('10000')
+      }
+    ]);
+
+    await systems().Core.connect(owner).setMinLiquidityRatio(One.mul(2));
+
+    // ping to make sure ratio is applied on active position for read only calls
+    await systems().Core.connect(owner).getPositionDebt(accountId, poolId, collateralAddress());
+  });
+
+  const restore = snapshotCheckpoint(provider);
+
+  describe('getSystemMaxValuePerShare()', async () => {
+
+    describe('when undelegated from pool', async () => {
+      before(restore);
+      before('undelegate', async () => {
+        await systems().Core.connect(user1).delegateCollateral(
+          accountId, 
+          poolId, 
+          collateralAddress(), 
+          0, 
+          ethers.utils.parseEther('1')
+        );
+
+        // sanity
+        assertBn.equal(
+          await systems().Core.Market_get_creditCapacityD18(marketId()),
+          0
+        );
+      });
+
+      it('returns 0 for a pool with nothing delegated', async () => {
+        assertBn.equal(
+          await systems().Core.Pool_getSystemMaxValuePerShare(poolId, marketId(), 0, 0),
+          0
+        );
+      });
+    });
+
+    describe('with usual staking position', async () => {
+      before(restore);
+
+      it('returns 0 with 0 unused credit capacity even if there are shares', async () => {
+        assertBn.equal(
+          await systems().Core.Pool_getSystemMaxValuePerShare(poolId, marketId(), depositAmount.div(2), 0),
+          ethers.utils.parseEther('0.25')
+        );
+      });
+
+      it('returns 50 with 100 unused credit capacity with shares multiplied', async () => {
+        assertBn.equal(
+          // multiply by deposit shares because we want 100 units of capacity per share
+          await systems().Core.Pool_getSystemMaxValuePerShare(poolId, marketId(), depositAmount.div(2), 0),
+          ethers.utils.parseEther('0.25')
+        );
+      });
+
+      describe('change min liquidity ratio', async () => {
+        before('change ratio', async () => {
+          await systems().Core.connect(owner).setMinLiquidityRatio(ethers.utils.parseEther('4'));
+        });
+
+        it('returns even less available liquidity with same credit capacity query', async () => {
+          assertBn.equal(
+            // multiply by deposit shares because we want 100 units of capacity per share
+            await systems().Core.Pool_getSystemMaxValuePerShare(poolId, marketId(), depositAmount.div(2), 0),
+            ethers.utils.parseEther('0.125')
+          );
+        });
+      });
+    });
+  });
+
+  describe('recalculateVaultCollateral()', async () => {
+
+    before(restore);
+
+    let initialMarketCapacity: ethers.BigNumber;
+
+    before('save market capacity', async () => {
+      initialMarketCapacity = await systems().Core.Market_get_creditCapacityD18(marketId());
+    });
+
+    it('recalculates nothing when vault is empty', async () => {
+      await systems().Core.connect(owner).Pool_recalculateVaultCollateral(poolId, collateralAddress());
+
+      // remaining in the test todo
+    });
+
+    describe('market debt goes up', async () => {
+      before('increase market debt', async () => {
+        await MockMarket().connect(owner).setReportedDebt(depositAmount.div(10));
+
+        // call this function to trigger downstream debts
+        assertBn.equal(
+          await systems().Core.connect(owner).callStatic.getPositionDebt(accountId, poolId, collateralAddress()),
+          depositAmount.div(10)
+        );
+
+        await systems().Core.connect(owner).getPositionDebt(accountId, poolId, collateralAddress());
+
+      });
+
+      it('system max value per share returns same as the market', async () => {
+        // debt per share should be increased because of the debt but the parameter 
+        // still shows same amount of max value pre share
+        assertBn.equal(
+          await systems().Core.Pool_getSystemMaxValuePerShare(poolId, marketId(), 0, 0),
+          One.div(10)
+        );
+      });
+
+      it('returns same credit capacity since limit has not been updated', async () => {
+        assertBn.equal(
+          await systems().Core.Pool_getSystemMaxValuePerShare(
+            poolId, 
+            marketId(), 
+            depositAmount,
+            await systems().Core.Pool_get_totalVaultDebtsD18(poolId)
+          ),
+          depositAmount.div(2).mul(One).div(depositAmount)
+        );
+      });
+
+      it('the ultimate capacity of the market ends up to be the same', async () => {
+        assertBn.equal(
+          await systems().Core.Market_get_creditCapacityD18(marketId()),
+          initialMarketCapacity
+        );
+      });
+
+      describe('when more collateral is added', async () => {
+        before('increase collateral', async () => {
+          await systems().Core.connect(user1).delegateCollateral(
+            accountId, 
+            poolId, 
+            collateralAddress(), 
+            depositAmount.mul(2), 
+            ethers.utils.parseEther('1')
+          );
+        });
+
+        it('has more limit', async () => {
+          assertBn.equal(
+            await systems().Core.Pool_getSystemMaxValuePerShare(
+              poolId, 
+              marketId(), 
+              depositAmount.mul(2),
+              await systems().Core.Pool_get_totalVaultDebtsD18(poolId)
+            ),
+            One.div(100).mul(55) // value becomes 55 because there are more shares, but half of them have 0.1 attached to them
+          );
+        });
+
+        it('the ultimate capacity of the pool ends up higher', async () => {
+          assertBn.gt(
+            await systems().Core.Market_get_creditCapacityD18(marketId()),
+            initialMarketCapacity
+          );
+        });
+      });
+    });
+  });
+});

--- a/packages/synthetix-main/test/integration/storage/Pool.test.ts
+++ b/packages/synthetix-main/test/integration/storage/Pool.test.ts
@@ -25,17 +25,6 @@ describe('Pool', function () {
   before('init', async () => {
     [owner, user1] = signers();
 
-    // create a basic pool
-    /*await systems().Core.connect(owner).createPool(poolId, await owner.getAddress());
-
-    await systems().Core.connect(owner).setPoolConfiguration(poolId, [
-      {
-        marketId: marketId(),
-        weightD18: 1,
-        maxDebtShareValueD18: ethers.utils.parseEther('10000')
-      }
-    ]);*/
-
     // create a secondary pool for testing cases of having multiple pools for one market
     await systems()
       .Core.connect(owner)


### PR DESCRIPTION
add tests to verify that the system imposed max debt limit is sufficiently
protecting the protocol from debt loss.

there were some bugs identified
during this process, but they have been fixed now.