### PR TITLE
use create2 to get stable addresses for proxy contracts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
             workspace: "@synthetixio/main"
             size-contracts: true
     steps:
-      - run: mkdir -p ~/.local/share/cannon && echo "{"ipfsUrl":"http://localhost:5001"}" > ~/.local/share/cannon/settings.json
+      - run: mkdir -p ~/.local/share/cannon && echo '{"ipfsUrl":"http://localhost:5001"}' > ~/.local/share/cannon/settings.json
       - name: Install Foundry (Cannon)
         uses: foundry-rs/foundry-toolchain@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,14 @@
 name: Test
 
-on: [push]
+on:
+  pull_request: {}
+  push:
+    branches:
+      - "main"
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    env:
-      CANNON_SETTINGS: ${{ secrets.CANNON_SETTINGS }}
     strategy:
       matrix:
         package:
@@ -39,7 +41,7 @@ jobs:
             workspace: "@synthetixio/main"
             size-contracts: true
     steps:
-      - run: mkdir -p ~/.local/share/cannon && echo "$CANNON_SETTINGS" > ~/.local/share/cannon/settings.json
+      - run: mkdir -p ~/.local/share/cannon && echo "{"ipfsUrl":"http://localhost:5001"}" > ~/.local/share/cannon/settings.json
       - name: Install Foundry (Cannon)
         uses: foundry-rs/foundry-toolchain@v1
         with:
@@ -50,6 +52,9 @@ jobs:
         with:
           node-version: "16.16.0"
           cache: "npm"
