### PR TITLE
🔎 Update VaultModule logic

### DIFF
--- a/protocol/synthetix/contracts/interfaces/IVaultModule.sol
+++ b/protocol/synthetix/contracts/interfaces/IVaultModule.sol
@@ -18,6 +18,11 @@ interface IVaultModule {
     error CapacityLocked(uint256 marketId);
 
     /**
+     * @notice Thrown when the specified new collateral amount to delegate to the vault equals the current existing amount.
+     */
+    error InvalidCollateralAmount();
+
+    /**
      * @notice Emitted when {sender} updates the delegation of collateral in the specified liquidity position.
      * @param accountId The id of the account whose position was updated.
      * @param poolId The id of the pool in which the position was updated.

--- a/protocol/synthetix/contracts/modules/core/VaultModule.sol
+++ b/protocol/synthetix/contracts/modules/core/VaultModule.sol
@@ -66,7 +66,7 @@ contract VaultModule is IVaultModule {
         uint256 currentCollateralAmount = vault.currentAccountCollateral(accountId);
 
         // Ensure current collateral amount differs from the new collateral amount.
-        if (newCollateralAmount == currentCollateralAmount) revert InvalidCollateralAmount();
+        if (newCollateralAmountD18 == currentCollateralAmount) revert InvalidCollateralAmount();
 
         // If increasing delegated collateral amount,
         // Check that the account has sufficient collateral.

--- a/protocol/synthetix/contracts/modules/core/VaultModule.sol
+++ b/protocol/synthetix/contracts/modules/core/VaultModule.sol
@@ -65,6 +65,9 @@ contract VaultModule is IVaultModule {
 
         uint256 currentCollateralAmount = vault.currentAccountCollateral(accountId);
 
+        // Ensure current collateral amount differs from the new collateral amount.
+        if (newCollateralAmount == currentCollateralAmount) revert InvalidCollateralAmount();
+
         // If increasing delegated collateral amount,
         // Check that the account has sufficient collateral.
         if (newCollateralAmount > currentCollateralAmount) {

--- a/protocol/synthetix/storage.dump.sol
+++ b/protocol/synthetix/storage.dump.sol
@@ -196,10 +196,10 @@ library NodeDefinition {
         bytes parameters;
         bytes32[] parents;
     }
-    function load(bytes32 id) internal pure returns (Data storage data) {
+    function load(bytes32 id) internal pure returns (Data storage node) {
         bytes32 s = keccak256(abi.encode("io.synthetix.oracle-manager.Node", id));
         assembly {
-            data.slot := s
+            node.slot := s
         }
     }
 }
@@ -303,10 +303,10 @@ library Account {
         bytes32 __slotAvailableForFutureUse;
         mapping(address => Collateral.Data) collaterals;
     }
-    function load(uint128 id) internal pure returns (Data storage data) {
+    function load(uint128 id) internal pure returns (Data storage account) {
         bytes32 s = keccak256(abi.encode("io.synthetix.synthetix.Account", id));
         assembly {
-            data.slot := s
+            account.slot := s
         }
     }
 }
@@ -346,16 +346,16 @@ library CollateralConfiguration {
         address tokenAddress;
         uint256 minDelegationD18;
     }
-    function load(address token) internal pure returns (Data storage data) {
+    function load(address token) internal pure returns (Data storage collateralConfiguration) {
         bytes32 s = keccak256(abi.encode("io.synthetix.synthetix.CollateralConfiguration", token));
         assembly {
-            data.slot := s
+            collateralConfiguration.slot := s
         }
     }
-    function loadAvailableCollaterals() internal pure returns (SetUtil.AddressSet storage data) {
+    function loadAvailableCollaterals() internal pure returns (SetUtil.AddressSet storage availableCollaterals) {
         bytes32 s = _SLOT_AVAILABLE_COLLATERALS;
         assembly {
-            data.slot := s
+            availableCollaterals.slot := s
         }
     }
 }
@@ -404,10 +404,10 @@ library Market {
         address collateralType;
         uint256 amountD18;
     }
-    function load(uint128 id) internal pure returns (Data storage data) {
+    function load(uint128 id) internal pure returns (Data storage market) {
         bytes32 s = keccak256(abi.encode("io.synthetix.synthetix.Market", id));
         assembly {
-            data.slot := s
+            market.slot := s
         }
     }
 }
@@ -428,10 +428,10 @@ library MarketCreator {
         mapping(address => uint128[]) marketIdsForAddress;
         uint128 lastCreatedMarketId;
     }
-    function getMarketStore() internal pure returns (Data storage data) {
+    function getMarketStore() internal pure returns (Data storage marketStore) {
         bytes32 s = _SLOT_MARKET_CREATOR;
         assembly {
-            data.slot := s
+            marketStore.slot := s
         }
     }
 }
@@ -450,10 +450,10 @@ library OracleManager {
     struct Data {
         address oracleManagerAddress;
     }
-    function load() internal pure returns (Data storage data) {
+    function load() internal pure returns (Data storage oracleManager) {
         bytes32 s = _SLOT_ORACLE_MANAGER;
         assembly {
-            data.slot := s
+            oracleManager.slot := s
         }
     }
 }
@@ -471,10 +471,10 @@ library Pool {
         Distribution.Data vaultsDebtDistribution;
         mapping(address => Vault.Data) vaults;
     }
-    function load(uint128 id) internal pure returns (Data storage data) {
+    function load(uint128 id) internal pure returns (Data storage pool) {
         bytes32 s = keccak256(abi.encode("io.synthetix.synthetix.Pool", id));
         assembly {
-            data.slot := s
+            pool.slot := s
         }
     }
 }
@@ -518,10 +518,10 @@ library SystemPoolConfiguration {
         uint preferredPool;
         SetUtil.UintSet approvedPools;
     }
-    function load() internal pure returns (Data storage data) {
+    function load() internal pure returns (Data storage systemPoolConfiguration) {
         bytes32 s = _SLOT_SYSTEM_POOL_CONFIGURATION;
         assembly {
-            data.slot := s
+            systemPoolConfiguration.slot := s
         }
     }
 }

--- a/protocol/synthetix/test/integration/modules/core/PoolModuleFundAdmin.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/PoolModuleFundAdmin.test.ts
@@ -418,17 +418,6 @@ describe('PoolModule Admin', function () {
           // to go below max debt, we have to get user to invest
           // in the market, and then reset the market
 
-          // aquire USD from the zero pool
-          await systems()
-            .Core.connect(user1)
-            .delegateCollateral(
-              accountId,
-              0,
-              collateralAddress(),
-              depositAmount,
-              ethers.utils.parseEther('1')
-            );
-
           await systems().Core.connect(user1).mintUsd(accountId, 0, collateralAddress(), Hundred);
           await systems().USD.connect(user1).approve(MockMarket().address, Hundred);
           await MockMarket().connect(user1).buySynth(Hundred);

--- a/protocol/synthetix/test/integration/modules/core/VaultModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/VaultModule.test.ts
@@ -175,6 +175,20 @@ describe('VaultModule', function () {
       );
     });
 
+    it('fails when new collateral amount equals current collateral amount', async () => {
+      await assertRevert(
+        systems().Core.connect(user1).delegateCollateral(
+          accountId,
+          poolId,
+          collateralAddress(),
+          depositAmount,
+          ethers.utils.parseEther('1')
+        ),
+        'InvalidCollateralAmount()',
+        systems().Core
+      );
+    });
+
     it('fails when pool does not exist', async () => {
       await assertRevert(
         systems()

--- a/protocol/synthetix/test/integration/modules/core/VaultModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/VaultModule.test.ts
@@ -177,13 +177,15 @@ describe('VaultModule', function () {
 
     it('fails when new collateral amount equals current collateral amount', async () => {
       await assertRevert(
-        systems().Core.connect(user1).delegateCollateral(
-          accountId,
-          poolId,
-          collateralAddress(),
-          depositAmount,
-          ethers.utils.parseEther('1')
-        ),
+        systems()
+          .Core.connect(user1)
+          .delegateCollateral(
+            accountId,
+            poolId,
+            collateralAddress(),
+            depositAmount,
+            ethers.utils.parseEther('1')
+          ),
         'InvalidCollateralAmount()',
         systems().Core
       );


### PR DESCRIPTION
`VaultModule.delegateCollateral()` can be called with a `newCollateralAmount` equal to the `currentCollateralAmount`. This can lead to unexpected behavior. Add a check to prevent this edge case.

## Description
* Add comparison check
* Add customer error
* Test new logic

## Related issue(s)
N/A

## Motivation and Context
Addresses Iosiro audit feedback item 5.3.3