### PR TITLE
Wrapper changes / tests

### DIFF
--- a/markets/spot-market/contracts/interfaces/IFeeConfigurationModule.sol
+++ b/markets/spot-market/contracts/interfaces/IFeeConfigurationModule.sol
@@ -46,6 +46,14 @@ interface IFeeConfigurationModule {
     event FeeCollectorSet(uint indexed synthMarketId, address feeCollector);
 
     /**
+     * @notice emitted when wrapper fees are set for a given market
+     * @param synthMarketId Id of the market to set the wrapper fees.
+     * @param wrapFee wrapping fee in %, 18 decimals. Can be negative.
+     * @param unwrapFee unwrapping fee in %, 18 decimals. Can be negative.
+     */
+    event WrapperFeesSet(uint indexed synthMarketId, int wrapFee, int unwrapFee);
+
+    /**
      * @notice Thrown when the fee collector does not implement the IFeeCollector interface
      */
     error InvalidFeeCollectorInterface(address invalidFeeCollector);
@@ -98,4 +106,14 @@ interface IFeeConfigurationModule {
      * @param feeCollector address of the fee collector inheriting the IFeeCollector interface.
      */
     function setFeeCollector(uint128 synthMarketId, address feeCollector) external;
+
+    /**
+     * @notice sets wrapper related fees.
+     * @dev only marketOwner can set the wrapper fees
+     * @dev fees can be negative.  this is a way to unwind the wrapper if needed by providing incentives.
+     * @param synthMarketId Id of the market the wrapper fees apply to.
+     * @param wrapFee wrapping fee in %, 18 decimals. Can be negative.
+     * @param unwrapFee unwrapping fee in %, 18 decimals. Can be negative.
+     */
+    function setWrapperFees(uint128 synthMarketId, int wrapFee, int unwrapFee) external;
 }

--- a/markets/spot-market/contracts/interfaces/IWrapperModule.sol
+++ b/markets/spot-market/contracts/interfaces/IWrapperModule.sol
@@ -18,15 +18,19 @@ interface IWrapperModule {
     /**
      * @notice Thrown when user tries to wrap more than the set supply cap for the market.
      */
-    error WrapperExceedsSupplyCap(uint supplyCap, uint currentSupply, uint amountToWrap);
+    error WrapperExceedsMaxAmount(uint maxWrappableAmount, uint currentSupply, uint amountToWrap);
 
     /**
      * @notice Gets fired when wrapper supply is set for a given market, collateral type.
      * @param synthMarketId Id of the market the wrapper is initialized for.
      * @param wrapCollateralType the collateral used to wrap the synth.
-     * @param supplyCap the local supply cap for the wrapper.
+     * @param maxWrappableAmount the local supply cap for the wrapper.
      */
-    event WrapperSet(uint indexed synthMarketId, address wrapCollateralType, uint256 supplyCap);
+    event WrapperSet(
+        uint indexed synthMarketId,
+        address wrapCollateralType,
+        uint256 maxWrappableAmount
+    );
 
     /**
      * @notice Gets fired after user wraps synth
@@ -62,9 +66,13 @@ interface IWrapperModule {
      * @dev There is a synthetix v3 core system supply cap also set. If the current supply becomes higher than either the core system supply cap or the local market supply cap, wrapping will be disabled.
      * @param marketId Id of the market to enable wrapping for.
      * @param wrapCollateralType The collateral being used to wrap the synth.
-     * @param supplyCap The maximum amount of collateral that can be wrapped.  This value is registered with the Market Manager
+     * @param maxWrappableAmount The maximum amount of collateral that can be wrapped.
      */
-    function setWrapper(uint128 marketId, address wrapCollateralType, uint256 supplyCap) external;
+    function setWrapper(
+        uint128 marketId,
+        address wrapCollateralType,
+        uint256 maxWrappableAmount
+    ) external;
 
     /**
      * @notice Wraps the specified amount and returns similar value of synth minus the fees.

--- a/markets/spot-market/contracts/interfaces/IWrapperModule.sol
+++ b/markets/spot-market/contracts/interfaces/IWrapperModule.sol
@@ -9,17 +9,24 @@ interface IWrapperModule {
      * @notice Thrown when trader specified amounts to wrap/unwrap without holding the underlying asset.
      */
     error InsufficientFunds();
+
     /**
      * @notice Thrown when trader has not provided allowance for the market to transfer the underlying asset.
      */
     error InsufficientAllowance(uint expected, uint current);
 
     /**
-     * @notice Gets fired after wrapper is initialized for the market.
+     * @notice Thrown when user tries to wrap more than the set supply cap for the market.
+     */
+    error WrapperExceedsSupplyCap(uint supplyCap, uint currentSupply, uint amountToWrap);
+
+    /**
+     * @notice Gets fired when wrapper supply is set for a given market, collateral type.
      * @param synthMarketId Id of the market the wrapper is initialized for.
      * @param collateralType the collateral used to wrap the synth.
+     * @param supplyCap the local supply cap for the wrapper.
      */
-    event WrapperInitialized(uint indexed synthMarketId, address collateralType);
+    event WrapperSet(uint indexed synthMarketId, address collateralType, uint256 supplyCap);
 
     /**
      * @notice Gets fired after user wraps synth
@@ -50,13 +57,14 @@ interface IWrapperModule {
     );
 
     /**
-     * @notice Initializes wrapper functionality for the specified market with the specified collateral type.
-     * @dev Initializing wrapper enables traders to wrap and unwrap synths with the specified collateral type.
-     * @dev The collateral type has to be a supported collateral type in the synthetix v3 core system, otherwise this transaction fails.
+     * @notice Used to set the wrapper supply cap for a given market and collateral type.
+     * @dev If the supply cap is set to 0 or lower than the current outstanding supply, then the wrapper is disabled.
+     * @dev There is a synthetix v3 core system supply cap also set. If the current supply becomes higher than either the core system supply cap or the local market supply cap, wrapping will be disabled.
      * @param marketId Id of the market to enable wrapping for.
      * @param collateralType The collateral being used to wrap the synth.
+     * @param supplyCap The maximum amount of collateral that can be wrapped.  This value is registered with the Market Manager
      */
-    function initializeWrapper(uint128 marketId, address collateralType) external;
+    function setWrapper(uint128 marketId, address collateralType, uint256 supplyCap) external;
 
     /**
      * @notice Wraps the specified amount and returns similar value of synth minus the fees.

--- a/markets/spot-market/contracts/interfaces/IWrapperModule.sol
+++ b/markets/spot-market/contracts/interfaces/IWrapperModule.sol
@@ -23,10 +23,10 @@ interface IWrapperModule {
     /**
      * @notice Gets fired when wrapper supply is set for a given market, collateral type.
      * @param synthMarketId Id of the market the wrapper is initialized for.
-     * @param collateralType the collateral used to wrap the synth.
+     * @param wrapCollateralType the collateral used to wrap the synth.
      * @param supplyCap the local supply cap for the wrapper.
      */
-    event WrapperSet(uint indexed synthMarketId, address collateralType, uint256 supplyCap);
+    event WrapperSet(uint indexed synthMarketId, address wrapCollateralType, uint256 supplyCap);
 
     /**
      * @notice Gets fired after user wraps synth
@@ -61,10 +61,10 @@ interface IWrapperModule {
      * @dev If the supply cap is set to 0 or lower than the current outstanding supply, then the wrapper is disabled.
      * @dev There is a synthetix v3 core system supply cap also set. If the current supply becomes higher than either the core system supply cap or the local market supply cap, wrapping will be disabled.
      * @param marketId Id of the market to enable wrapping for.
-     * @param collateralType The collateral being used to wrap the synth.
+     * @param wrapCollateralType The collateral being used to wrap the synth.
      * @param supplyCap The maximum amount of collateral that can be wrapped.  This value is registered with the Market Manager
      */
-    function setWrapper(uint128 marketId, address collateralType, uint256 supplyCap) external;
+    function setWrapper(uint128 marketId, address wrapCollateralType, uint256 supplyCap) external;
 
     /**
      * @notice Wraps the specified amount and returns similar value of synth minus the fees.

--- a/markets/spot-market/contracts/modules/FeeConfigurationModule.sol
+++ b/markets/spot-market/contracts/modules/FeeConfigurationModule.sol
@@ -90,4 +90,14 @@ contract FeeConfigurationModule is IFeeConfigurationModule {
 
         emit FeeCollectorSet(synthMarketId, feeCollector);
     }
+
+    function setWrapperFees(uint128 synthMarketId, int wrapFee, int unwrapFee) external override {
+        SpotMarketFactory.load().onlyMarketOwner(synthMarketId);
+
+        FeeConfiguration.Data storage feeConfiguration = FeeConfiguration.load(synthMarketId);
+        feeConfiguration.wrapFixedFee = wrapFee;
+        feeConfiguration.unwrapFixedFee = unwrapFee;
+
+        emit WrapperFeesSet(synthMarketId, wrapFee, unwrapFee);
+    }
 }

--- a/markets/spot-market/contracts/modules/WrapperModule.sol
+++ b/markets/spot-market/contracts/modules/WrapperModule.sol
@@ -29,19 +29,16 @@ contract WrapperModule is IWrapperModule {
     /**
      * @inheritdoc IWrapperModule
      */
-    function initializeWrapper(uint128 marketId, address collateralType) external override {
-        SpotMarketFactory.Data storage store = SpotMarketFactory.load();
-        store.onlyMarketOwner(marketId);
+    function setWrapper(
+        uint128 marketId,
+        address collateralType,
+        uint256 supplyCap
+    ) external override {
+        SpotMarketFactory.load().onlyMarketOwner(marketId);
 
-        Wrapper.create(marketId, collateralType);
+        Wrapper.update(marketId, collateralType, supplyCap);
 
-        IMarketCollateralModule(store.synthetix).configureMaximumMarketCollateral(
-            marketId,
-            collateralType,
-            type(uint256).max // TODO: add supply cap
-        );
-
-        emit WrapperInitialized(marketId, collateralType);
+        emit WrapperSet(marketId, collateralType, supplyCap);
     }
 
     /**
@@ -53,7 +50,8 @@ contract WrapperModule is IWrapperModule {
     ) external override returns (uint256 amountToMint) {
         SpotMarketFactory.Data storage store = SpotMarketFactory.load();
         Wrapper.Data storage wrapperStore = Wrapper.load(marketId);
-        wrapperStore.onlyEnabledWrapper();
+        store.isValidMarket(marketId);
+        wrapperStore.isValidWrapper();
 
         IERC20 wrappingCollateral = IERC20(wrapperStore.collateralType);
 
@@ -64,11 +62,24 @@ contract WrapperModule is IWrapperModule {
                 store.usdToken.allowance(msg.sender, address(this))
             );
 
+        uint currentDepositedCollateral = IMarketCollateralModule(store.synthetix)
+            .getMarketCollateralAmount(marketId, wrapperStore.collateralType);
+
+        // revert when wrapping more than the supply cap
+        if (currentDepositedCollateral + wrapAmount > wrapperStore.supplyCap) {
+            revert WrapperExceedsSupplyCap(
+                wrapperStore.supplyCap,
+                currentDepositedCollateral,
+                wrapAmount
+            );
+        }
+
         // safe transfer?
         wrappingCollateral.transferFrom(msg.sender, address(this), wrapAmount);
+        wrappingCollateral.approve(store.synthetix, wrapAmount);
         IMarketCollateralModule(store.synthetix).depositMarketCollateral(
             marketId,
-            address(this),
+            wrapperStore.collateralType,
             wrapAmount
         );
 
@@ -119,7 +130,8 @@ contract WrapperModule is IWrapperModule {
     ) external override returns (uint256 returnCollateralAmount) {
         SpotMarketFactory.Data storage store = SpotMarketFactory.load();
         Wrapper.Data storage wrapperStore = Wrapper.load(marketId);
-        wrapperStore.onlyEnabledWrapper();
+        store.isValidMarket(marketId);
+        wrapperStore.isValidWrapper();
 
         ITokenModule synth = SynthUtil.getToken(marketId);
 
@@ -135,7 +147,7 @@ contract WrapperModule is IWrapperModule {
             unwrapAmount,
             SpotMarketFactory.TransactionType.UNWRAP
         );
-        (uint256 returnAmount, int256 totalFees) = FeeUtil.calculateFees(
+        (uint256 returnAmountUsd, int256 totalFees) = FeeUtil.calculateFees(
             marketId,
             msg.sender,
             unwrapAmountInUsd,
@@ -154,11 +166,10 @@ contract WrapperModule is IWrapperModule {
 
         returnCollateralAmount = Price.usdSynthExchangeRate(
             marketId,
-            returnAmount,
+            returnAmountUsd,
             SpotMarketFactory.TransactionType.UNWRAP
         );
 
-        // TODO: would be nice to combine withdrawing market collateral and transferring collateral to seller
         IMarketCollateralModule(store.synthetix).withdrawMarketCollateral(
             marketId,
             wrapperStore.collateralType,
@@ -166,7 +177,7 @@ contract WrapperModule is IWrapperModule {
         );
 
         ITokenModule(wrapperStore.collateralType).transfer(msg.sender, returnCollateralAmount);
-        synth.burn(msg.sender, unwrapAmount);
+        synth.burn(address(this), unwrapAmount);
 
         emit SynthUnwrapped(marketId, returnCollateralAmount, totalFees, collectedFees);
     }

--- a/markets/spot-market/contracts/modules/WrapperModule.sol
+++ b/markets/spot-market/contracts/modules/WrapperModule.sol
@@ -31,14 +31,14 @@ contract WrapperModule is IWrapperModule {
      */
     function setWrapper(
         uint128 marketId,
-        address collateralType,
+        address wrapCollateralType,
         uint256 supplyCap
     ) external override {
         SpotMarketFactory.load().onlyMarketOwner(marketId);
 
-        Wrapper.update(marketId, collateralType, supplyCap);
+        Wrapper.update(marketId, wrapCollateralType, supplyCap);
 
-        emit WrapperSet(marketId, collateralType, supplyCap);
+        emit WrapperSet(marketId, wrapCollateralType, supplyCap);
     }
 
     /**
@@ -53,7 +53,7 @@ contract WrapperModule is IWrapperModule {
         store.isValidMarket(marketId);
         wrapperStore.isValidWrapper();
 
-        IERC20 wrappingCollateral = IERC20(wrapperStore.collateralType);
+        IERC20 wrappingCollateral = IERC20(wrapperStore.wrapCollateralType);
 
         if (wrappingCollateral.balanceOf(msg.sender) < wrapAmount) revert InsufficientFunds();
         if (wrappingCollateral.allowance(msg.sender, address(this)) < wrapAmount)
@@ -63,7 +63,7 @@ contract WrapperModule is IWrapperModule {
             );
 
         uint currentDepositedCollateral = IMarketCollateralModule(store.synthetix)
-            .getMarketCollateralAmount(marketId, wrapperStore.collateralType);
+            .getMarketCollateralAmount(marketId, wrapperStore.wrapCollateralType);
 
         // revert when wrapping more than the supply cap
         if (currentDepositedCollateral + wrapAmount > wrapperStore.supplyCap) {
@@ -79,7 +79,7 @@ contract WrapperModule is IWrapperModule {
         wrappingCollateral.approve(store.synthetix, wrapAmount);
         IMarketCollateralModule(store.synthetix).depositMarketCollateral(
             marketId,
-            wrapperStore.collateralType,
+            wrapperStore.wrapCollateralType,
             wrapAmount
         );
 
@@ -172,11 +172,11 @@ contract WrapperModule is IWrapperModule {
 
         IMarketCollateralModule(store.synthetix).withdrawMarketCollateral(
             marketId,
-            wrapperStore.collateralType,
+            wrapperStore.wrapCollateralType,
             returnCollateralAmount
         );
 
-        ITokenModule(wrapperStore.collateralType).transfer(msg.sender, returnCollateralAmount);
+        ITokenModule(wrapperStore.wrapCollateralType).transfer(msg.sender, returnCollateralAmount);
         synth.burn(address(this), unwrapAmount);
 
         emit SynthUnwrapped(marketId, returnCollateralAmount, totalFees, collectedFees);

--- a/markets/spot-market/contracts/modules/WrapperModule.sol
+++ b/markets/spot-market/contracts/modules/WrapperModule.sol
@@ -32,13 +32,13 @@ contract WrapperModule is IWrapperModule {
     function setWrapper(
         uint128 marketId,
         address wrapCollateralType,
-        uint256 supplyCap
+        uint256 maxWrappableAmount
     ) external override {
         SpotMarketFactory.load().onlyMarketOwner(marketId);
 
-        Wrapper.update(marketId, wrapCollateralType, supplyCap);
+        Wrapper.update(marketId, wrapCollateralType, maxWrappableAmount);
 
-        emit WrapperSet(marketId, wrapCollateralType, supplyCap);
+        emit WrapperSet(marketId, wrapCollateralType, maxWrappableAmount);
     }
 
     /**
@@ -66,9 +66,9 @@ contract WrapperModule is IWrapperModule {
             .getMarketCollateralAmount(marketId, wrapperStore.wrapCollateralType);
 
         // revert when wrapping more than the supply cap
-        if (currentDepositedCollateral + wrapAmount > wrapperStore.supplyCap) {
-            revert WrapperExceedsSupplyCap(
-                wrapperStore.supplyCap,
+        if (currentDepositedCollateral + wrapAmount > wrapperStore.maxWrappableAmount) {
+            revert WrapperExceedsMaxAmount(
+                wrapperStore.maxWrappableAmount,
                 currentDepositedCollateral,
                 wrapAmount
             );

--- a/markets/spot-market/contracts/storage/Wrapper.sol
+++ b/markets/spot-market/contracts/storage/Wrapper.sol
@@ -7,7 +7,7 @@ import "@synthetixio/core-modules/contracts/interfaces/ITokenModule.sol";
  * @title Wrapper library servicing the wrapper module
  */
 library Wrapper {
-    error WrappingNotInitialized();
+    error InvalidCollateralType();
 
     struct Data {
         /**
@@ -16,9 +16,9 @@ library Wrapper {
          */
         address collateralType;
         /**
-         * @dev sets if wrapping is enabled for given market id
+         * @dev amount of collateral that can be wrapped
          */
-        bool wrappingEnabled;
+        uint256 supplyCap;
     }
 
     function load(uint128 marketId) internal pure returns (Data storage store) {
@@ -28,18 +28,15 @@ library Wrapper {
         }
     }
 
-    function create(uint128 marketId, address collateralType) internal {
-        update(load(marketId), true, collateralType);
-    }
-
-    function update(Data storage self, bool wrappingEnabled, address collateralType) internal {
+    function update(uint128 marketId, address collateralType, uint256 supplyCap) internal {
+        Data storage self = load(marketId);
         self.collateralType = collateralType;
-        self.wrappingEnabled = wrappingEnabled;
+        self.supplyCap = supplyCap;
     }
 
-    function onlyEnabledWrapper(Wrapper.Data storage self) internal view {
-        if (self.wrappingEnabled) {
-            revert WrappingNotInitialized();
+    function isValidWrapper(Data storage self) internal view {
+        if (self.collateralType == address(0)) {
+            revert InvalidCollateralType();
         }
     }
 }

--- a/markets/spot-market/contracts/storage/Wrapper.sol
+++ b/markets/spot-market/contracts/storage/Wrapper.sol
@@ -18,7 +18,7 @@ library Wrapper {
         /**
          * @dev amount of collateral that can be wrapped
          */
-        uint256 supplyCap;
+        uint256 maxWrappableAmount;
     }
 
     function load(uint128 marketId) internal pure returns (Data storage store) {
@@ -28,10 +28,14 @@ library Wrapper {
         }
     }
 
-    function update(uint128 marketId, address wrapCollateralType, uint256 supplyCap) internal {
+    function update(
+        uint128 marketId,
+        address wrapCollateralType,
+        uint256 maxWrappableAmount
+    ) internal {
         Data storage self = load(marketId);
         self.wrapCollateralType = wrapCollateralType;
-        self.supplyCap = supplyCap;
+        self.maxWrappableAmount = maxWrappableAmount;
     }
 
     function isValidWrapper(Data storage self) internal view {

--- a/markets/spot-market/contracts/storage/Wrapper.sol
+++ b/markets/spot-market/contracts/storage/Wrapper.sol
@@ -14,7 +14,7 @@ library Wrapper {
          * @dev tracks the type of collateral used for wrapping
          * helpful for checking balances and allowances
          */
-        address collateralType;
+        address wrapCollateralType;
         /**
          * @dev amount of collateral that can be wrapped
          */
@@ -28,14 +28,14 @@ library Wrapper {
         }
     }
 
-    function update(uint128 marketId, address collateralType, uint256 supplyCap) internal {
+    function update(uint128 marketId, address wrapCollateralType, uint256 supplyCap) internal {
         Data storage self = load(marketId);
-        self.collateralType = collateralType;
+        self.wrapCollateralType = wrapCollateralType;
         self.supplyCap = supplyCap;
     }
 
     function isValidWrapper(Data storage self) internal view {
-        if (self.collateralType == address(0)) {
+        if (self.wrapCollateralType == address(0)) {
             revert InvalidCollateralType();
         }
     }

--- a/markets/spot-market/contracts/utils/FeeUtil.sol
+++ b/markets/spot-market/contracts/utils/FeeUtil.sol
@@ -205,7 +205,7 @@ library FeeUtil {
 
         Wrapper.Data storage wrapper = Wrapper.load(marketId);
         uint wrappedMarketCollateral = IMarketCollateralModule(SpotMarketFactory.load().synthetix)
-            .getMarketCollateralAmount(marketId, wrapper.collateralType)
+            .getMarketCollateralAmount(marketId, wrapper.wrapCollateralType)
             .mulDecimal(collateralPrice);
 
         uint initialSkew = totalSynthValue - wrappedMarketCollateral;

--- a/markets/spot-market/contracts/utils/FeeUtil.sol
+++ b/markets/spot-market/contracts/utils/FeeUtil.sol
@@ -318,7 +318,7 @@ library FeeUtil {
     function _applyFees(
         uint amount,
         int fees // 18 decimals
-    ) private view returns (uint amountUsable, int feesCollected) {
+    ) private pure returns (uint amountUsable, int feesCollected) {
         feesCollected = fees.mulDecimal(amount.toInt());
         amountUsable = (amount.toInt() - feesCollected).toUint();
     }

--- a/markets/spot-market/contracts/utils/FeeUtil.sol
+++ b/markets/spot-market/contracts/utils/FeeUtil.sol
@@ -204,12 +204,9 @@ library FeeUtil {
         );
 
         Wrapper.Data storage wrapper = Wrapper.load(marketId);
-        uint wrappedMarketCollateral = 0;
-        if (wrapper.wrappingEnabled) {
-            wrappedMarketCollateral = IMarketCollateralModule(SpotMarketFactory.load().synthetix)
-                .getMarketCollateralAmount(marketId, wrapper.collateralType)
-                .mulDecimal(collateralPrice);
-        }
+        uint wrappedMarketCollateral = IMarketCollateralModule(SpotMarketFactory.load().synthetix)
+            .getMarketCollateralAmount(marketId, wrapper.collateralType)
+            .mulDecimal(collateralPrice);
 
         uint initialSkew = totalSynthValue - wrappedMarketCollateral;
         uint initialSkewAdjustment = initialSkew.divDecimal(skewScaleValue);
@@ -303,10 +300,11 @@ library FeeUtil {
         SpotMarketFactory.Data storage store = SpotMarketFactory.load();
 
         if (address(feeCollector) != address(0)) {
-            store.usdToken.approve(address(feeCollector), totalFees);
-
             uint previousUsdBalance = store.usdToken.balanceOf(address(this));
+
+            store.usdToken.approve(address(feeCollector), totalFees);
             feeCollector.collectFees(marketId, totalFees);
+
             uint currentUsdBalance = store.usdToken.balanceOf(address(this));
             collectedFees = previousUsdBalance - currentUsdBalance;
 
@@ -320,7 +318,7 @@ library FeeUtil {
     function _applyFees(
         uint amount,
         int fees // 18 decimals
-    ) private pure returns (uint amountUsable, int feesCollected) {
+    ) private view returns (uint amountUsable, int feesCollected) {
         feesCollected = fees.mulDecimal(amount.toInt());
         amountUsable = (amount.toInt() - feesCollected).toUint();
     }

--- a/markets/spot-market/test/WrapperModule.test.ts
+++ b/markets/spot-market/test/WrapperModule.test.ts
@@ -8,7 +8,7 @@ import { SynthRouter } from '../generated/typechain';
 
 const bn = (n: number) => wei(n).toBN();
 
-describe.only('WrapperModule', () => {
+describe('WrapperModule', () => {
   const { systems, signers, marketId } = bootstrapTraders(
     bootstrapWithSynth('Synthetic Ether', 'snxETH')
   );

--- a/markets/spot-market/test/WrapperModule.test.ts
+++ b/markets/spot-market/test/WrapperModule.test.ts
@@ -17,7 +17,7 @@ describe('WrapperModule', () => {
   let synth: SynthRouter;
 
   before('identify actors', async () => {
-    [, , marketOwner, trader1, trader2] = signers();
+    [, , marketOwner, trader1] = signers();
   });
 
   before('identify synth', async () => {

--- a/markets/spot-market/test/WrapperModule.test.ts
+++ b/markets/spot-market/test/WrapperModule.test.ts
@@ -1,0 +1,248 @@
+import { ethers } from 'ethers';
+import { wei } from '@synthetixio/wei';
+import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
+import assertEvent from '@synthetixio/core-utils/utils/assertions/assert-event';
+import assertBn from '@synthetixio/core-utils/utils/assertions/assert-bignumber';
+import { bootstrapTraders, bootstrapWithSynth } from './bootstrap';
+import { SynthRouter } from '../generated/typechain';
+
+const bn = (n: number) => wei(n).toBN();
+
+describe.only('WrapperModule', () => {
+  const { systems, signers, marketId } = bootstrapTraders(
+    bootstrapWithSynth('Synthetic Ether', 'snxETH')
+  );
+
+  let marketOwner: ethers.Signer, trader1: ethers.Signer, trader2: ethers.Signer;
+  let synth: SynthRouter;
+
+  before('identify actors', async () => {
+    [, , marketOwner, trader1, trader2] = signers();
+  });
+
+  before('identify synth', async () => {
+    const synthAddress = await systems().SpotMarket.getSynth(1);
+    synth = systems().Synth(synthAddress);
+  });
+
+  before('set wrapper fees', async () => {
+    await systems().SpotMarket.connect(marketOwner).setWrapperFees(marketId(), bn(0.01), bn(0.005));
+  });
+
+  before('set fee collector', async () => {
+    await systems()
+      .SpotMarket.connect(marketOwner)
+      .setFeeCollector(marketId(), systems().FeeCollectorMock.address);
+  });
+
+  it('reverts when invalid market id', async () => {
+    await assertRevert(systems().SpotMarket.wrap(25, 10000), 'InvalidMarket');
+  });
+
+  it('reverts when wrapper not set', async () => {
+    await assertRevert(systems().SpotMarket.wrap(marketId(), 10000), 'InvalidCollateralType');
+  });
+
+  it('reverts when not a market owner tries updating wrapper', async () => {
+    await assertRevert(
+      systems().SpotMarket.setWrapper(marketId(), systems().CollateralMock.address, bn(1000)),
+      'OnlyMarketOwner'
+    );
+  });
+
+  describe('enable wrapper', () => {
+    let txn: ethers.providers.TransactionResponse;
+    before('enable wrapper', async () => {
+      txn = await systems()
+        .SpotMarket.connect(marketOwner)
+        .setWrapper(marketId(), systems().CollateralMock.address, bn(500));
+    });
+
+    it('emits event', async () => {
+      await assertEvent(
+        txn,
+        `WrapperSet(${marketId()}, "${systems().CollateralMock.address}", ${bn(500)})`,
+        systems().SpotMarket
+      );
+    });
+  });
+
+  describe('wrap', () => {
+    describe('without enough funds', () => {
+      it('reverts', async () => {
+        await assertRevert(
+          systems().SpotMarket.connect(trader1).wrap(marketId(), bn(1_000_000)),
+          'InsufficientFunds'
+        );
+      });
+    });
+
+    describe('when proper allowances are not set', () => {
+      it('reverts', async () => {
+        await assertRevert(
+          systems().SpotMarket.connect(trader1).wrap(marketId(), bn(1_000)),
+          'InsufficientAllowance'
+        );
+      });
+    });
+
+    describe('with proper funds and allowance', () => {
+      before('set allowance', async () => {
+        await systems()
+          .CollateralMock.connect(trader1)
+          .approve(systems().SpotMarket.address, bn(1));
+      });
+
+      let txn: ethers.providers.TransactionResponse, previousWithdrwableUsd: ethers.BigNumber;
+
+      before('identify withdrawable usd', async () => {
+        previousWithdrwableUsd = await systems().Core.getWithdrawableMarketUsd(marketId());
+      });
+
+      before('wrap using collateral', async () => {
+        txn = await systems().SpotMarket.connect(trader1).wrap(marketId(), bn(1));
+      });
+
+      it('returns correct amount of synth to trader', async () => {
+        assertBn.equal(
+          await synth.balanceOf(await trader1.getAddress()),
+          bn(1).sub(bn(0.01)) // 1 - 0.01% fee
+        );
+      });
+
+      it('collected half fees to fee collector', async () => {
+        assertBn.equal(
+          await systems().USD.balanceOf(systems().FeeCollectorMock.address),
+          bn(4.5) // assuming price of 1 eth = $900 (sell feed id)
+        );
+      });
+
+      it('deposited correct amount into market collateral', async () => {
+        assertBn.equal(
+          await systems().Core.getMarketCollateralAmount(
+            marketId(),
+            systems().CollateralMock.address
+          ),
+          bn(1)
+        );
+      });
+
+      it('properly reflects withdrawable usd', async () => {
+        // collateral price in core = $1000/eth
+        // fees withdrawn from core = $9
+        // fees collected by fee collector = $4.5
+        // fees re-deposited into core = $4.5
+        // withdrawable usd = $1000 - $9 + $4.5 = $995.5
+        assertBn.equal(
+          await systems().Core.getWithdrawableMarketUsd(marketId()),
+          previousWithdrwableUsd.add(bn(995.5))
+        );
+      });
+
+      it('emits wrap event', async () => {
+        await assertEvent(
+          txn,
+          `SynthWrapped(${marketId()}, ${bn(0.99)}, ${bn(9)}, ${bn(4.5)})`,
+          systems().SpotMarket
+        );
+      });
+    });
+  });
+
+  describe('unwrap', () => {
+    describe('when not enough synth', () => {
+      it('reverts', async () => {
+        await assertRevert(
+          systems().SpotMarket.connect(trader1).unwrap(marketId(), bn(1_000)),
+          'InsufficientFunds'
+        );
+      });
+    });
+
+    describe('when proper allowances are not set', () => {
+      it('reverts', async () => {
+        await assertRevert(
+          systems().SpotMarket.connect(trader1).unwrap(marketId(), bn(0.1)),
+          'InsufficientAllowance'
+        );
+      });
+    });
+
+    describe('with proper synth funds and allowance', async () => {
+      before('set allowance', async () => {
+        await synth.connect(trader1).approve(systems().SpotMarket.address, bn(0.5));
+      });
+
+      let txn: ethers.providers.TransactionResponse,
+        previousWithdrwableUsd: ethers.BigNumber,
+        previousTrader1CollateralAmount: ethers.BigNumber,
+        previousFeeCollectorUsdBalance: ethers.BigNumber,
+        previousMarketCollateralAmount: ethers.BigNumber;
+
+      before('identify previous balances', async () => {
+        previousWithdrwableUsd = await systems().Core.getWithdrawableMarketUsd(marketId());
+        previousTrader1CollateralAmount = await systems().CollateralMock.balanceOf(
+          await trader1.getAddress()
+        );
+        previousFeeCollectorUsdBalance = await systems().USD.balanceOf(
+          systems().FeeCollectorMock.address
+        );
+        previousMarketCollateralAmount = await systems().Core.getMarketCollateralAmount(
+          marketId(),
+          systems().CollateralMock.address
+        );
+      });
+
+      before('unwrap synth', async () => {
+        txn = await systems().SpotMarket.connect(trader1).unwrap(marketId(), bn(0.5));
+      });
+
+      it('returns correct amount of collateral to trader', async () => {
+        assertBn.equal(
+          await systems().CollateralMock.balanceOf(await trader1.getAddress()),
+          previousTrader1CollateralAmount.add(bn(0.4975)) // 0.5 - 0.5% fee
+        );
+      });
+
+      it('collected half fees to fee collector', async () => {
+        // 1 eth = $900
+        // 0.5 eth = $450
+        // .5% fee = $2.25
+        // 2.25 / 2 = 1.125 (half goes to fee collector)
+        assertBn.equal(
+          await systems().USD.balanceOf(systems().FeeCollectorMock.address),
+          previousFeeCollectorUsdBalance.add(bn(1.125))
+        );
+      });
+
+      it('withdrew correct amount from market collateral', async () => {
+        assertBn.equal(
+          await systems().Core.getMarketCollateralAmount(
+            marketId(),
+            systems().CollateralMock.address
+          ),
+          previousMarketCollateralAmount.sub(bn(0.4975))
+        );
+      });
+
+      it('properly reflects withdrawable usd', async () => {
+        // fees withdrawn from core = $2.25
+        // fees collected by fee collector = $1.125
+        // fees re-deposited into core = $1.125
+        // withdrew 0.4975 ETH to return to user = $497.5
+        assertBn.equal(
+          await systems().Core.getWithdrawableMarketUsd(marketId()),
+          previousWithdrwableUsd.sub(bn(497.5).add(bn(1.125)))
+        );
+      });
+
+      it('emits unwrap event', async () => {
+        await assertEvent(
+          txn,
+          `SynthUnwrapped(${marketId()}, ${bn(0.4975)}, ${bn(2.25)}, ${bn(1.125)})`,
+          systems().SpotMarket
+        );
+      });
+    });
+  });
+});

--- a/markets/spot-market/test/WrapperModule.test.ts
+++ b/markets/spot-market/test/WrapperModule.test.ts
@@ -13,7 +13,7 @@ describe('WrapperModule', () => {
     bootstrapWithSynth('Synthetic Ether', 'snxETH')
   );
 
-  let marketOwner: ethers.Signer, trader1: ethers.Signer, trader2: ethers.Signer;
+  let marketOwner: ethers.Signer, trader1: ethers.Signer;
   let synth: SynthRouter;
 
   before('identify actors', async () => {
@@ -93,10 +93,10 @@ describe('WrapperModule', () => {
           .approve(systems().SpotMarket.address, bn(1));
       });
 
-      let txn: ethers.providers.TransactionResponse, previousWithdrwableUsd: ethers.BigNumber;
+      let txn: ethers.providers.TransactionResponse, previousWithdrawableUsd: ethers.BigNumber;
 
       before('identify withdrawable usd', async () => {
-        previousWithdrwableUsd = await systems().Core.getWithdrawableMarketUsd(marketId());
+        previousWithdrawableUsd = await systems().Core.getWithdrawableMarketUsd(marketId());
       });
 
       before('wrap using collateral', async () => {
@@ -135,7 +135,7 @@ describe('WrapperModule', () => {
         // withdrawable usd = $1000 - $9 + $4.5 = $995.5
         assertBn.equal(
           await systems().Core.getWithdrawableMarketUsd(marketId()),
-          previousWithdrwableUsd.add(bn(995.5))
+          previousWithdrawableUsd.add(bn(995.5))
         );
       });
 
@@ -174,13 +174,13 @@ describe('WrapperModule', () => {
       });
 
       let txn: ethers.providers.TransactionResponse,
-        previousWithdrwableUsd: ethers.BigNumber,
+        previousWithdrawableUsd: ethers.BigNumber,
         previousTrader1CollateralAmount: ethers.BigNumber,
         previousFeeCollectorUsdBalance: ethers.BigNumber,
         previousMarketCollateralAmount: ethers.BigNumber;
 
       before('identify previous balances', async () => {
-        previousWithdrwableUsd = await systems().Core.getWithdrawableMarketUsd(marketId());
+        previousWithdrawableUsd = await systems().Core.getWithdrawableMarketUsd(marketId());
         previousTrader1CollateralAmount = await systems().CollateralMock.balanceOf(
           await trader1.getAddress()
         );
@@ -232,7 +232,7 @@ describe('WrapperModule', () => {
         // withdrew 0.4975 ETH to return to user = $497.5
         assertBn.equal(
           await systems().Core.getWithdrawableMarketUsd(marketId()),
-          previousWithdrwableUsd.sub(bn(497.5).add(bn(1.125)))
+          previousWithdrawableUsd.sub(bn(497.5).add(bn(1.125)))
         );
       });
 
@@ -258,8 +258,7 @@ describe('WrapperModule', () => {
       await systems().SpotMarket.connect(trader1).wrap(marketId(), bn(1));
     });
 
-    let previousWithdrwableUsd: ethers.BigNumber,
-      previousTrader1CollateralAmount: ethers.BigNumber,
+    let previousTrader1CollateralAmount: ethers.BigNumber,
       previousFeeCollectorBalance: ethers.BigNumber;
 
     before('identify previous values', async () => {

--- a/markets/spot-market/test/bootstrap.ts
+++ b/markets/spot-market/test/bootstrap.ts
@@ -102,13 +102,10 @@ export function bootstrapWithStakedPool() {
   before('configure collateral', async () => {
     const [owner] = r.signers();
 
-    // deploy an aggregator
-    collateralAddress = r.systems().CollateralMock.address;
-
-    // add collateral,
+    // add collateral
     await (
       await r.systems().Core.connect(owner).configureCollateral({
-        tokenAddress: collateralAddress,
+        tokenAddress: r.systems().CollateralMock.address,
         oracleNodeId,
         issuanceRatioD18: '5000000000000000000',
         liquidationRatioD18: '1500000000000000000',
@@ -162,6 +159,17 @@ export function bootstrapWithSynth(name: string, token: string) {
       .systems()
       .SpotMarket.callStatic.registerSynth(name, token, marketOwner.getAddress());
     await r.systems().SpotMarket.registerSynth(name, token, marketOwner.getAddress());
+  });
+
+  before('configure market collateral supply cap', async () => {
+    await r
+      .systems()
+      .Core.connect(coreOwner)
+      .configureMaximumMarketCollateral(
+        marketId,
+        r.systems().CollateralMock.address,
+        ethers.constants.MaxUint256
+      );
   });
 
   before('setup buy and sell feeds', async () => {


### PR DESCRIPTION
- wrapper fees changed to int's as they can be negative.
- removed `wrappingEnabled` and setup a local supply cap that can be set to 0 if we need to disable.
- unwrapping is still allowed and the supply cap doesn't affect it.
- lots of tests; including negative fee tests.