### PR TITLE
Make all object functions internal

### DIFF
--- a/protocol/synthetix/contracts/storage/Distribution.sol
+++ b/protocol/synthetix/contracts/storage/Distribution.sol
@@ -80,7 +80,7 @@ library Distribution {
         bytes32 actorId,
         uint newActorSharesD18
     ) internal returns (int valueChangeD18) {
-        valueChangeD18 = _getActorValueChange(dist, actorId);
+        valueChangeD18 = getActorValueChange(dist, actorId);
 
         DistributionActor.Data storage actor = dist.actorInfo[actorId];
 
@@ -112,10 +112,10 @@ library Distribution {
      * which is `(valuePerShare_now - valuePerShare_then) * shares`,
      * or just `delta_valuePerShare * shares`.
      */
-    function _getActorValueChange(
+    function getActorValueChange(
         Data storage dist,
         bytes32 actorId
-    ) private view returns (int valueChangeD18) {
+    ) internal view returns (int valueChangeD18) {
         DistributionActor.Data storage actor = dist.actorInfo[actorId];
         int deltaValuePerShareD27 = dist.valuePerShareD27 - actor.lastValuePerShareD27;
 

--- a/protocol/synthetix/contracts/storage/Market.sol
+++ b/protocol/synthetix/contracts/storage/Market.sol
@@ -374,7 +374,7 @@ library Market {
         int256 targetBalanceD18 = totalDebt(self);
         int256 outstandingBalanceD18 = targetBalanceD18 - self.lastDistributedMarketBalanceD18;
 
-        (, bool exhausted) = _bumpPools(self, outstandingBalanceD18, maxIter);
+        (, bool exhausted) = bumpPools(self, outstandingBalanceD18, maxIter);
 
         if (!exhausted && self.poolsDebtDistribution.totalSharesD18 > 0) {
             // cannot use `outstandingBalance` here because `self.lastDistributedMarketBalance`
@@ -389,10 +389,10 @@ library Market {
     /**
      * @dev Determine the target valuePerShare of the poolsDebtDistribution, given the value that is yet to be distributed.
      */
-    function _getTargetValuePerShare(
+    function getTargetValuePerShare(
         Market.Data storage self,
         int valueToDistributeD18
-    ) private view returns (int targetValuePerShareD18) {
+    ) internal view returns (int targetValuePerShareD18) {
         return
             self.poolsDebtDistribution.getValuePerShare() +
             valueToDistributeD18.divDecimal(self.poolsDebtDistribution.totalSharesD18.toInt());
@@ -403,11 +403,11 @@ library Market {
      *
      * The debt is distributed up to the limit of the max value per share that the pool tolerates on the market.
      */
-    function _bumpPools(
+    function bumpPools(
         Data storage self,
         int maxDistributedD18,
         uint maxIter
-    ) private returns (int actuallyDistributedD18, bool exhausted) {
+    ) internal returns (int actuallyDistributedD18, bool exhausted) {
         if (maxDistributedD18 == 0 || self.poolsDebtDistribution.totalSharesD18 == 0) {
             return (0, false);
         }
@@ -441,14 +441,14 @@ library Market {
             // Note: `-edgePool.priority` is actually the max value per share limit of the pool
             if (
                 -edgePool.priority >=
-                k * _getTargetValuePerShare(self, (maxDistributedD18 - actuallyDistributedD18))
+                k * getTargetValuePerShare(self, (maxDistributedD18 - actuallyDistributedD18))
             ) {
                 break;
             }
 
             // The pool has hit its maximum value per share and needs to be removed.
             // Note: No need to update capacity because pool max share value = valuePerShare when this happens.
-            _togglePool(fromHeap, toHeap);
+            togglePool(fromHeap, toHeap);
 
             // Distribute the market's debt to the limit, i.e. for that which exceeds the maximum value per share.
             int debtToLimitD18 = self.poolsDebtDistribution.totalSharesD18.toInt().mulDecimal(
@@ -494,7 +494,7 @@ library Market {
     /**
      * @dev Moves a pool from one heap into another.
      */
-    function _togglePool(HeapUtil.Data storage from, HeapUtil.Data storage to) private {
+    function togglePool(HeapUtil.Data storage from, HeapUtil.Data storage to) internal {
         HeapUtil.Node memory node = from.extractMax();
         to.insert(node.id, -node.priority);
     }

--- a/protocol/synthetix/contracts/storage/MarketCreator.sol
+++ b/protocol/synthetix/contracts/storage/MarketCreator.sol
@@ -12,7 +12,7 @@ library MarketCreator {
         uint128 lastCreatedMarketId;
     }
 
-    function _getStore() private pure returns (Data storage data) {
+    function getMarketStore() internal pure returns (Data storage data) {
         bytes32 s = keccak256("MarketStore");
         assembly {
             data.slot := s
@@ -27,7 +27,7 @@ library MarketCreator {
      * Note: If an external `IMarket` contract tracks several market ids, this function should be called for each market it tracks, resulting in multiple ids for the same address.
      */
     function create(address marketAddress) internal returns (Market.Data storage market) {
-        Data storage store = _getStore();
+        Data storage store = getMarketStore();
 
         uint128 id = store.lastCreatedMarketId;
         id++;
@@ -48,6 +48,6 @@ library MarketCreator {
      * Note: A contract implementing the `IMarket` interface may represent more than just one market, and thus several market ids could be associated to a single external contract address.
      */
     function loadIdsByAddress(address marketAddress) internal view returns (uint128[] storage ids) {
-        return _getStore().marketIdsForAddress[marketAddress];
+        return getMarketStore().marketIdsForAddress[marketAddress];
     }
 }

--- a/protocol/synthetix/contracts/storage/ScalableMapping.sol
+++ b/protocol/synthetix/contracts/storage/ScalableMapping.sol
@@ -87,7 +87,7 @@ library ScalableMapping {
         // Represent the actor's change in value by changing the actor's number of shares,
         // and keeping the distribution's scaleModifier constant.
 
-        resultingSharesD18 = _getSharesForAmount(self, newActorValueD18);
+        resultingSharesD18 = getSharesForAmount(self, newActorValueD18);
 
         // Modify the total shares with the actor's change in shares.
         self.totalSharesD18 = (self.totalSharesD18 + resultingSharesD18 - self.sharesD18[actorId])
@@ -121,10 +121,10 @@ library ScalableMapping {
                 self.totalSharesD18) / DecimalMath.UNIT_PRECISE;
     }
 
-    function _getSharesForAmount(
+    function getSharesForAmount(
         Data storage self,
         uint amountD18
-    ) private view returns (uint sharesD18) {
+    ) internal view returns (uint sharesD18) {
         sharesD18 =
             (amountD18 * DecimalMath.UNIT_PRECISE) /
             (self.scaleModifierD27 + DecimalMath.UNIT_PRECISE_INT128).toUint();


### PR DESCRIPTION
Make all object/library functions internal, so that they can be accessed by generative tests.

Another alternative was to enforce encapsulation in objects by making functions that are only called from the object itself private, and rename them to start with underscore, but this would not allow us to test them directly. So we resolved to make every thing internal and that's that.