### PR TITLE
Fee calculator test setup/tests

### DIFF
--- a/markets/spot-market/cannonfile.test.toml
+++ b/markets/spot-market/cannonfile.test.toml
@@ -1,133 +1,17 @@
-name = "spot-market"
-version = "<%= package.version %>"
-description = "Spot market implementation"
+version = "<%= package.version %>-testable"
 
-[setting.coreProxyOwner]
-description = "owner of v3 core proxy"
-defaultValue = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
-
-[setting.marketOwner]
-description = "spot market owner"
-defaultValue = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
+include = [
+  "cannonfile.toml"
+]
 
 [import.synthetix]
 source = "synthetix:3.0.0-alpha.7-testable"
 
-[setting.oracle_manager_version]
-defaultValue = "1.2.1"
+[contract.FeeCollectorMock]
+artifact = "contracts/mocks/FeeCollectorMock.sol:FeeCollectorMock"
 
-[import.oracle_manager]
-source = "oracle-manager:<%= settings.oracle_manager_version %>"
-options.owner = "<%= settings.owner %>"
-
-[contract.SpotMarketFactoryModule]
-artifact = "SpotMarketFactoryModule"
-
-[contract.AtomicOrderModule]
-artifact = "AtomicOrderModule"
-
-[contract.AsyncOrderModule]
-artifact = "AsyncOrderModule"
-
-[contract.WrapperModule]
-artifact = "WrapperModule"
-
-[contract.FeeConfigurationModule]
-artifact = "FeeConfigurationModule"
-
-[contract.SynthTokenModule]
-artifact = "SynthTokenModule"
-
-[contract.AsyncOrderClaimTokenModule]
-artifact = "AsyncOrderClaimTokenModule"
-
-[contract.CoreModule]
-artifact = "contracts/modules/CoreModule.sol:CoreModule"
-
-[contract.InitialSpotMarketProxy]
-artifact = "contracts/Proxy.sol:Proxy"
-args = ["<%= contracts.CoreModule.address %>"]
-abiOf = ["CoreModule"]
-salt = "<%= settings.salt %>"
-depends = ["contract.CoreModule"]
-
-[invoke.acquire_ownership]
-target = ["InitialSpotMarketProxy"]
-from = "<%= settings.coreProxyOwner %>"
-func = "initializeOwnerModule"
-args = ["<%= settings.coreProxyOwner %>"]
-depends = ["contract.InitialSpotMarketProxy"]
-
-# Core
-[router.SpotMarketRouter]
-contracts = [
-  "CoreModule",
-  "SpotMarketFactoryModule",
-  "AtomicOrderModule",
-  "AsyncOrderModule",
-  "WrapperModule",
-  "FeeConfigurationModule"
-]
-depends = [
-  "contract.CoreModule",
-  "contract.SpotMarketFactoryModule",
-  "contract.AtomicOrderModule",
-  "contract.AsyncOrderModule",
-  "contract.WrapperModule",
-  "contract.FeeConfigurationModule"
-]
-
-[invoke.upgrade_spot_market_proxy]
-target = ["InitialSpotMarketProxy"]
-from = "<%= settings.coreProxyOwner %>"
-func = "upgradeTo"
-args = ["<%= contracts.SpotMarketRouter.address %>"]
-factory.SpotMarketProxy.abiOf = ["SpotMarketRouter"]
-factory.SpotMarketProxy.event = "Upgraded"
-factory.SpotMarketProxy.arg = 0
-depends = ["invoke.acquire_ownership", "router.SpotMarketRouter"]
-
-# create synth router
-[router.SynthRouter]
-contracts = [
-  "CoreModule",
-  "SynthTokenModule"
-]
-depends = [
-  "contract.CoreModule",
-  "contract.SynthTokenModule"
-]
-
-# create async order claim token router
-
-[router.AsyncOrderClaimRouter]
-contracts = [
-  "CoreModule",
-  "AsyncOrderClaimTokenModule"
-]
-depends = [
-  "contract.CoreModule",
-  "contract.AsyncOrderClaimTokenModule"
-]
-
-
-[invoke.initialize_spot_market_factory]
-target = ["SpotMarketProxy"]
-from = "<%= settings.coreProxyOwner %>"
-func = "initialize"
-args = [
-  "<%= imports.synthetix.contracts.CoreProxy.address %>",
-  "<%= imports.synthetix.contracts.USDProxy.address %>",
-  "<%= imports.oracle_manager.contracts.Proxy.address %>",
-  "<%= contracts.SynthRouter.address %>",
-  "<%= contracts.AsyncOrderClaimRouter.address %>"
-]
-depends = ["invoke.upgrade_spot_market_proxy", "import.synthetix", "import.oracle_manager", "router.SynthRouter", "router.AsyncOrderClaimRouter"]
-
-# add pool owner to feature flag allow list (owner must be pdao for this to be successful)
-[invoke.addSpotMarketToFeatureFlag]
-target = ["synthetix.CoreProxy"]
-func = "addToFeatureFlagAllowlist"
-from = "<%= settings.coreProxyOwner %>"
-args = ["0x72656769737465724d61726b6574000000000000000000000000000000000000", "<%= contracts.SpotMarketProxy.address %>"] # formatBytes32String("registerMarket")
-depends = ['import.synthetix', 'invoke.upgrade_spot_market_proxy']
+[invoke.set_usd_token_for_fee_collector]
+target = ["FeeCollectorMock"]
+func = "setUsdToken"
+args = ["<%= imports.synthetix.contracts.USDProxy.address %>"]
+depends = ["contract.FeeCollectorMock", "import.synthetix"]

