### PR TITLE
audit feedback: fix IssueUSDModule debt bug

### DIFF
--- a/protocol/synthetix/contracts/storage/Pool.sol
+++ b/protocol/synthetix/contracts/storage/Pool.sol
@@ -213,6 +213,7 @@ library Pool {
         uint256 totalSharesD18 = self.vaultsDebtDistribution.totalSharesD18;
         int256 valuePerShareD18 = marketData.poolsDebtDistribution.getValuePerShare();
 
+        // solhint-disable-next-line numcast/safe-cast
         int256 debtPerShareD18 = debtD18 > 0 ? debtD18.divDecimal(totalSharesD18.toInt()) : int(0);
 
         if (minLiquidityRatioD18 == 0) {
@@ -416,10 +417,10 @@ library Pool {
         );
         int256 getPositionDebtD18 = updateAccountDebt(self, collateralType, accountId);
 
-        return getPositionDebtD18 > 0 ? 
-            getPositionCollateralValueD18.divDecimal(
-                getPositionDebtD18.toUint()
-            ) : 1e20;
+        return
+            getPositionDebtD18 > 0
+                ? getPositionCollateralValueD18.divDecimal(getPositionDebtD18.toUint())
+                : 1e20;
     }
 
     /**

--- a/protocol/synthetix/contracts/storage/Pool.sol
+++ b/protocol/synthetix/contracts/storage/Pool.sol
@@ -213,9 +213,11 @@ library Pool {
         uint256 totalSharesD18 = self.vaultsDebtDistribution.totalSharesD18;
         int256 valuePerShareD18 = marketData.poolsDebtDistribution.getValuePerShare();
 
+        int256 debtPerShareD18 = debtD18 > 0 ? debtD18.divDecimal(totalSharesD18.toInt()) : int(0);
+
         if (minLiquidityRatioD18 == 0) {
             // If minLiquidityRatioD18 is zero, then set limit to 100%.
-            return valuePerShareD18 + DecimalMath.UNIT_INT;
+            return valuePerShareD18 + DecimalMath.UNIT_INT - debtPerShareD18;
         } else if (totalSharesD18 == 0) {
             // margin = credit / systemLimit, per share
             return valuePerShareD18;
@@ -227,7 +229,7 @@ library Pool {
             return
                 marketData.poolsDebtDistribution.getValuePerShare() +
                 marginD18.toInt() -
-                debtD18.divDecimal(totalSharesD18.toInt());
+                debtPerShareD18;
         }
     }
 
@@ -414,11 +416,10 @@ library Pool {
         );
         int256 getPositionDebtD18 = updateAccountDebt(self, collateralType, accountId);
 
-        // if they have a credit, just treat their debt as 0
-        return
+        return getPositionDebtD18 > 0 ? 
             getPositionCollateralValueD18.divDecimal(
-                getPositionDebtD18 < 0 ? 0 : getPositionDebtD18.toUint()
-            );
+                getPositionDebtD18.toUint()
+            ) : 1e20;
     }
 
     /**

--- a/protocol/synthetix/test/integration/bootstrap.ts
+++ b/protocol/synthetix/test/integration/bootstrap.ts
@@ -154,17 +154,17 @@ export function bootstrapWithStakedPool() {
         ethers.utils.parseEther('1')
       );
 
-      // also for convenience invest in the 0 pool
-      await r
-        .systems()
-        .Core.connect(user1)
-        .delegateCollateral(
-          accountId,
-          0,
-          collateralAddress,
-          depositAmount,
-          ethers.utils.parseEther('1')
-        );
+    // also for convenience invest in the 0 pool
+    await r
+      .systems()
+      .Core.connect(user1)
+      .delegateCollateral(
+        accountId,
+        0,
+        collateralAddress,
+        depositAmount,
+        ethers.utils.parseEther('1')
+      );
   });
 
   const restore = snapshotCheckpoint(r.provider);

--- a/protocol/synthetix/test/integration/bootstrap.ts
+++ b/protocol/synthetix/test/integration/bootstrap.ts
@@ -153,6 +153,18 @@ export function bootstrapWithStakedPool() {
         depositAmount,
         ethers.utils.parseEther('1')
       );
+
+      // also for convenience invest in the 0 pool
+      await r
+        .systems()
+        .Core.connect(user1)
+        .delegateCollateral(
+          accountId,
+          0,
+          collateralAddress,
+          depositAmount,
+          ethers.utils.parseEther('1')
+        );
   });
 
   const restore = snapshotCheckpoint(r.provider);

--- a/protocol/synthetix/test/integration/modules/core/IssueUSDModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/IssueUSDModule.test.ts
@@ -201,10 +201,14 @@ describe('IssueUSDModule', function () {
         await MockMarket.setReportedDebt(depositAmount);
 
         // Issue max capacity, which has not been reduced
-        await MockMarket.connect(user1).sellSynth(capacity);
+        await assertRevert(
+          MockMarket.connect(user1).sellSynth(capacity),
+          'NotEnoughLiquidity(',
+          systems().Core
+        );
 
         // Should not have been allowed to mint more than the system limit
-        assertBn.equal(
+        /*assertBn.equal(
           await systems().USD.balanceOf(user1.getAddress()),
           depositAmount.div(10).div(ratio)
         );
@@ -213,7 +217,7 @@ describe('IssueUSDModule', function () {
         assertBn.equal(
           await systems().Core.callStatic.getVaultCollateralRatio(poolId, collateralAddress()),
           ethers.utils.parseEther('1').div(ratio)
-        );
+        );*/
       };
     }
 

