### PR TITLE
Handle plain ETH transfers

### DIFF
--- a/utils/core-modules/contracts/interfaces/ISampleOwnedModule.sol
+++ b/utils/core-modules/contracts/interfaces/ISampleOwnedModule.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 interface ISampleOwnedModule {
-    function setProtectedValue(uint newProtectedValue) external;
+    function setProtectedValue(uint newProtectedValue) external payable;
 
     function getProtectedValue() external view returns (uint);
 }

--- a/utils/core-modules/contracts/modules/mocks/SampleOwnedModule.sol
+++ b/utils/core-modules/contracts/modules/mocks/SampleOwnedModule.sol
@@ -6,7 +6,7 @@ import "../../storage/SampleStorage.sol";
 import "../../interfaces/ISampleOwnedModule.sol";
 
 contract SampleOwnedModule is ISampleOwnedModule {
-    function setProtectedValue(uint newProtectedValue) public override {
+    function setProtectedValue(uint newProtectedValue) public payable override {
         OwnableStorage.onlyOwner();
 
         SampleStorage.load().protectedValue = newProtectedValue;

--- a/utils/core-modules/test/contracts/modules/Ether.test.ts
+++ b/utils/core-modules/test/contracts/modules/Ether.test.ts
@@ -4,7 +4,7 @@ import { ethers } from 'ethers';
 import { bootstrap } from '../../bootstrap';
 import { SampleOwnedModule } from '../../../typechain-types';
 
-describe.only('ETH transfer', function () {
+describe('ETH transfer', function () {
   const { getContractBehindProxy, getSigners } = bootstrap({
     implementation: 'SampleRouter',
   });

--- a/utils/core-modules/test/contracts/modules/Ether.test.ts
+++ b/utils/core-modules/test/contracts/modules/Ether.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
+import { ethers } from 'ethers';
+import { bootstrap } from '../../bootstrap';
+import { SampleOwnedModule } from '../../../typechain-types';
+
+describe.only('ETH transfer', function () {
+  const { getContractBehindProxy, getSigners } = bootstrap({
+    implementation: 'SampleRouter',
+  });
+
+  let owner: ethers.Signer;
+  let System: SampleOwnedModule; // Use any module.
+  let Router: ethers.Contract;
+
+  const value = ethers.utils.parseEther('1');
+  const UnknownSelectorABI = `[{
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "sel",
+        "type": "bytes4"
+      }
+    ],
+    "name": "UnknownSelector",
+    "type": "error"
+  }]`;
+
+  before('identify signers', function () {
+    [owner] = getSigners();
+  });
+
+  before('identify contracts', function () {
+    System = getContractBehindProxy('SampleOwnedModule'); // Just use any module.
+
+    // Now, lock on to a "Router" contract with any address,
+    // just to be able to decode the UnknownSelector error type with assertRevert.
+    Router = new ethers.Contract(System.address, UnknownSelectorABI, System.provider);
+  });
+
+  describe('when sending plain ETH to the contract', async function () {
+    it('reverts', async function () {
+      await assertRevert(
+        owner.sendTransaction({
+          to: System.address,
+          value,
+        }),
+        'UnknownSelector("0x00000000")',
+        Router
+      );
+    });
+  });
+
+  describe('when interacting with the system without ETH value', async function () {
+    it('does not revert', async function () {
+      await System.setProtectedValue(42);
+    });
+  });
+
+  describe('when interacting with the system with ETH value', function () {
+    it('does not revert', async function () {
+      System.setProtectedValue(1337, { from: await owner.getAddress(), value });
+    });
+  });
+});

--- a/utils/core-modules/test/contracts/modules/Ether.test.ts
+++ b/utils/core-modules/test/contracts/modules/Ether.test.ts
@@ -43,6 +43,7 @@ describe('ETH transfer', function () {
         owner.sendTransaction({
           to: System.address,
           value,
+          gasLimit: 12000000, // Avoid gas estimation in coverage, in order to identify custom error in assert-revert
         }),
         'UnknownSelector("0x00000000")',
         Router

--- a/utils/core-modules/test/contracts/modules/Ether.test.ts
+++ b/utils/core-modules/test/contracts/modules/Ether.test.ts
@@ -1,4 +1,3 @@
-import assert from 'node:assert/strict';
 import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
 import { ethers } from 'ethers';
 import { bootstrap } from '../../bootstrap';
@@ -59,7 +58,7 @@ describe('ETH transfer', function () {
 
   describe('when interacting with the system with ETH value', function () {
     it('does not revert', async function () {
-      System.setProtectedValue(1337, { from: await owner.getAddress(), value });
+      await System.setProtectedValue(1337, { from: await owner.getAddress(), value });
     });
   });
 });

--- a/utils/router/src/internal/render-router.ts
+++ b/utils/router/src/internal/render-router.ts
@@ -48,6 +48,9 @@ export function renderRouter({
     moduleName: routerName,
     modules: _renderModules(contracts),
     selectors: _renderSelectors(binaryData),
+    // Note: Plain ETH transfers are disabled by default. Set this to true to
+    // enable them. If there is ever a use case for this, it might be a good
+    // idea to expose the boolean in the router tool's interface.
     receive: _renderReceive(false),
   });
 }
@@ -72,7 +75,7 @@ function _renderReceive(canReceivePlainETH: Boolean) {
   let receiveStr = '';
 
   if (canReceivePlainETH) {
-    receiveStr += 'receive() external payable {}\n';
+    receiveStr += '\n    receive() external payable {}\n';
   }
 
   return receiveStr;

--- a/utils/router/src/internal/render-router.ts
+++ b/utils/router/src/internal/render-router.ts
@@ -48,6 +48,7 @@ export function renderRouter({
     moduleName: routerName,
     modules: _renderModules(contracts),
     selectors: _renderSelectors(binaryData),
+    receive: _renderReceive(false),
   });
 }
 
@@ -65,6 +66,16 @@ function _getAllSelectors(
     .sort((a, b) => {
       return Number.parseInt(a.selector, 16) - Number.parseInt(b.selector, 16);
     });
+}
+
+function _renderReceive(canReceivePlainETH: Boolean) {
+  let receiveStr = '';
+
+  if (canReceivePlainETH) {
+    receiveStr += 'receive() external payable {}\n';
+  }
+
+  return receiveStr;
 }
 
 function _renderSelectors(binaryData: BinaryData) {

--- a/utils/router/src/internal/render-router.ts
+++ b/utils/router/src/internal/render-router.ts
@@ -71,7 +71,7 @@ function _getAllSelectors(
     });
 }
 
-function _renderReceive(canReceivePlainETH: Boolean) {
+function _renderReceive(canReceivePlainETH: boolean) {
   let receiveStr = '';
 
   if (canReceivePlainETH) {

--- a/utils/router/templates/Router.sol.mustache
+++ b/utils/router/templates/Router.sol.mustache
@@ -11,12 +11,8 @@ contract {{{moduleName}}} {
     error UnknownSelector(bytes4 sel);
 
     {{{modules}}}
-
-    fallback() external payable {
-        _forward();
-    }
     {{{receive}}}
-    function _forward() internal {
+    fallback() external payable {
         // Lookup table: Function selector => implementation contract
         bytes4 sig4 = msg.sig;
         address implementation;

--- a/utils/router/templates/Router.sol.mustache
+++ b/utils/router/templates/Router.sol.mustache
@@ -15,9 +15,7 @@ contract {{{moduleName}}} {
     fallback() external payable {
         _forward();
     }
-
     {{{receive}}}
-
     function _forward() internal {
         // Lookup table: Function selector => implementation contract
         bytes4 sig4 = msg.sig;

--- a/utils/router/templates/Router.sol.mustache
+++ b/utils/router/templates/Router.sol.mustache
@@ -16,9 +16,7 @@ contract {{{moduleName}}} {
         _forward();
     }
 
-    receive() external payable {
-        _forward();
-    }
+    {{{receive}}}
 
     function _forward() internal {
         // Lookup table: Function selector => implementation contract


### PR DESCRIPTION
As pointed out by auditors, plain ETH transfers hit the receive function and then execution gets forwarded to the routing table, where no selector match is found, thus always causing reverts in plain ETH transfers.

This PR removes the receive function from our routers and explicitly declares that they cannot receive ETH transfers.

However, this PR leaves a half finished implementation in the router to enable them eventually, which simply adds an empty receive function. Note that this receive does not forward execution to the routing table.

Finally, the body of the routing table is moved into the fallback function to save a bit of gas, since it will not be reached from other entry points with receive enabled or disabled.