+      - uses: ibnesayeed/setup-ipfs@92d412e0dad36c06ffab50733e9c624896a0964f
+        with:
+          run_daemon: true
       - run: npm ci
       - run: npm run build
       - if: ${{ matrix.size-contracts }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3570,13 +3570,15 @@
       "dev": true
     },
     "node_modules/@usecannon/builder": {
-      "version": "2.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@usecannon/builder/-/builder-2.0.0-alpha.0.tgz",
-      "integrity": "sha512-ekJhR1llF2hPU4EoYgJCLOU4yYLu1kVcISPe6aZUT5LfhndMvKD7m22wAzOyqMmtjqknN941RzD85bzoOIWgRw==",
+      "version": "2.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@usecannon/builder/-/builder-2.0.0-alpha.2.tgz",
+      "integrity": "sha512-dAbUfIwzQ5IdSJOddcj+DVD1f4apEXmfGeWsGnL/Xs9zcWTPYHamTKRAxYej+GgBRLJYZu8CcyM+JTPqWMkE3Q==",
       "dev": true,
       "dependencies": {
         "ajv": "^8.11.0",
+        "axios": "^1.2.2",
         "debug": "^4.3.4",
+        "form-data": "^4.0.0",
         "lodash": "^4.17.21",
         "pako": "^2.1.0"
       },
@@ -3603,6 +3605,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/@usecannon/builder/node_modules/axios": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.2.tgz",
+      "integrity": "sha512-bz/J4gS2S3I7mpN/YZfGFTqhXTYzRho8Ay38w2otuuDR322KzFIWm/4W2K6gIwvWaws5n+mnb7D1lN9uD+QH6Q==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/@usecannon/builder/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -3610,14 +3623,14 @@
       "dev": true
     },
     "node_modules/@usecannon/cli": {
-      "version": "2.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@usecannon/cli/-/cli-2.0.0-alpha.0.tgz",
-      "integrity": "sha512-iahz7vhjWZjMS12ghFcdIBAmx6Kk7l4RGSgubGoLlXXTTvY7yJ6P+FKFG6y4yOeCrW6+213niGaWO/9pldRhyA==",
+      "version": "2.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@usecannon/cli/-/cli-2.0.0-alpha.2.tgz",
+      "integrity": "sha512-TK2OqX38agWkDL1Dd8OwgiN2JBEYaPmxWWGx46RgwugS0JDFJKN4qhIWMI/vMlMR4mWaCPT1KeNTwaLgGhadnw==",
       "dev": true,
       "dependencies": {
         "@iarna/toml": "^3.0.0",
         "@synthetixio/wei": "^2.74.1",
-        "@usecannon/builder": "^2.0.0-alpha.0",
+        "@usecannon/builder": "^2.0.0-alpha.2",
         "chalk": "^4.1.2",
         "commander": "^9.3.0",
         "debug": "^4.3.4",
@@ -8063,14 +8076,14 @@
       }
     },
     "node_modules/hardhat-cannon": {
-      "version": "2.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/hardhat-cannon/-/hardhat-cannon-2.0.0-alpha.0.tgz",
-      "integrity": "sha512-gJ0q4cH4Zz57mITQVz6uEEaiOX6rwjcPclUErjAAzLhLpeSi6Qmq9UrIgRVkrqKkGa8hMPD2gocyjjXXC3kh+g==",
+      "version": "2.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/hardhat-cannon/-/hardhat-cannon-2.0.0-alpha.2.tgz",
+      "integrity": "sha512-sWZ8bi+EyixCpJcJIPJbYDznmIJbJOPBoqlQ9Y1QH6UhkklRXaqr0sN8MAPh4bsmxfVn5NGYkAsbCDE6QTKBUg==",
       "dev": true,
       "dependencies": {
         "@iarna/toml": "^3.0.0",
-        "@usecannon/builder": "^2.0.0-alpha.0",
-        "@usecannon/cli": "^2.0.0-alpha.0",
+        "@usecannon/builder": "^2.0.0-alpha.2",
+        "@usecannon/cli": "^2.0.0-alpha.2",
         "adm-zip": "^0.5.9",
         "ajv": "^8.10.0",
         "chalk": "^4.1.2",
@@ -16925,7 +16938,7 @@
         "@typechain/hardhat": "6.1.3",
         "dotenv": "16.0.1",
         "hardhat": "2.12.3",
-        "hardhat-cannon": "^2.0.0-alpha.0",
+        "hardhat-cannon": "^2.0.0-alpha.2",
         "hardhat-contract-sizer": "2.1.1",
         "hardhat-gas-reporter": "1.0.9",
         "hardhat-ignore-warnings": "0.2.5",
@@ -19094,7 +19107,7 @@
         "@types/jsonpath": "0.2.0",
         "@types/lodash": "4.14.191",
         "@types/mustache": "4.2.1",
-        "@usecannon/builder": "^2.0.0-alpha.0",
+        "@usecannon/builder": "^2.0.0-alpha.2",
         "mocha": "9.1.1",
         "nyc": "15.1.0",
         "source-map-support": "0.5.21",
@@ -19102,7 +19115,7 @@
         "typechain": "8.1.1"
       },
       "peerDependencies": {
-        "@usecannon/builder": "^2.0.0-alpha.0"
+        "@usecannon/builder": "^2.0.0-alpha.2"
       },
       "peerDependenciesMeta": {
         "@usecannon/builder": {
@@ -19175,7 +19188,7 @@
         "@synthetixio/core-modules": "*",
         "@synthetixio/hardhat-router": "*",
         "@synthetixio/hardhat-storage": "*",
-        "hardhat-cannon": "^2.0.0-alpha.0"
+        "hardhat-cannon": "^2.0.0-alpha.2"
       }
     },
     "utils/solhint-plugin-numcast": {
@@ -21277,7 +21290,7 @@
         "@typechain/hardhat": "6.1.3",
         "dotenv": "16.0.1",
         "hardhat": "2.12.3",
-        "hardhat-cannon": "^2.0.0-alpha.0",
+        "hardhat-cannon": "^2.0.0-alpha.2",
         "hardhat-contract-sizer": "2.1.1",
         "hardhat-gas-reporter": "1.0.9",
         "hardhat-ignore-warnings": "0.2.5",
@@ -22876,7 +22889,7 @@
         "@types/jsonpath": "0.2.0",
         "@types/lodash": "4.14.191",
         "@types/mustache": "4.2.1",
-        "@usecannon/builder": "^2.0.0-alpha.0",
+        "@usecannon/builder": "^2.0.0-alpha.2",
         "ajv": "^8.11.0",
         "axios": "1.2.0",
         "debug": "4.3.4",
@@ -22941,7 +22954,7 @@
         "@synthetixio/core-modules": "*",
         "@synthetixio/hardhat-router": "*",
         "@synthetixio/hardhat-storage": "*",
-        "hardhat-cannon": "^2.0.0-alpha.0"
+        "hardhat-cannon": "^2.0.0-alpha.2"
       }
     },
     "@synthetixio/spot-market": {
@@ -23516,13 +23529,15 @@
       "dev": true
     },
     "@usecannon/builder": {
-      "version": "2.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@usecannon/builder/-/builder-2.0.0-alpha.0.tgz",
-      "integrity": "sha512-ekJhR1llF2hPU4EoYgJCLOU4yYLu1kVcISPe6aZUT5LfhndMvKD7m22wAzOyqMmtjqknN941RzD85bzoOIWgRw==",
+      "version": "2.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@usecannon/builder/-/builder-2.0.0-alpha.2.tgz",
+      "integrity": "sha512-dAbUfIwzQ5IdSJOddcj+DVD1f4apEXmfGeWsGnL/Xs9zcWTPYHamTKRAxYej+GgBRLJYZu8CcyM+JTPqWMkE3Q==",
       "dev": true,
       "requires": {
         "ajv": "^8.11.0",
+        "axios": "^1.2.2",
         "debug": "^4.3.4",
+        "form-data": "^4.0.0",
         "lodash": "^4.17.21",
         "pako": "^2.1.0"
       },
@@ -23539,6 +23554,17 @@
             "uri-js": "^4.2.2"
           }
         },