--- a/protocol/synthetix/test/integration/modules/core/IssueUSDModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/IssueUSDModule.test.ts
@@ -183,7 +183,7 @@ describe('IssueUSDModule', function () {
     });
   });
 
-  describe('edge case: verify debt is excluded from available mint', async() => {
+  describe('edge case: verify debt is excluded from available mint', async () => {
     before(restore);
     afterEach(restore);
 
@@ -191,36 +191,30 @@ describe('IssueUSDModule', function () {
       return async () => {
         // Initial capacity
         const capacity = await systems().Core.connect(user1).getWithdrawableMarketUsd(marketId);
-        
+
         // Mint USD against collateral
-        await systems().Core.connect(user1).mintUsd(
-          accountId,
-          poolId,
-          collateralAddress(),
-          depositAmount.div(10).div(ratio)
-        );
-    
+        await systems()
+          .Core.connect(user1)
+          .mintUsd(accountId, poolId, collateralAddress(), depositAmount.div(10).div(ratio));
+
         // Bypass MockMarket internal accounting
         await MockMarket.setReportedDebt(depositAmount);
 
         // Issue max capacity, which has not been reduced
-        await MockMarket.connect(user1).sellSynth(
-          capacity
-        );
+        await MockMarket.connect(user1).sellSynth(capacity);
 
         // Should not have been allowed to mint more than the system limit
         assertBn.equal(
           await systems().USD.balanceOf(user1.getAddress()),
           depositAmount.div(10).div(ratio)
         );
-        
 
         // cratio is exactly equal to 1 because that is what the system allows.
         assertBn.equal(
           await systems().Core.callStatic.getVaultCollateralRatio(poolId, collateralAddress()),
           ethers.utils.parseEther('1').div(ratio)
         );
-      }
+      };
     }
 
     // thanks to iosiro for the below test
@@ -233,6 +227,6 @@ describe('IssueUSDModule', function () {
       });
 
       it('try to create debt beyond system max c ratio', exploit(2));
-    })
+    });
   });
 });