--- a/markets/spot-market/contracts/mocks/FeeCollectorMock.sol
+++ b/markets/spot-market/contracts/mocks/FeeCollectorMock.sol
@@ -1,0 +1,28 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@synthetixio/core-modules/contracts/interfaces/ITokenModule.sol";
+import "../interfaces/external/IFeeCollector.sol";
+
+contract FeeCollectorMock is IFeeCollector {
+    ITokenModule public usdToken;
+
+    function setUsdToken(ITokenModule _usdToken) external {
+        usdToken = _usdToken;
+    }
+
+    // collects 50% of the fees
+    function collectFees(uint128 marketId, uint256 feeAmount) external override {
+        uint feeToCollect = feeAmount / 2;
+
+        usdToken.transferFrom(msg.sender, address(this), feeToCollect);
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(IERC165) returns (bool) {
+        return
+            interfaceId == type(IFeeCollector).interfaceId ||
+            interfaceId == this.supportsInterface.selector;
+    }
+}

--- a/markets/spot-market/contracts/utils/FeeUtil.sol
+++ b/markets/spot-market/contracts/utils/FeeUtil.sol
@@ -295,14 +295,13 @@ library FeeUtil {
             uint previousUsdBalance = store.usdToken.balanceOf(address(this));
             feeCollector.collectFees(marketId, totalFees);
             uint currentUsdBalance = store.usdToken.balanceOf(address(this));
-            collectedFees = currentUsdBalance - previousUsdBalance;
-
-            // TODO: event for fees collected?
+            collectedFees = previousUsdBalance - currentUsdBalance;
 
             store.usdToken.approve(address(feeCollector), 0);
         }
 
-        store.depositToMarketManager(marketId, totalFees - collectedFees);
+        uint feesToDeposit = totalFees - collectedFees;
+        store.depositToMarketManager(marketId, feesToDeposit);
     }
 
     function _applyFees(

--- a/markets/spot-market/test/bootstrap.ts
+++ b/markets/spot-market/test/bootstrap.ts
@@ -11,6 +11,7 @@ import {
   SynthetixCollateralMock,
   Oracle_managerProxy,
   SynthRouter,
+  FeeCollectorMock,
 } from '../generated/typechain';
 
 type Proxies = {
@@ -20,6 +21,7 @@ type Proxies = {
   ['oracle_manager.Proxy']: Oracle_managerProxy;
   SpotMarketProxy: SpotMarketProxy;
   SynthRouter: SynthRouter;
+  FeeCollectorMock: FeeCollectorMock;
 };
 
 export type Systems = {
@@ -28,6 +30,7 @@ export type Systems = {
   USD: SynthetixUSDProxy;
   CollateralMock: SynthetixCollateralMock;
   OracleManager: Oracle_managerProxy;
+  FeeCollectorMock: FeeCollectorMock;
   Synth: (address: string) => SynthRouter;
 };
 
@@ -45,6 +48,7 @@ before('load contracts', () => {
     SpotMarket: getContract('SpotMarketProxy'),
     OracleManager: getContract('oracle_manager.Proxy'),
     CollateralMock: getContract('synthetix.CollateralMock'),
+    FeeCollectorMock: getContract('FeeCollectorMock'),
     Synth: (address: string) => getContract('SynthRouter', address),
   };
 });


### PR DESCRIPTION
- Adds a `FeeCalculatorMock` that collects 50% of the fees.
- Set this mock in tests and make sure the fees are collected properly and the rest are deposited into market manager.