### PR TITLE
`CoreRouter` cannonfile generation setp should not include account to…

### DIFF
--- a/packages/synthetix-main/cannonfile.test.toml
+++ b/packages/synthetix-main/cannonfile.test.toml
@@ -147,7 +147,6 @@ args = [
   "contracts/routers/chain-<%= chainId %>/CoreRouter.sol:CoreRouter",
   '''<%= JSON.stringify({
     InitialModuleBundle: contracts.InitialModuleBundle,
-    AccountTokenModule: contracts.AccountTokenModule,
     FeatureFlagModule: contracts.FeatureFlagModule,
     AccountModule: contracts.AccountModule,
     AssociateDebtModule: contracts.AssociateDebtModule,

--- a/packages/synthetix-main/cannonfile.toml
+++ b/packages/synthetix-main/cannonfile.toml
@@ -83,7 +83,6 @@ args = [
   "contracts/routers/chain-<%= chainId %>/CoreRouter.sol:CoreRouter",
   '''<%= JSON.stringify({
     InitialModuleBundle: contracts.InitialModuleBundle,
-    AccountTokenModule: contracts.AccountTokenModule,
     FeatureFlagModule: contracts.FeatureFlagModule,
     AccountModule: contracts.AccountModule,
     AssociateDebtModule: contracts.AssociateDebtModule,


### PR DESCRIPTION
…ken module

this causes a bug where the data is included during a layered build step when it is not needed