--- a/protocol/synthetix/test/integration/modules/core/MarketManagerModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/MarketManagerModule.test.ts
@@ -85,7 +85,7 @@ describe('MarketManagerModule', function () {
     before(restore);
 
     before('acquire USD', async () => {
-      await systems().Core.connect(user1).mintUsd(accountId, poolId, collateralAddress(), One);
+      await systems().Core.connect(user1).mintUsd(accountId, 0, collateralAddress(), One);
     });
 
     it('should not work if user has not approved', async () => {
@@ -121,7 +121,7 @@ describe('MarketManagerModule', function () {
         // should only have the one USD minted earlier
         assertBn.equal(
           await systems().Core.callStatic.getVaultDebt(poolId, collateralAddress()),
-          One
+          0
         );
       });
     });
@@ -132,7 +132,7 @@ describe('MarketManagerModule', function () {
 
     describe('deposit into the pool', async () => {
       before('mint USD to use market', async () => {
-        await systems().Core.connect(user1).mintUsd(accountId, poolId, collateralAddress(), One);
+        await systems().Core.connect(user1).mintUsd(accountId, 0, collateralAddress(), One);
         await systems().USD.connect(user1).approve(MockMarket().address, One);
         txn = await MockMarket().connect(user1).buySynth(One);
       });

--- a/protocol/synthetix/test/integration/modules/core/VaultModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/VaultModule.test.ts
@@ -92,19 +92,27 @@ describe('VaultModule', function () {
     });
 
     it('returns 0 debt', async () => {
-      assertBn.equal(await systems().Core.callStatic.getVaultDebt(fakeFreshVaultId, collateralAddress()), 0);
+      assertBn.equal(
+        await systems().Core.callStatic.getVaultDebt(fakeFreshVaultId, collateralAddress()),
+        0
+      );
     });
 
     it('returns 0 collateral', async () => {
       assertBn.equal(
-        (await systems().Core.callStatic.getVaultCollateral(fakeFreshVaultId, collateralAddress()))[0],
+        (
+          await systems().Core.callStatic.getVaultCollateral(fakeFreshVaultId, collateralAddress())
+        )[0],
         0
       );
     });
 
     it('returns 0 collateral ratio', async () => {
       assertBn.equal(
-        await systems().Core.callStatic.getVaultCollateralRatio(fakeFreshVaultId, collateralAddress()),
+        await systems().Core.callStatic.getVaultCollateralRatio(
+          fakeFreshVaultId,
+          collateralAddress()
+        ),
         0
       );
     });

--- a/protocol/synthetix/test/integration/modules/core/VaultModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/VaultModule.test.ts
@@ -85,20 +85,26 @@ describe('VaultModule', function () {
   }
 
   describe('fresh vault', async () => {
+    const fakeFreshVaultId = 209372;
+
+    before('create empty vault', async () => {
+      await systems().Core.createPool(fakeFreshVaultId, await user1.getAddress());
+    });
+
     it('returns 0 debt', async () => {
-      assertBn.equal(await systems().Core.callStatic.getVaultDebt(0, collateralAddress()), 0);
+      assertBn.equal(await systems().Core.callStatic.getVaultDebt(fakeFreshVaultId, collateralAddress()), 0);
     });
 
     it('returns 0 collateral', async () => {
       assertBn.equal(
-        (await systems().Core.callStatic.getVaultCollateral(0, collateralAddress()))[0],
+        (await systems().Core.callStatic.getVaultCollateral(fakeFreshVaultId, collateralAddress()))[0],
         0
       );
     });
 
     it('returns 0 collateral ratio', async () => {
       assertBn.equal(
-        await systems().Core.callStatic.getVaultCollateralRatio(0, collateralAddress()),
+        await systems().Core.callStatic.getVaultCollateralRatio(fakeFreshVaultId, collateralAddress()),
         0
       );
     });
@@ -181,7 +187,13 @@ describe('VaultModule', function () {
       const restore = snapshotCheckpoint(provider);
       after(restore);
 
-      before('disable collatearal', async () => {
+      const fakeVaultId = 93729028;
+
+      before('create empty vault', async () => {
+        await systems().Core.createPool(fakeVaultId, await user1.getAddress());
+      });
+
+      before('disable collateral', async () => {
         const beforeConfiguration = await systems().Core.getCollateralConfiguration(
           collateralAddress()
         );
@@ -197,7 +209,7 @@ describe('VaultModule', function () {
             .Core.connect(user1)
             .delegateCollateral(
               accountId,
-              0,
+              fakeVaultId,
               collateralAddress(),
               depositAmount.div(50),
               ethers.utils.parseEther('1')


### PR DESCRIPTION
in audit feedback submitted by iosiro, it is possible to

it turns out this issue was related to insufficient testing of the system collateralization ratio check, which should have been deducting the balance of the system from the available credit capacity. thankfully, this was easily resolved from a solidity perspective, it was just a missing calculation in one branch.

unfortunately the fix uncovered a few other faulty tests which also had to be resolved, which is part of the reason why there are changes all over the tests for various reasons.

iosiro's provided test has been altered slightly and brought into the codebase to ensure we have strong coverage of this particular bug in the future.

cc @iosiro-security