### PR TITLE
add missing distributeDebtToPools public method

### DIFF
--- a/protocol/oracle-manager/cannonfile.toml
+++ b/protocol/oracle-manager/cannonfile.toml
@@ -28,13 +28,6 @@ create2 = true
 
 depends = ["contract.CoreModule"]
 
-[invoke.acquire_ownership]
-target = ["InitialProxy"]
-from = "<%= settings.owner %>"
-func = "initializeOwnerModule"
-args = ["<%= settings.owner %>"]
-depends = ["contract.InitialProxy"]
-
 [router.OracleRouter]
 contracts = ["CoreModule", "NodeModule"]
 depends = [
@@ -50,4 +43,4 @@ args = ["<%= contracts.OracleRouter.address %>"]
 factory.Proxy.abiOf = ["OracleRouter"]
 factory.Proxy.event = "Upgraded"
 factory.Proxy.arg = 0
-depends = ["invoke.acquire_ownership", "router.OracleRouter"]
+depends = ["contract.InitialProxy", "router.OracleRouter"]

--- a/protocol/synthetix/contracts/interfaces/IMarketManagerModule.sol
+++ b/protocol/synthetix/contracts/interfaces/IMarketManagerModule.sol
@@ -132,4 +132,14 @@ interface IMarketManagerModule {
      * @return A boolean that is true if the market's capacity is locked at the time of the query.
      */
     function isMarketCapacityLocked(uint128 marketId) external view returns (bool);
+
+    /**
+     * @notice Update a market's current debt registration with the system.
+     * This function is provided as an escape hatch for pool griefing, preventing
+     * overwhelming the system with a series of very small pools and creating high gas
+     * costs to update an account.
+     * @param marketId the id of the market that needs pools bumped
+     * @return whether or not all bumpable pools have been bumped
+     */
+    function distributeDebtToPools(uint128 marketId, uint maxIter) external returns (bool);
 }

--- a/protocol/synthetix/contracts/modules/core/MarketManagerModule.sol
+++ b/protocol/synthetix/contracts/modules/core/MarketManagerModule.sol
@@ -151,4 +151,14 @@ contract MarketManagerModule is IMarketManagerModule {
 
         emit MarketUsdWithdrawn(marketId, target, amount, msg.sender);
     }
+
+    /**
+     * @inheritdoc IMarketManagerModule
+     */
+    function distributeDebtToPools(
+        uint128 marketId,
+        uint maxIter
+    ) external override returns (bool) {
+        return Market.load(marketId).distributeDebtToPools(maxIter);
+    }
 }

--- a/protocol/synthetix/contracts/storage/Market.sol
+++ b/protocol/synthetix/contracts/storage/Market.sol
@@ -10,6 +10,8 @@ import "./MarketPoolInfo.sol";
 
 import "../interfaces/external/IMarket.sol";
 
+import "hardhat/console.sol";
+
 /**
  * @title Connects external contracts that implement the `IMarket` interface to the system.
  *
@@ -373,7 +375,10 @@ library Market {
      *
      * Note: The parameter `maxIter` is used as an escape hatch to discourage griefing.
      */
-    function distributeDebtToPools(Data storage self, uint256 maxIter) internal {
+    function distributeDebtToPools(
+        Data storage self,
+        uint256 maxIter
+    ) internal returns (bool fullyDistributed) {
         // Get the current and last distributed market balances.
         // Note: The last distributed balance will be cached within this function's execution.
         int256 targetBalanceD18 = totalDebt(self);
@@ -389,6 +394,8 @@ library Market {
             );
             self.lastDistributedMarketBalanceD18 = targetBalanceD18.to128();
         }
+
+        return !exhausted;
     }
 
     /**

--- a/utils/common-config/hardhat.config.ts
+++ b/utils/common-config/hardhat.config.ts
@@ -60,12 +60,15 @@ const config = {
       chainId: 10,
     },
     goerli: {
-      url: `https://goerli.infura.io/v3/${process.env.INFURA_API_KEY}`,
+      url:
+        process.env.NETWORK_ENDPOINT || `https://goerli.infura.io/v3/${process.env.INFURA_API_KEY}`,
       accounts: process.env.DEPLOYER_PRIVATE_KEY ? [process.env.DEPLOYER_PRIVATE_KEY] : [],
       chainId: 5,
     },
     ['avalanche-fuji']: {
-      url: `https://avalanche-fuji.infura.io/v3/${process.env.INFURA_API_KEY}`,
+      url:
+        process.env.NETWORK_ENDPOINT ||
+        `https://avalanche-fuji.infura.io/v3/${process.env.INFURA_API_KEY}`,
       accounts: process.env.DEPLOYER_PRIVATE_KEY ? [process.env.DEPLOYER_PRIVATE_KEY] : [],
       chainId: 43113,
     },


### PR DESCRIPTION
this method should have been added in the first place. Its just a
callthrough to `Market.distributeDebtToPools` to allow for anyone to
clear out a outstanding undistributed debt through the markets