### PR TITLE
Rename DistributionEntry to RewardDistributionEntry

### DIFF
--- a/protocol/synthetix/cannonfile.test.toml
+++ b/protocol/synthetix/cannonfile.test.toml
@@ -106,8 +106,8 @@ artifact = "contracts/modules/test/TestableDistributionModule.sol:TestableDistri
 [contract.TestableDistributionActorModule]
 artifact = "contracts/modules/test/TestableDistributionActorModule.sol:TestableDistributionActorModule"
 
-[contract.TestableDistributionEntryModule]
-artifact = "contracts/modules/test/TestableDistributionEntryModule.sol:TestableDistributionEntryModule"
+[contract.TestableRewardDistributionEntryModule]
+artifact = "contracts/modules/test/TestableRewardDistributionEntryModule.sol:TestableRewardDistributionEntryModule"
 
 [contract.TestableMarketModule]
 artifact = "contracts/modules/test/TestableMarketModule.sol:TestableMarketModule"
@@ -170,7 +170,7 @@ args = [
     TestableCollateralLockModule: contracts.TestableCollateralLockModule,
     TestableDistributionModule: contracts.TestableDistributionModule,
     TestableDistributionActorModule: contracts.TestableDistributionActorModule,
-    TestableDistributionEntryModule: contracts.TestableDistributionEntryModule,
+    TestableRewardDistributionEntryModule: contracts.TestableDistributionEntryModule,
     TestableMarketModule: contracts.TestableMarketModule,
     TestableMarketConfigurationModule: contracts.TestableMarketConfigurationModule,
     TestablePoolModule: contracts.TestablePoolModule,
@@ -208,7 +208,7 @@ depends = [
   "contract.TestableCollateralLockModule",
   "contract.TestableDistributionModule",
   "contract.TestableDistributionActorModule",
-  "contract.TestableDistributionEntryModule",
+  "contract.TestableRewardDistributionEntryModule",
   "contract.TestableMarketModule",
   "contract.TestableMarketConfigurationModule",
   "contract.TestableMarketPoolInfoModule",
@@ -248,7 +248,7 @@ abiOf = [
   "TestableCollateralLockModule",
   "TestableDistributionModule",
   "TestableDistributionActorModule",
-  "TestableDistributionEntryModule",
+  "TestableRewardDistributionEntryModule",
   "TestableMarketModule",
   "TestableMarketConfigurationModule",
   "TestableMarketPoolInfoModule",

--- a/protocol/synthetix/contracts/modules/core/RewardsManagerModule.sol
+++ b/protocol/synthetix/contracts/modules/core/RewardsManagerModule.sol
@@ -7,7 +7,7 @@ import "@synthetixio/core-contracts/contracts/utils/DecimalMath.sol";
 
 import "@synthetixio/core-contracts/contracts/utils/SafeCast.sol";
 
-import "../../storage/DistributionEntry.sol";
+import "../../storage/RewardDistributionEntry.sol";
 
 import "../../storage/Account.sol";
 import "../../storage/AccountRBAC.sol";
@@ -31,9 +31,9 @@ contract RewardsManagerModule is IRewardsManagerModule {
 
     using Vault for Vault.Data;
     using Distribution for Distribution.Data;
-    using DistributionEntry for DistributionEntry.Data;
+    using RewardDistributionEntry for RewardDistributionEntry.Data;
 
-    uint private constant _MAX_REWARD_DISTRIBUTIONS = 10;
+    uint256 private constant _MAX_REWARD_DISTRIBUTIONS = 10;
 
     /**
      * @inheritdoc IRewardsManagerModule
@@ -76,7 +76,7 @@ contract RewardsManagerModule is IRewardsManagerModule {
     function distributeRewards(
         uint128 poolId,
         address collateralType,
-        uint amount,
+        uint256 amount,
         uint64 start,
         uint32 duration
     ) external override {
@@ -115,7 +115,7 @@ contract RewardsManagerModule is IRewardsManagerModule {
         uint128 poolId,
         address collateralType,
         uint128 accountId
-    ) external override returns (uint[] memory, address[] memory) {
+    ) external override returns (uint256[] memory, address[] memory) {
         Vault.Data storage vault = Pool.load(poolId).vaults[collateralType];
         return vault.updateRewards(accountId);
     }
@@ -127,7 +127,7 @@ contract RewardsManagerModule is IRewardsManagerModule {
         uint128 poolId,
         address collateralType,
         address distributor
-    ) external view override returns (uint) {
+    ) external view override returns (uint256) {
         return _getRewardRate(poolId, collateralType, distributor);
     }
 
@@ -139,7 +139,7 @@ contract RewardsManagerModule is IRewardsManagerModule {
         address collateralType,
         uint128 accountId,
         address distributor
-    ) external override returns (uint) {
+    ) external override returns (uint256) {
         Account.onlyWithPermission(accountId, AccountRBAC._REWARDS_PERMISSION);
 
         Vault.Data storage vault = Pool.load(poolId).vaults[collateralType];
@@ -149,7 +149,7 @@ contract RewardsManagerModule is IRewardsManagerModule {
             revert ParameterError.InvalidParameter("invalid-params", "reward is not found");
         }
 
-        uint reward = vault.updateReward(accountId, rewardId);
+        uint256 reward = vault.updateReward(accountId, rewardId);
 
         vault.rewards[rewardId].distributor.payout(
             accountId,
@@ -177,12 +177,12 @@ contract RewardsManagerModule is IRewardsManagerModule {
         uint128 poolId,
         address collateralType,
         address distributor
-    ) internal view returns (uint) {
+    ) internal view returns (uint256) {
         Vault.Data storage vault = Pool.load(poolId).vaults[collateralType];
-        uint totalShares = vault.currentEpoch().accountsDebtDistribution.totalSharesD18;
+        uint256 totalShares = vault.currentEpoch().accountsDebtDistribution.totalSharesD18;
         bytes32 rewardId = _getRewardId(poolId, collateralType, distributor);
 
-        int curTime = block.timestamp.toInt();
+        int256 curTime = block.timestamp.toInt();
 
         // No rewards are currently being distributed if the distributor doesn't exist, they are scheduled to be distributed in the future, or the distribution as already completed
         if (
@@ -195,8 +195,8 @@ contract RewardsManagerModule is IRewardsManagerModule {
         }
 
         return
-            int(vault.rewards[rewardId].entry.scheduledValueD18).toUint().divDecimal(
-                uint(vault.rewards[rewardId].entry.duration).divDecimal(totalShares)
+            int256(vault.rewards[rewardId].entry.scheduledValueD18).toUint().divDecimal(
+                uint256(vault.rewards[rewardId].entry.duration).divDecimal(totalShares)
             );
     }
 

--- a/protocol/synthetix/contracts/storage/RewardDistribution.sol
+++ b/protocol/synthetix/contracts/storage/RewardDistribution.sol
@@ -3,14 +3,14 @@ pragma solidity ^0.8.0;
 
 import "../interfaces/external/IRewardDistributor.sol";
 
-import "./DistributionEntry.sol";
+import "./RewardDistributionEntry.sol";
 import "./RewardDistributionStatus.sol";
 
 library RewardDistribution {
     struct Data {
         // 3rd party smart contract which holds/mints the pools
         IRewardDistributor distributor;
-        DistributionEntry.Data entry;
+        RewardDistributionEntry.Data entry;
         uint128 rewardPerShareD18;
         mapping(uint256 => RewardDistributionStatus.Data) actorInfo;
     }

--- a/protocol/synthetix/contracts/storage/RewardDistributionEntry.sol
+++ b/protocol/synthetix/contracts/storage/RewardDistributionEntry.sol
@@ -76,10 +76,10 @@ library RewardDistributionEntry {
     /**
      * call every time before `totalShares` changes
      */
-    function updateEntry(Data storage entry, uint256 totalSharesAmountD18)
-        internal
-        returns (int256)
-    {
+    function updateEntry(
+        Data storage entry,
+        uint256 totalSharesAmountD18
+    ) internal returns (int256) {
         if (entry.scheduledValueD18 == 0 || totalSharesAmountD18 == 0) {
             // cannot process distributed rewards if a pool is empty.
             return 0;

--- a/protocol/synthetix/contracts/storage/RewardDistributionEntry.sol
+++ b/protocol/synthetix/contracts/storage/RewardDistributionEntry.sol
@@ -7,7 +7,7 @@ import "@synthetixio/core-contracts/contracts/utils/SafeCast.sol";
 
 import "./Distribution.sol";
 
-library DistributionEntry {
+library RewardDistributionEntry {
     using DecimalMath for int256;
     using SafeCastU128 for uint128;
     using SafeCastU256 for uint256;
@@ -31,11 +31,11 @@ library DistributionEntry {
     function distribute(
         Data storage entry,
         Distribution.Data storage dist,
-        int amountD18,
+        int256 amountD18,
         uint64 start,
         uint32 duration
-    ) internal returns (int diffD18) {
-        uint totalSharesD18 = dist.totalSharesD18;
+    ) internal returns (int256 diffD18) {
+        uint256 totalSharesD18 = dist.totalSharesD18;
 
         if (totalSharesD18 == 0) {
             revert ParameterError.InvalidParameter(
@@ -44,7 +44,7 @@ library DistributionEntry {
             );
         }
 
-        int curTime = block.timestamp.toInt().to128();
+        int256 curTime = block.timestamp.toInt().to128();
 
         // ensure any previously active distribution has applied
         diffD18 += updateEntry(entry, dist.totalSharesD18);
@@ -76,7 +76,10 @@ library DistributionEntry {
     /**
      * call every time before `totalShares` changes
      */
-    function updateEntry(Data storage entry, uint totalSharesAmountD18) internal returns (int) {
+    function updateEntry(Data storage entry, uint256 totalSharesAmountD18)
+        internal
+        returns (int256)
+    {
         if (entry.scheduledValueD18 == 0 || totalSharesAmountD18 == 0) {
             // cannot process distributed rewards if a pool is empty.
             return 0;
@@ -84,7 +87,7 @@ library DistributionEntry {
 
         int128 curTime = block.timestamp.toInt().to128();
 
-        int valuePerShareChangeD18 = 0;
+        int256 valuePerShareChangeD18 = 0;
 
         if (curTime < int64(entry.start)) {
             return 0;
@@ -92,17 +95,17 @@ library DistributionEntry {
 
         // determine whether this is an instant distribution or a delayed distribution
         if (entry.duration == 0 && entry.lastUpdate < entry.start) {
-            valuePerShareChangeD18 = int(entry.scheduledValueD18).divDecimal(
+            valuePerShareChangeD18 = int256(entry.scheduledValueD18).divDecimal(
                 totalSharesAmountD18.toInt()
             );
         } else if (entry.lastUpdate < entry.start + entry.duration) {
             // find out what is "newly" distributed
-            int lastUpdateDistributedD18 = entry.lastUpdate < entry.start
+            int256 lastUpdateDistributedD18 = entry.lastUpdate < entry.start
                 ? int128(0)
                 : (entry.scheduledValueD18 * int64(entry.lastUpdate - entry.start)) /
                     int32(entry.duration);
 
-            int curUpdateDistributedD18 = entry.scheduledValueD18;
+            int256 curUpdateDistributedD18 = entry.scheduledValueD18;
             if (curTime < int64(entry.start + entry.duration)) {
                 curUpdateDistributedD18 =
                     (curUpdateDistributedD18 * (curTime - int64(entry.start))) /

--- a/protocol/synthetix/contracts/storage/Vault.sol
+++ b/protocol/synthetix/contracts/storage/Vault.sol
@@ -77,14 +77,10 @@ library Vault {
      *
      * Returns the amount of collateral that this vault is providing in net USD terms.
      */
-    function updateCreditCapacity(Data storage self, uint256 collateralPriceD18)
-        internal
-        returns (
-            uint256 usdWeightD18,
-            int256 totalDebtD18,
-            int256 deltaDebtD18
-        )
-    {
+    function updateCreditCapacity(
+        Data storage self,
+        uint256 collateralPriceD18
+    ) internal returns (uint256 usdWeightD18, int256 totalDebtD18, int256 deltaDebtD18) {
         VaultEpoch.Data storage epochData = currentEpoch(self);
 
         uint256 scaleModifierD27 = (epochData.collateralAmounts.scaleModifierD27 +
@@ -110,10 +106,10 @@ library Vault {
     /**
      * @dev Consolidates an accounts debt.
      */
-    function consolidateAccountDebt(Data storage self, uint128 accountId)
-        internal
-        returns (int256)
-    {
+    function consolidateAccountDebt(
+        Data storage self,
+        uint128 accountId
+    ) internal returns (int256) {
         return currentEpoch(self).consolidateAccountDebt(accountId);
     }
 
@@ -121,10 +117,10 @@ library Vault {
      * @dev Traverses available rewards for this vault, and updates an accounts
      * claim on them according to the amount of debt shares they have.
      */
-    function updateRewards(Data storage self, uint128 accountId)
-        internal
-        returns (uint256[] memory, address[] memory)
-    {
+    function updateRewards(
+        Data storage self,
+        uint128 accountId
+    ) internal returns (uint256[] memory, address[] memory) {
         uint256[] memory rewards = new uint256[](self.rewardIds.length());
         address[] memory distributors = new address[](self.rewardIds.length());
         for (uint256 i = 0; i < self.rewardIds.length(); i++) {
@@ -198,11 +194,10 @@ library Vault {
     /**
      * @dev Returns an account's collateral value in this vault's current epoch.
      */
-    function currentAccountCollateral(Data storage self, uint128 accountId)
-        internal
-        view
-        returns (uint256)
-    {
+    function currentAccountCollateral(
+        Data storage self,
+        uint128 accountId
+    ) internal view returns (uint256) {
         return currentEpoch(self).getAccountCollateral(accountId);
     }
 }

--- a/protocol/synthetix/contracts/storage/Vault.sol
+++ b/protocol/synthetix/contracts/storage/Vault.sol
@@ -21,7 +21,7 @@ import "@synthetixio/core-contracts/contracts/utils/SafeCast.sol";
 library Vault {
     using VaultEpoch for VaultEpoch.Data;
     using Distribution for Distribution.Data;
-    using DistributionEntry for DistributionEntry.Data;
+    using RewardDistributionEntry for RewardDistributionEntry.Data;
     using ScalableMapping for ScalableMapping.Data;
     using DecimalMath for uint256;
     using DecimalMath for int128;
@@ -77,10 +77,14 @@ library Vault {
      *
      * Returns the amount of collateral that this vault is providing in net USD terms.
      */
-    function updateCreditCapacity(
-        Data storage self,
-        uint256 collateralPriceD18
-    ) internal returns (uint256 usdWeightD18, int256 totalDebtD18, int256 deltaDebtD18) {
+    function updateCreditCapacity(Data storage self, uint256 collateralPriceD18)
+        internal
+        returns (
+            uint256 usdWeightD18,
+            int256 totalDebtD18,
+            int256 deltaDebtD18
+        )
+    {
         VaultEpoch.Data storage epochData = currentEpoch(self);
 
         uint256 scaleModifierD27 = (epochData.collateralAmounts.scaleModifierD27 +
@@ -106,10 +110,10 @@ library Vault {
     /**
      * @dev Consolidates an accounts debt.
      */
-    function consolidateAccountDebt(
-        Data storage self,
-        uint128 accountId
-    ) internal returns (int256) {
+    function consolidateAccountDebt(Data storage self, uint128 accountId)
+        internal
+        returns (int256)
+    {
         return currentEpoch(self).consolidateAccountDebt(accountId);
     }
 
@@ -117,10 +121,10 @@ library Vault {
      * @dev Traverses available rewards for this vault, and updates an accounts
      * claim on them according to the amount of debt shares they have.
      */
-    function updateRewards(
-        Data storage self,
-        uint128 accountId
-    ) internal returns (uint256[] memory, address[] memory) {
+    function updateRewards(Data storage self, uint128 accountId)
+        internal
+        returns (uint256[] memory, address[] memory)
+    {
         uint256[] memory rewards = new uint256[](self.rewardIds.length());
         address[] memory distributors = new address[](self.rewardIds.length());
         for (uint256 i = 0; i < self.rewardIds.length(); i++) {
@@ -194,10 +198,11 @@ library Vault {
     /**
      * @dev Returns an account's collateral value in this vault's current epoch.
      */
-    function currentAccountCollateral(
-        Data storage self,
-        uint128 accountId
-    ) internal view returns (uint256) {
+    function currentAccountCollateral(Data storage self, uint128 accountId)
+        internal
+        view
+        returns (uint256)
+    {
         return currentEpoch(self).getAccountCollateral(accountId);
     }
 }


### PR DESCRIPTION
The name “DistributionEntry” suggests that this has something to do with the central “Distribution” object (like “DistributionActor”). IMO it should be renamed to break this suggested association.