### PR TITLE
Async fixed fee

### DIFF
--- a/markets/spot-market/contracts/interfaces/IFeeConfigurationModule.sol
+++ b/markets/spot-market/contracts/interfaces/IFeeConfigurationModule.sol
@@ -34,7 +34,8 @@ interface IFeeConfigurationModule {
     event AsyncFixedFeeSet(uint indexed synthMarketId, uint asyncFixedFee);
 
     /**
-     * @notice emitted when the fixed fee for atomic orders is set for a given transactor
+     * @notice emitted when the fixed fee is set for a given transactor
+     * @dev this overrides the async/atomic fixed fees for a given transactor
      * @param synthMarketId Id of the market to set the fees for.
      * @param transactor fixed fee for the transactor (overrides the global fixed fee)
      * @param fixedFeeAmount the fixed fee for the corresponding market, and transactor

--- a/markets/spot-market/contracts/interfaces/IFeeConfigurationModule.sol
+++ b/markets/spot-market/contracts/interfaces/IFeeConfigurationModule.sol
@@ -27,12 +27,19 @@ interface IFeeConfigurationModule {
     event AtomicFixedFeeSet(uint indexed synthMarketId, uint atomicFixedFee);
 
     /**
+     * @notice emitted when the fixed fee for async orders is set.
+     * @param synthMarketId Id of the market to set the fees for.
+     * @param asyncFixedFee the fixed fee for the corresponding market
+     */
+    event AsyncFixedFeeSet(uint indexed synthMarketId, uint asyncFixedFee);
+
+    /**
      * @notice emitted when the fixed fee for atomic orders is set for a given transactor
      * @param synthMarketId Id of the market to set the fees for.
      * @param transactor fixed fee for the transactor (overrides the global fixed fee)
      * @param fixedFeeAmount the fixed fee for the corresponding market, and transactor
      */
-    event AtomicTransactorFixedFeeSet(
+    event TransactorFixedFeeSet(
         uint indexed synthMarketId,
         address transactor,
         uint fixedFeeAmount
@@ -67,6 +74,14 @@ interface IFeeConfigurationModule {
     function setAtomicFixedFee(uint128 synthMarketId, uint atomicFixedFee) external;
 
     /**
+     * @notice sets the async fixed fee for a given market
+     * @dev only marketOwner can set the fee
+     * @param synthMarketId Id of the market the fee applies to.
+     * @param asyncFixedFee fixed fee amount represented in bips with 18 decimals.
+     */
+    function setAsyncFixedFee(uint128 synthMarketId, uint asyncFixedFee) external;
+
+    /**
      * @notice sets the skew scale for a given market
      * @dev only marketOwner can set the skew scale
      * @param synthMarketId Id of the market the skew scale applies to.
@@ -84,12 +99,13 @@ interface IFeeConfigurationModule {
     function setMarketUtilizationFees(uint128 synthMarketId, uint utilizationFeeRate) external;
 
     /**
-     * @notice sets the atomic fixed fee for a given market and transactor
+     * @notice sets the fixed fee for a given market and transactor
+     * @dev overrides both the atomic and async fixed fees
      * @dev only marketOwner can set the fee
      * @dev especially useful for direct integrations where configured traders get a discount
      * @param synthMarketId Id of the market the custom transactor fee applies to.
      * @param transactor address of the trader getting discounted fees.
-     * @param fixedFeeAmount the atomic fixed fee applying to the provided transactor.
+     * @param fixedFeeAmount the fixed fee applying to the provided transactor.
      */
     function setCustomTransactorFees(
         uint128 synthMarketId,

--- a/markets/spot-market/contracts/modules/FeeConfigurationModule.sol
+++ b/markets/spot-market/contracts/modules/FeeConfigurationModule.sol
@@ -33,6 +33,17 @@ contract FeeConfigurationModule is IFeeConfigurationModule {
     /**
      * @inheritdoc IFeeConfigurationModule
      */
+    function setAsyncFixedFee(uint128 synthMarketId, uint asyncFixedFee) external override {
+        SpotMarketFactory.load().onlyMarketOwner(synthMarketId);
+
+        FeeConfiguration.load(synthMarketId).asyncFixedFee = asyncFixedFee;
+
+        emit AsyncFixedFeeSet(synthMarketId, asyncFixedFee);
+    }
+
+    /**
+     * @inheritdoc IFeeConfigurationModule
+     */
     function setMarketSkewScale(uint128 synthMarketId, uint skewScale) external override {
         SpotMarketFactory.load().onlyMarketOwner(synthMarketId);
 
@@ -68,7 +79,7 @@ contract FeeConfigurationModule is IFeeConfigurationModule {
         SpotMarketFactory.load().onlyMarketOwner(synthMarketId);
         FeeConfiguration.setAtomicFixedFeeOverride(synthMarketId, transactor, fixedFeeAmount);
 
-        emit AtomicTransactorFixedFeeSet(synthMarketId, transactor, fixedFeeAmount);
+        emit TransactorFixedFeeSet(synthMarketId, transactor, fixedFeeAmount);
     }
 
     /**

--- a/markets/spot-market/contracts/storage/FeeConfiguration.sol
+++ b/markets/spot-market/contracts/storage/FeeConfiguration.sol
@@ -17,6 +17,10 @@ library FeeConfiguration {
          */
         uint atomicFixedFee;
         /**
+         * @dev atomic buy/sell fixed fee that's applied on all async trades. Percentage, 18 decimals
+         */
+        uint asyncFixedFee;
+        /**
          * @dev utilization fee rate (in percentage) is the rate of fees applied based on the ratio of delegated collateral to total outstanding synth exposure. 18 decimals
          * applied on buy trades only.
          */

--- a/markets/spot-market/contracts/utils/FeeUtil.sol
+++ b/markets/spot-market/contracts/utils/FeeUtil.sol
@@ -122,7 +122,7 @@ library FeeUtil {
             SpotMarketFactory.TransactionType.BUY
         );
 
-        uint fixedFee = _getAtomicFixedFee(feeConfiguration, transactor);
+        uint fixedFee = _getFixedFee(feeConfiguration, transactor, async);
 
         int totalFees = utilizationFee.toInt() + skewFee + fixedFee.toInt();
 
@@ -152,7 +152,7 @@ library FeeUtil {
             SpotMarketFactory.TransactionType.SELL
         );
 
-        uint fixedFee = _getAtomicFixedFee(feeConfiguration, transactor);
+        uint fixedFee = _getFixedFee(feeConfiguration, transactor, async);
         int totalFees = skewFee + fixedFee.toInt();
 
         (amountUsable, feesCollected) = _applyFees(amount, totalFees);
@@ -319,15 +319,20 @@ library FeeUtil {
         amountUsable = (amount.toInt() - feesCollected).toUint();
     }
 
-    function _getAtomicFixedFee(
+    /*
+     * @dev if special fee is set for a given transactor that takes precedence over the global fixed fees
+     * otherwise, if async order, use async fixed fee, otherwise use atomic fixed fee
+     */
+    function _getFixedFee(
         FeeConfiguration.Data storage feeConfiguration,
-        address transactor
+        address transactor,
+        bool async
     ) private view returns (uint) {
-        // TODO: add to readme, can't set transactor's value to zero
-        // talk to afif
         return
             feeConfiguration.atomicFixedFeeOverrides[transactor] > 0
                 ? feeConfiguration.atomicFixedFeeOverrides[transactor]
+                : async
+                ? feeConfiguration.asyncFixedFee
                 : feeConfiguration.atomicFixedFee;
     }
 }


### PR DESCRIPTION
after chatting with afif, looks like we need this back.  generally, this will be set to lower than the atomic fixed fee so users are incentivized to use async orders more.