+        "axios": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.2.tgz",
+          "integrity": "sha512-bz/J4gS2S3I7mpN/YZfGFTqhXTYzRho8Ay38w2otuuDR322KzFIWm/4W2K6gIwvWaws5n+mnb7D1lN9uD+QH6Q==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.15.0",
+            "form-data": "^4.0.0",
+            "proxy-from-env": "^1.1.0"
+          }
+        },
         "json-schema-traverse": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -23548,14 +23574,14 @@
       }
     },
     "@usecannon/cli": {
-      "version": "2.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@usecannon/cli/-/cli-2.0.0-alpha.0.tgz",
-      "integrity": "sha512-iahz7vhjWZjMS12ghFcdIBAmx6Kk7l4RGSgubGoLlXXTTvY7yJ6P+FKFG6y4yOeCrW6+213niGaWO/9pldRhyA==",
+      "version": "2.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@usecannon/cli/-/cli-2.0.0-alpha.2.tgz",
+      "integrity": "sha512-TK2OqX38agWkDL1Dd8OwgiN2JBEYaPmxWWGx46RgwugS0JDFJKN4qhIWMI/vMlMR4mWaCPT1KeNTwaLgGhadnw==",
       "dev": true,
       "requires": {
         "@iarna/toml": "^3.0.0",
         "@synthetixio/wei": "^2.74.1",
-        "@usecannon/builder": "^2.0.0-alpha.0",
+        "@usecannon/builder": "^2.0.0-alpha.2",
         "chalk": "^4.1.2",
         "commander": "^9.3.0",
         "debug": "^4.3.4",
@@ -27281,14 +27307,14 @@
       }
     },
     "hardhat-cannon": {
-      "version": "2.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/hardhat-cannon/-/hardhat-cannon-2.0.0-alpha.0.tgz",
-      "integrity": "sha512-gJ0q4cH4Zz57mITQVz6uEEaiOX6rwjcPclUErjAAzLhLpeSi6Qmq9UrIgRVkrqKkGa8hMPD2gocyjjXXC3kh+g==",
+      "version": "2.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/hardhat-cannon/-/hardhat-cannon-2.0.0-alpha.2.tgz",
+      "integrity": "sha512-sWZ8bi+EyixCpJcJIPJbYDznmIJbJOPBoqlQ9Y1QH6UhkklRXaqr0sN8MAPh4bsmxfVn5NGYkAsbCDE6QTKBUg==",
       "dev": true,
       "requires": {
         "@iarna/toml": "^3.0.0",
-        "@usecannon/builder": "^2.0.0-alpha.0",
-        "@usecannon/cli": "^2.0.0-alpha.0",
+        "@usecannon/builder": "^2.0.0-alpha.2",
+        "@usecannon/cli": "^2.0.0-alpha.2",
         "adm-zip": "^0.5.9",
         "ajv": "^8.10.0",
         "chalk": "^4.1.2",

--- a/protocol/oracle-manager/cannonfile.toml
+++ b/protocol/oracle-manager/cannonfile.toml
@@ -16,12 +16,15 @@ artifact = "contracts/modules/OracleManagerModule.sol:OracleManagerModule"
 
 [contract.CoreModule]
 artifact = "contracts/modules/CoreModule.sol:CoreModule"
+create2 = true
 
 [contract.InitialProxy]
 artifact = "contracts/Proxy.sol:Proxy"
-args = ["<%= contracts.CoreModule.address %>"]
-abiOf = ["CoreModule"]
+args = ["<%= contracts.CoreModule.address %>", "<%= settings.owner %>"]
 salt = "<%= settings.salt %>"
+abiOf = ["CoreModule"]
+create2 = true
+
 depends = ["contract.CoreModule"]
 
 [invoke.acquire_ownership]

--- a/protocol/oracle-manager/contracts/Proxy.sol
+++ b/protocol/oracle-manager/contracts/Proxy.sol
@@ -6,5 +6,8 @@ import {OwnableStorage} from "@synthetixio/core-contracts/contracts/ownership/Ow
 
 contract Proxy is UUPSProxyWithOwner {
     // solhint-disable-next-line no-empty-blocks
-    constructor(address firstImplementation, address initialOwner) UUPSProxyWithOwner(firstImplementation, initialOwner) {}
+    constructor(
+        address firstImplementation,
+        address initialOwner
+    ) UUPSProxyWithOwner(firstImplementation, initialOwner) {}
 }

--- a/protocol/oracle-manager/contracts/Proxy.sol
+++ b/protocol/oracle-manager/contracts/Proxy.sol
@@ -1,9 +1,10 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {UUPSProxy} from "@synthetixio/core-contracts/contracts/proxy/UUPSProxy.sol";
+import {UUPSProxyWithOwner} from "@synthetixio/core-contracts/contracts/proxy/UUPSProxyWithOwner.sol";
+import {OwnableStorage} from "@synthetixio/core-contracts/contracts/ownership/OwnableStorage.sol";
 
-contract Proxy is UUPSProxy {
+contract Proxy is UUPSProxyWithOwner {
     // solhint-disable-next-line no-empty-blocks
-    constructor(address firstImplementation) UUPSProxy(firstImplementation) {}
+    constructor(address firstImplementation, address initialOwner) UUPSProxyWithOwner(firstImplementation, initialOwner) {}
 }

--- a/protocol/synthetix/cannonfile.toml
+++ b/protocol/synthetix/cannonfile.toml
@@ -20,6 +20,7 @@ options.owner = "<%= settings.owner %>"
 
 [contract.InitialModuleBundle]
 artifact = "contracts/modules/InitialModuleBundle.sol:InitialModuleBundle"
+create2 = true
 
 [contract.FeatureFlagModule]
 artifact = "contracts/modules/core/FeatureFlagModule.sol:FeatureFlagModule"
@@ -119,17 +120,11 @@ depends = [
 
 [contract.InitialCoreProxy]
 artifact = "contracts/Proxy.sol:Proxy"
-args = ["<%= contracts.InitialModuleBundle.address %>"]
+args = ["<%= contracts.InitialModuleBundle.address %>", "<%= settings.owner %>"]
 abiOf = ["InitialModuleBundle"]
 salt = "<%= settings.salt %>"
+create2 = true
 depends = ["contract.InitialModuleBundle"]
-
-[invoke.acquire_ownership]
-target = ["InitialCoreProxy"]
-from = "<%= settings.owner %>"
-func = "initializeOwnerModule"
-args = ["<%= settings.owner %>"]
-depends = ["contract.InitialCoreProxy"]
 
 [invoke.upgrade_core_proxy]
 target = ["InitialCoreProxy"]
@@ -143,7 +138,7 @@ factory.CoreProxy.event = "Upgraded"
 factory.CoreProxy.arg = 0
 
 depends = [
-  "invoke.acquire_ownership",
+  "contract.InitialCoreProxy",
   "router.CoreRouter"
 ]
 

--- a/protocol/synthetix/contracts/Proxy.sol
+++ b/protocol/synthetix/contracts/Proxy.sol
@@ -6,5 +6,8 @@ import {OwnableStorage} from "@synthetixio/core-contracts/contracts/ownership/Ow
 
 contract Proxy is UUPSProxyWithOwner {
     // solhint-disable-next-line no-empty-blocks
-    constructor(address firstImplementation, address initialOwner) UUPSProxyWithOwner(firstImplementation, initialOwner) {}
+    constructor(
+        address firstImplementation,
+        address initialOwner
+    ) UUPSProxyWithOwner(firstImplementation, initialOwner) {}
 }

--- a/protocol/synthetix/contracts/Proxy.sol
+++ b/protocol/synthetix/contracts/Proxy.sol
@@ -1,9 +1,10 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "@synthetixio/core-contracts/contracts/proxy/UUPSProxy.sol";
+import {UUPSProxyWithOwner} from "@synthetixio/core-contracts/contracts/proxy/UUPSProxyWithOwner.sol";
+import {OwnableStorage} from "@synthetixio/core-contracts/contracts/ownership/OwnableStorage.sol";
 
-contract Proxy is UUPSProxy {
+contract Proxy is UUPSProxyWithOwner {
     // solhint-disable-next-line no-empty-blocks
-    constructor(address firstImplementation) UUPSProxy(firstImplementation) {}
+    constructor(address firstImplementation, address initialOwner) UUPSProxyWithOwner(firstImplementation, initialOwner) {}
 }

--- a/utils/common-config/package.json
+++ b/utils/common-config/package.json
@@ -14,7 +14,7 @@
     "@typechain/hardhat": "6.1.3",
     "dotenv": "16.0.1",
     "hardhat": "2.12.3",
-    "hardhat-cannon": "^2.0.0-alpha.0",
+    "hardhat-cannon": "^2.0.0-alpha.2",
     "hardhat-contract-sizer": "2.1.1",
     "hardhat-gas-reporter": "1.0.9",
     "hardhat-ignore-warnings": "0.2.5",

--- a/utils/core-contracts/contracts/proxy/UUPSProxyWithOwner.sol
+++ b/utils/core-contracts/contracts/proxy/UUPSProxyWithOwner.sol
@@ -1,0 +1,12 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {UUPSProxy} from "./UUPSProxy.sol";
+import {OwnableStorage} from "../ownership/OwnableStorage.sol";
+
+contract UUPSProxyWithOwner is UUPSProxy {
+    // solhint-disable-next-line no-empty-blocks
+    constructor(address firstImplementation, address initialOwner) UUPSProxy(firstImplementation) {
+        OwnableStorage.load().owner = initialOwner;
+    }
+}

--- a/utils/hardhat-router/src/utils/tests.ts
+++ b/utils/hardhat-router/src/utils/tests.ts
@@ -51,6 +51,13 @@ export function coreBootstrap<Contracts>({ cannonfile = 'cannonfile.toml' }: Par
     provider = cannonInfo.provider as ethers.providers.JsonRpcProvider;
     signers = cannonInfo.signers as ethers.Signer[];
 
+    for (const signer of signers) {
+      await provider.send('hardhat_setBalance', [
+        await signer.getAddress(),
+        `0x${(1e22).toString(16)}`,
+      ]);
+    }
+
     try {
       await provider.send('anvil_setBlockTimestampInterval', [1]);
     } catch (err) {

--- a/utils/router/package.json
+++ b/utils/router/package.json
@@ -25,14 +25,14 @@
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
-    "@usecannon/builder": "^2.0.0-alpha.0"
+    "@usecannon/builder": "^2.0.0-alpha.2"
   },
   "devDependencies": {
     "@types/debug": "4.1.7",
     "@types/jsonpath": "0.2.0",
     "@types/lodash": "4.14.191",
     "@types/mustache": "4.2.1",
-    "@usecannon/builder": "^2.0.0-alpha.0",
+    "@usecannon/builder": "^2.0.0-alpha.2",
     "mocha": "9.1.1",
     "nyc": "15.1.0",
     "source-map-support": "0.5.21",

--- a/utils/router/src/utils/cannon.ts
+++ b/utils/router/src/utils/cannon.ts
@@ -50,17 +50,22 @@ const routerAction = {
 
     const newConfig = this.configInject(ctx, config);
 
-    const contractAbis = {};
+    const contractAbis: any = {};
+    const contractAddresses: any = {};
 
     for (const n of newConfig.contracts) {
-      const contract = getContractFromPath(ctx, n);
+      const contract = getContractDefinitionFromPath(ctx, n);
       if (!contract) {
         throw new Error(`contract not found: ${n}`);
       }
+
+      contractAbis[n] = contract.abi;
+      contractAddresses[n] = contract.address;
     }
 
     return {
       contractAbis,
+      contractAddresses,
       config: newConfig,
     };
   },

--- a/utils/router/src/utils/cannon.ts
+++ b/utils/router/src/utils/cannon.ts
@@ -12,7 +12,6 @@ import {
 
 import {
   getContractDefinitionFromPath,
-  getContractFromPath,
   getMergedAbiFromContractPaths,
 } from '@usecannon/builder/dist/util';
 
@@ -50,7 +49,9 @@ const routerAction = {
 
     const newConfig = this.configInject(ctx, config);
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const contractAbis: any = {};
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const contractAddresses: any = {};
 
     for (const n of newConfig.contracts) {

--- a/utils/sample-project/package.json
+++ b/utils/sample-project/package.json
@@ -13,6 +13,6 @@
     "@synthetixio/core-modules": "*",
     "@synthetixio/hardhat-router": "*",
     "@synthetixio/hardhat-storage": "*",
-    "hardhat-cannon": "^2.0.0-alpha.0"
+    "hardhat-cannon": "^2.0.0-alpha.2"
   }
 }


### PR DESCRIPTION
newly supported on cannon.

also enable running the test jobs in CI for untrusted maintainers. They don't depend on any secrets now with the latest changes.