### PR TITLE
add new security features

### DIFF
--- a/protocol/synthetix/cannonfile.toml
+++ b/protocol/synthetix/cannonfile.toml
@@ -216,3 +216,26 @@ args = [
   "<%= imports.oracle_manager.contracts.Proxy.address %>",
 ]
 depends = ["invoke.upgrade_core_proxy", "provision.oracle_manager"]
+
+[invoke.enable_basic_features]
+target = ["CoreProxy"]
+fromCall.func = "owner"
+func = "multicall"
+args = [[
+  # for all the below functions, "0x7d632bd2" is the selector for "setFeatureFlagAllowAll(bytes32,bool)"
+  "0x7d632bd2<%= defaultAbiCoder.encode(['bytes32', 'bool'], [formatBytes32String('createAccount'), true]).slice(2) %>",
+  "0x7d632bd2<%= defaultAbiCoder.encode(['bytes32', 'bool'], [formatBytes32String('deposit'), true]).slice(2) %>",
+  "0x7d632bd2<%= defaultAbiCoder.encode(['bytes32', 'bool'], [formatBytes32String('withdraw'), true]).slice(2) %>",
+  "0x7d632bd2<%= defaultAbiCoder.encode(['bytes32', 'bool'], [formatBytes32String('mintUsd'), true]).slice(2) %>",
+  "0x7d632bd2<%= defaultAbiCoder.encode(['bytes32', 'bool'], [formatBytes32String('burnUsd'), true]).slice(2) %>",
+  "0x7d632bd2<%= defaultAbiCoder.encode(['bytes32', 'bool'], [formatBytes32String('liquidate'), true]).slice(2) %>",
+  "0x7d632bd2<%= defaultAbiCoder.encode(['bytes32', 'bool'], [formatBytes32String('liquidateVault'), true]).slice(2) %>",
+  "0x7d632bd2<%= defaultAbiCoder.encode(['bytes32', 'bool'], [formatBytes32String('depositMarketCollateral'), true]).slice(2) %>",
+  "0x7d632bd2<%= defaultAbiCoder.encode(['bytes32', 'bool'], [formatBytes32String('withdrawMarketCollateral'), true]).slice(2) %>",
+  "0x7d632bd2<%= defaultAbiCoder.encode(['bytes32', 'bool'], [formatBytes32String('depositMarketUsd'), true]).slice(2) %>",
+  "0x7d632bd2<%= defaultAbiCoder.encode(['bytes32', 'bool'], [formatBytes32String('withdrawMarketUsd'), true]).slice(2) %>",
+  "0x7d632bd2<%= defaultAbiCoder.encode(['bytes32', 'bool'], [formatBytes32String('claimRewards'), true]).slice(2) %>",
+  "0x7d632bd2<%= defaultAbiCoder.encode(['bytes32', 'bool'], [formatBytes32String('delegateCollateral'), true]).slice(2) %>",
+]]
+
+depends = ["invoke.upgrade_core_proxy"]

--- a/protocol/synthetix/contracts/interfaces/IAccountModule.sol
+++ b/protocol/synthetix/contracts/interfaces/IAccountModule.sol
@@ -173,4 +173,11 @@ interface IAccountModule {
      * @return The owner of the given account id.
      */
     function getAccountOwner(uint128 accountId) external view returns (address);
+
+    /**
+     * @notice Returns the last unix timestamp that a permissioned action was taken with this account
+     * @param accountId The account id to check
+     * @return The unix timestamp of the last time a permissioned action occured with the account
+     */
+    function getAccountLastInteraction(uint128 accountId) external view returns (uint);
 }

--- a/protocol/synthetix/contracts/interfaces/IUtilsModule.sol
+++ b/protocol/synthetix/contracts/interfaces/IUtilsModule.sol
@@ -18,4 +18,17 @@ interface IUtilsModule {
      * @param oracleManagerAddress The address of the oracle manager.
      */
     function configureOracleManager(address oracleManagerAddress) external;
+
+    /**
+     * @notice Configure a generic value in the KV system
+     * @param k the key of the value to set
+     * @param v the value that the key should be set to
+     */
+    function setConfig(bytes32 k, bytes32 v) external;
+
+    /**
+     * @notice Read a generic value from the KV system
+     * @param k the key to read
+     */
+    function getConfig(bytes32 k) external view returns (bytes32 v);
 }

--- a/protocol/synthetix/contracts/modules/core/AccountModule.sol
+++ b/protocol/synthetix/contracts/modules/core/AccountModule.sol
@@ -155,11 +155,18 @@ contract AccountModule is IAccountModule {
     }
 
     /**
+     * @inheritdoc IAccountModule
+     */
+    function getAccountLastInteraction(uint128 accountId) external view returns (uint) {
+        return Account.load(accountId).lastInteraction;
+    }
+
+    /**
      * @dev Reverts if the caller is not the account token managed by this module.
      */
     // Note: Disabling Solidity warning, not sure why it suggests pure mutability.
     // solc-ignore-next-line func-mutability
-    function _onlyAccountToken() internal {
+    function _onlyAccountToken() internal view {
         if (msg.sender != address(getAccountTokenAddress())) {
             revert OnlyAccountTokenProxy(msg.sender);
         }

--- a/protocol/synthetix/contracts/modules/core/AccountModule.sol
+++ b/protocol/synthetix/contracts/modules/core/AccountModule.sol
@@ -7,6 +7,8 @@ import "../../interfaces/IAccountModule.sol";
 import "../../interfaces/IAccountTokenModule.sol";
 import "../../storage/Account.sol";
 
+import "@synthetixio/core-modules/contracts/storage/FeatureFlag.sol";
+
 /**
  * @title Module for managing accounts.
  * @dev See IAccountModule.
@@ -18,6 +20,8 @@ contract AccountModule is IAccountModule {
     using Account for Account.Data;
 
     bytes32 private constant _ACCOUNT_SYSTEM = "accountNft";
+
+    bytes32 private constant _CREATE_ACCOUNT_FEATURE_FLAG = "createAccount";
 
     /**
      * @inheritdoc IAccountModule
@@ -49,6 +53,7 @@ contract AccountModule is IAccountModule {
      * @inheritdoc IAccountModule
      */
     function createAccount(uint128 requestedAccountId) external override {
+        FeatureFlag.ensureAccessToFeature(_CREATE_ACCOUNT_FEATURE_FLAG);
         IAccountTokenModule accountTokenModule = IAccountTokenModule(getAccountTokenAddress());
         accountTokenModule.mint(msg.sender, requestedAccountId);
 

--- a/protocol/synthetix/contracts/modules/core/CollateralModule.sol
+++ b/protocol/synthetix/contracts/modules/core/CollateralModule.sol
@@ -10,6 +10,8 @@ import "../../storage/Account.sol";
 import "../../storage/CollateralConfiguration.sol";
 import "../../storage/CollateralLock.sol";
 
+import "@synthetixio/core-modules/contracts/storage/FeatureFlag.sol";
+
 /**
  * @title Module for managing user collateral.
  * @dev See ICollateralModule.
@@ -23,6 +25,9 @@ contract CollateralModule is ICollateralModule {
     using Collateral for Collateral.Data;
     using SafeCastU256 for uint256;
 
+    bytes32 private constant _DEPOSIT_FEATURE_FLAG = "deposit";
+    bytes32 private constant _WITHDRAW_FEATURE_FLAG = "withdraw";
+
     /**
      * @inheritdoc ICollateralModule
      */
@@ -31,6 +36,7 @@ contract CollateralModule is ICollateralModule {
         address collateralType,
         uint256 tokenAmount
     ) public override {
+        FeatureFlag.ensureAccessToFeature(_DEPOSIT_FEATURE_FLAG);
         CollateralConfiguration.collateralEnabled(collateralType);
 
         Account.Data storage account = Account.load(accountId);
@@ -61,6 +67,7 @@ contract CollateralModule is ICollateralModule {
         address collateralType,
         uint256 tokenAmount
     ) public override {
+        FeatureFlag.ensureAccessToFeature(_WITHDRAW_FEATURE_FLAG);
         Account.Data storage account = Account.loadAccountAndValidatePermission(
             accountId,
             AccountRBAC._WITHDRAW_PERMISSION

--- a/protocol/synthetix/contracts/modules/core/CollateralModule.sol
+++ b/protocol/synthetix/contracts/modules/core/CollateralModule.sol
@@ -9,6 +9,7 @@ import "../../interfaces/ICollateralModule.sol";
 import "../../storage/Account.sol";
 import "../../storage/CollateralConfiguration.sol";
 import "../../storage/CollateralLock.sol";
+import "../../storage/Config.sol";
 
 import "@synthetixio/core-modules/contracts/storage/FeatureFlag.sol";
 
@@ -27,6 +28,8 @@ contract CollateralModule is ICollateralModule {
 
     bytes32 private constant _DEPOSIT_FEATURE_FLAG = "deposit";
     bytes32 private constant _WITHDRAW_FEATURE_FLAG = "withdraw";
+
+    bytes32 private constant _CONFIG_TIMEOUT_WITHDRAW = "accountTimeoutWithdraw";
 
     /**
      * @inheritdoc ICollateralModule
@@ -68,9 +71,10 @@ contract CollateralModule is ICollateralModule {
         uint256 tokenAmount
     ) public override {
         FeatureFlag.ensureAccessToFeature(_WITHDRAW_FEATURE_FLAG);
-        Account.Data storage account = Account.loadAccountAndValidatePermission(
+        Account.Data storage account = Account.loadAccountAndValidatePermissionAndTimeout(
             accountId,
-            AccountRBAC._WITHDRAW_PERMISSION
+            AccountRBAC._WITHDRAW_PERMISSION,
+            uint(Config.read(_CONFIG_TIMEOUT_WITHDRAW))
         );
 
         uint256 tokenAmountD18 = CollateralConfiguration

--- a/protocol/synthetix/contracts/modules/core/IssueUSDModule.sol
+++ b/protocol/synthetix/contracts/modules/core/IssueUSDModule.sol
@@ -10,6 +10,8 @@ import "@synthetixio/core-modules/contracts/storage/AssociatedSystem.sol";
 import "../../storage/Account.sol";
 import "../../storage/CollateralConfiguration.sol";
 
+import "@synthetixio/core-modules/contracts/storage/FeatureFlag.sol";
+
 /**
  * @title Module for the minting and burning of stablecoins.
  * @dev See IIssueUSDModule.
@@ -31,6 +33,9 @@ contract IssueUSDModule is IIssueUSDModule {
 
     bytes32 private constant _USD_TOKEN = "USDToken";
 
+    bytes32 private constant _MINT_FEATURE_FLAG = "mintUsd";
+    bytes32 private constant _BURN_FEATURE_FLAG = "burnUsd";
+
     /**
      * @inheritdoc IIssueUSDModule
      */
@@ -40,6 +45,7 @@ contract IssueUSDModule is IIssueUSDModule {
         address collateralType,
         uint256 amount
     ) external override {
+        FeatureFlag.ensureAccessToFeature(_MINT_FEATURE_FLAG);
         Account.loadAccountAndValidatePermission(accountId, AccountRBAC._MINT_PERMISSION);
 
         Pool.Data storage pool = Pool.load(poolId);
@@ -82,6 +88,7 @@ contract IssueUSDModule is IIssueUSDModule {
         address collateralType,
         uint256 amount
     ) external override {
+        FeatureFlag.ensureAccessToFeature(_BURN_FEATURE_FLAG);
         Pool.Data storage pool = Pool.load(poolId);
 
         // Retrieve current position debt

--- a/protocol/synthetix/contracts/modules/core/IssueUSDModule.sol
+++ b/protocol/synthetix/contracts/modules/core/IssueUSDModule.sol
@@ -17,6 +17,7 @@ import "@synthetixio/core-modules/contracts/storage/FeatureFlag.sol";
  * @dev See IIssueUSDModule.
  */
 contract IssueUSDModule is IIssueUSDModule {
+    using Account for Account.Data;
     using AccountRBAC for AccountRBAC.Data;
     using AssociatedSystem for AssociatedSystem.Data;
     using Pool for Pool.Data;

--- a/protocol/synthetix/contracts/modules/core/LiquidationModule.sol
+++ b/protocol/synthetix/contracts/modules/core/LiquidationModule.sol
@@ -11,6 +11,8 @@ import "@synthetixio/core-contracts/contracts/errors/ParameterError.sol";
 import "@synthetixio/core-contracts/contracts/token/ERC20Helper.sol";
 import "@synthetixio/core-contracts/contracts/utils/SafeCast.sol";
 
+import "@synthetixio/core-modules/contracts/storage/FeatureFlag.sol";
+
 /**
  * @title Module for liquidated positions and vaults that are below the liquidation ratio.
  * @dev See ILiquidationModule.
@@ -33,6 +35,9 @@ contract LiquidationModule is ILiquidationModule {
 
     bytes32 private constant _USD_TOKEN = "USDToken";
 
+    bytes32 private constant _LIQUIDATE_FEATURE_FLAG = "liquidate";
+    bytes32 private constant _LIQUIDATE_VAULT_FEATURE_FLAG = "liquidateVault";
+
     /**
      * @inheritdoc ILiquidationModule
      */
@@ -42,6 +47,7 @@ contract LiquidationModule is ILiquidationModule {
         address collateralType,
         uint128 liquidateAsAccountId
     ) external override returns (LiquidationData memory liquidationData) {
+        FeatureFlag.ensureAccessToFeature(_LIQUIDATE_FEATURE_FLAG);
         // Ensure the account receiving rewards exists
         Account.exists(liquidateAsAccountId);
 
@@ -126,6 +132,7 @@ contract LiquidationModule is ILiquidationModule {
         uint128 liquidateAsAccountId,
         uint256 maxUsd
     ) external override returns (LiquidationData memory liquidationData) {
+        FeatureFlag.ensureAccessToFeature(_LIQUIDATE_VAULT_FEATURE_FLAG);
         // Ensure the account receiving collateral exists
         Account.exists(liquidateAsAccountId);
 

--- a/protocol/synthetix/contracts/modules/core/MarketCollateralModule.sol
+++ b/protocol/synthetix/contracts/modules/core/MarketCollateralModule.sol
@@ -7,6 +7,8 @@ import "@synthetixio/core-contracts/contracts/token/ERC20Helper.sol";
 import "../../interfaces/IMarketCollateralModule.sol";
 import "../../storage/Market.sol";
 
+import "@synthetixio/core-modules/contracts/storage/FeatureFlag.sol";
+
 /**
  * @title Module for allowing markets to directly increase their credit capacity by providing their own collateral.
  * @dev See IMarketCollateralModule.
@@ -16,6 +18,9 @@ contract MarketCollateralModule is IMarketCollateralModule {
     using CollateralConfiguration for CollateralConfiguration.Data;
     using Market for Market.Data;
 
+    bytes32 private constant _DEPOSIT_MARKET_COLLATERAL_FEATURE_FLAG = "depositMarketCollateral";
+    bytes32 private constant _WITHDRAW_MARKET_COLLATERAL_FEATURE_FLAG = "withdrawMarketCollateral";
+
     /**
      * @inheritdoc IMarketCollateralModule
      */
@@ -24,6 +29,7 @@ contract MarketCollateralModule is IMarketCollateralModule {
         address collateralType,
         uint256 tokenAmount
     ) public override {
+        FeatureFlag.ensureAccessToFeature(_DEPOSIT_MARKET_COLLATERAL_FEATURE_FLAG);
         Market.Data storage marketData = Market.load(marketId);
 
         uint256 systemAmount = CollateralConfiguration
@@ -61,6 +67,7 @@ contract MarketCollateralModule is IMarketCollateralModule {
         address collateralType,
         uint256 tokenAmount
     ) public override {
+        FeatureFlag.ensureAccessToFeature(_WITHDRAW_MARKET_COLLATERAL_FEATURE_FLAG);
         Market.Data storage marketData = Market.load(marketId);
 
         uint256 systemAmount = CollateralConfiguration

--- a/protocol/synthetix/contracts/modules/core/MarketManagerModule.sol
+++ b/protocol/synthetix/contracts/modules/core/MarketManagerModule.sol
@@ -29,6 +29,8 @@ contract MarketManagerModule is IMarketManagerModule {
 
     bytes32 private constant _USD_TOKEN = "USDToken";
     bytes32 private constant _MARKET_FEATURE_FLAG = "registerMarket";
+    bytes32 private constant _DEPOSIT_MARKET_FEATURE_FLAG = "depositMarketUsd";
+    bytes32 private constant _WITHDRAW_MARKET_FEATURE_FLAG = "withdrawMarketUsd";
 
     /**
      * @inheritdoc IMarketManagerModule
@@ -106,6 +108,7 @@ contract MarketManagerModule is IMarketManagerModule {
      * @inheritdoc IMarketManagerModule
      */
     function depositMarketUsd(uint128 marketId, address target, uint256 amount) external override {
+        FeatureFlag.ensureAccessToFeature(_DEPOSIT_MARKET_FEATURE_FLAG);
         Market.Data storage market = Market.load(marketId);
 
         // Call must come from the market itself.
@@ -131,6 +134,7 @@ contract MarketManagerModule is IMarketManagerModule {
      * @inheritdoc IMarketManagerModule
      */
     function withdrawMarketUsd(uint128 marketId, address target, uint256 amount) external override {
+        FeatureFlag.ensureAccessToFeature(_WITHDRAW_MARKET_FEATURE_FLAG);
         Market.Data storage marketData = Market.load(marketId);
 
         // Call must come from the market itself.

--- a/protocol/synthetix/contracts/modules/core/RewardsManagerModule.sol
+++ b/protocol/synthetix/contracts/modules/core/RewardsManagerModule.sol
@@ -13,6 +13,8 @@ import "../../storage/Pool.sol";
 
 import "../../interfaces/IRewardsManagerModule.sol";
 
+import "@synthetixio/core-modules/contracts/storage/FeatureFlag.sol";
+
 /**
  * @title Module for connecting rewards distributors to vaults.
  * @dev See IRewardsManagerModule.
@@ -32,6 +34,8 @@ contract RewardsManagerModule is IRewardsManagerModule {
     using RewardDistribution for RewardDistribution.Data;
 
     uint256 private constant _MAX_REWARD_DISTRIBUTIONS = 10;
+
+    bytes32 private constant _CLAIM_FEATURE_FLAG = "claimRewards";
 
     /**
      * @inheritdoc IRewardsManagerModule
@@ -143,6 +147,7 @@ contract RewardsManagerModule is IRewardsManagerModule {
         address collateralType,
         address distributor
     ) external override returns (uint256) {
+        FeatureFlag.ensureAccessToFeature(_CLAIM_FEATURE_FLAG);
         Account.loadAccountAndValidatePermission(accountId, AccountRBAC._REWARDS_PERMISSION);
 
         Vault.Data storage vault = Pool.load(poolId).vaults[collateralType];

--- a/protocol/synthetix/contracts/modules/core/UtilsModule.sol
+++ b/protocol/synthetix/contracts/modules/core/UtilsModule.sol
@@ -8,6 +8,7 @@ import "@synthetixio/core-contracts/contracts/ownership/OwnableStorage.sol";
 import "../../interfaces/IUtilsModule.sol";
 
 import "../../storage/OracleManager.sol";
+import "../../storage/Config.sol";
 
 /**
  * @title Module with assorted utility functions.
@@ -48,5 +49,15 @@ contract UtilsModule is IUtilsModule {
 
         OracleManager.Data storage oracle = OracleManager.load();
         oracle.oracleManagerAddress = oracleManagerAddress;
+    }
+
+    function setConfig(bytes32 k, bytes32 v) external override {
+        OwnableStorage.onlyOwner();
+        return Config.put(k, v);
+    }
+
+    function getConfig(bytes32 k) external view override returns (bytes32 v) {
+        OwnableStorage.onlyOwner();
+        return Config.read(k);
     }
 }

--- a/protocol/synthetix/contracts/modules/core/VaultModule.sol
+++ b/protocol/synthetix/contracts/modules/core/VaultModule.sol
@@ -7,6 +7,8 @@ import "@synthetixio/core-contracts/contracts/utils/SafeCast.sol";
 import "../../storage/Account.sol";
 import "../../storage/Pool.sol";
 
+import "@synthetixio/core-modules/contracts/storage/FeatureFlag.sol";
+
 import "../../interfaces/IVaultModule.sol";
 
 /**
@@ -32,6 +34,8 @@ contract VaultModule is IVaultModule {
     using SafeCastI128 for int128;
     using SafeCastI256 for int256;
 
+    bytes32 private constant _DELEGATE_FEATURE_FLAG = "delegateCollateral";
+
     /**
      * @inheritdoc IVaultModule
      */
@@ -42,6 +46,7 @@ contract VaultModule is IVaultModule {
         uint256 newCollateralAmountD18,
         uint256 leverage
     ) external override {
+        FeatureFlag.ensureAccessToFeature(_DELEGATE_FEATURE_FLAG);
         Pool.requireExists(poolId);
         Account.loadAccountAndValidatePermission(accountId, AccountRBAC._DELEGATE_PERMISSION);
 

--- a/protocol/synthetix/contracts/storage/Account.sol
+++ b/protocol/synthetix/contracts/storage/Account.sol
@@ -50,11 +50,9 @@ library Account {
          * @dev Role based access control data for the account.
          */
         AccountRBAC.Data rbac;
-
         uint64 lastInteraction;
         uint64 __slotAvailableForFutureUse;
         uint128 __slot2AvailableForFutureUse;
-
         /**
          * @dev Address set of collaterals that are being used in the system by this account.
          */
@@ -138,18 +136,17 @@ library Account {
         return totalAssignedD18;
     }
 
-    function recordInteraction(
-        Data storage self
-    ) internal {
+    function recordInteraction(Data storage self) internal {
+        // solhint-disable-next-line numcast/safe-cast
         self.lastInteraction = uint64(block.timestamp);
     }
 
     /**
-     * @dev Loads the Account object for the specified accountId, 
+     * @dev Loads the Account object for the specified accountId,
      * and validates that sender has the specified permission. It also resets
-     * the interaction timeout. These 
-     * are different actions but they are merged in a single function 
-     * because loading an account and checking for a permission is a very 
+     * the interaction timeout. These
+     * are different actions but they are merged in a single function
+     * because loading an account and checking for a permission is a very
      * common use case in other parts of the code.
      */
     function loadAccountAndValidatePermission(
@@ -161,16 +158,16 @@ library Account {
         if (!account.rbac.authorized(permission, msg.sender)) {
             revert PermissionDenied(accountId, permission, msg.sender);
         }
-        
+
         recordInteraction(account);
     }
 
     /**
-     * @dev Loads the Account object for the specified accountId, 
+     * @dev Loads the Account object for the specified accountId,
      * and validates that sender has the specified permission. It also resets
-     * the interaction timeout. These 
-     * are different actions but they are merged in a single function 
-     * because loading an account and checking for a permission is a very 
+     * the interaction timeout. These
+     * are different actions but they are merged in a single function
+     * because loading an account and checking for a permission is a very
      * common use case in other parts of the code.
      */
     function loadAccountAndValidatePermissionAndTimeout(
@@ -183,7 +180,7 @@ library Account {
         if (!account.rbac.authorized(permission, msg.sender)) {
             revert PermissionDenied(accountId, permission, msg.sender);
         }
-        
+
         uint endWaitingPeriod = account.lastInteraction + timeout;
         if (block.timestamp < endWaitingPeriod) {
             revert AccountActivityTimeoutPending(accountId, block.timestamp, endWaitingPeriod);

--- a/protocol/synthetix/contracts/storage/Account.sol
+++ b/protocol/synthetix/contracts/storage/Account.sol
@@ -45,8 +45,11 @@ library Account {
          * @dev Role based access control data for the account.
          */
         AccountRBAC.Data rbac;
-        // solhint-disable-next-line private-vars-leading-underscore
-        bytes32 __slotAvailableForFutureUse;
+
+        uint64 lastInteraction;
+        uint64 __slotAvailableForFutureUse;
+        uint128 __slot2AvailableForFutureUse;
+
         /**
          * @dev Address set of collaterals that are being used in the system by this account.
          */
@@ -131,17 +134,24 @@ library Account {
     }
 
     /**
-     * @dev Loads the Account object for the specified accountId, and validates that sender has the specified permission. These are two different actions but they are merged in a single function because loading an account and checking for a permission is a very common use case in other parts of the code.
+     * @dev Loads the Account object for the specified accountId, 
+     * and validates that sender has the specified permission. It also resets
+     * the interaction timeout. These 
+     * are different actions but they are merged in a single function 
+     * because loading an account and checking for a permission is a very 
+     * common use case in other parts of the code.
      */
     function loadAccountAndValidatePermission(
         uint128 accountId,
         bytes32 permission
-    ) internal view returns (Data storage account) {
+    ) internal returns (Data storage account) {
         account = Account.load(accountId);
 
         if (!account.rbac.authorized(permission, msg.sender)) {
             revert PermissionDenied(accountId, permission, msg.sender);
         }
+        
+        account.lastInteraction = uint64(block.timestamp);
     }
 
     /**

--- a/protocol/synthetix/contracts/storage/Config.sol
+++ b/protocol/synthetix/contracts/storage/Config.sol
@@ -5,7 +5,6 @@ pragma solidity >=0.8.11 <0.9.0;
  * @title System wide configuration for anything
  */
 library Config {
-
     struct Data {
         uint __unused;
     }

--- a/protocol/synthetix/contracts/storage/Config.sol
+++ b/protocol/synthetix/contracts/storage/Config.sol
@@ -1,0 +1,29 @@
+//SPDX-License-Identifier: MIT
+pragma solidity >=0.8.11 <0.9.0;
+
+/**
+ * @title System wide configuration for anything
+ */
+library Config {
+
+    struct Data {
+        uint __unused;
+    }
+
+    /**
+     * @dev Returns a config value
+     */
+    function read(bytes32 k) internal view returns (bytes32 v) {
+        bytes32 s = keccak256(abi.encode("Config", k));
+        assembly {
+            v := sload(s)
+        }
+    }
+
+    function put(bytes32 k, bytes32 v) internal {
+        bytes32 s = keccak256(abi.encode("Config", k));
+        assembly {
+            sstore(s, v)
+        }
+    }
+}

--- a/protocol/synthetix/storage.dump.sol
+++ b/protocol/synthetix/storage.dump.sol
@@ -1,6 +1,20 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.11<0.9.0;
 
+// @custom:artifact @synthetixio/core-contracts/contracts/ownership/AuthorizableStorage.sol:AuthorizableStorage
+library AuthorizableStorage {
+    bytes32 private constant _SLOT_AUTHORIZABLE_STORAGE = keccak256(abi.encode("io.synthetix.synthetix.Authorizable"));
+    struct Data {
+        address authorized;
+    }
+    function load() internal pure returns (Data storage store) {
+        bytes32 s = _SLOT_AUTHORIZABLE_STORAGE;
+        assembly {
+            store.slot := s
+        }
+    }
+}
+
 // @custom:artifact @synthetixio/core-contracts/contracts/ownership/OwnableStorage.sol:OwnableStorage
 library OwnableStorage {
     bytes32 private constant _SLOT_OWNABLE_STORAGE = keccak256(abi.encode("io.synthetix.core-contracts.Ownable"));

--- a/protocol/synthetix/test/integration/modules/core/AccountModule/AccountModule.create.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/AccountModule/AccountModule.create.test.ts
@@ -5,6 +5,7 @@ import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert
 import { ethers } from 'ethers';
 
 import { bootstrap } from '../../../bootstrap';
+import { verifyUsesFeatureFlag } from '../../../verifications';
 
 describe('AccountModule', function () {
   const { signers, systems } = bootstrap();
@@ -18,6 +19,12 @@ describe('AccountModule', function () {
     before('identify signers', async () => {
       [, user1, user2] = signers();
     });
+
+    verifyUsesFeatureFlag(
+      () => systems().Core,
+      'createAccount',
+      () => systems().Core.connect(user1).createAccount(1)
+    );
 
     describe('when user creates an account via the core system', function () {
       before('create the account', async function () {

--- a/protocol/synthetix/test/integration/modules/core/CollateralModule/CollateralModule.deposit.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/CollateralModule/CollateralModule.deposit.test.ts
@@ -3,11 +3,12 @@ import assertEvent from '@synthetixio/core-utils/utils/assertions/assert-event';
 import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
 import { ethers as Ethers } from 'ethers';
 import { ethers } from 'hardhat';
-import { fastForwardTo, getTime } from '@synthetixio/core-utils/utils/hardhat/rpc';
+import { fastForward, fastForwardTo, getTime } from '@synthetixio/core-utils/utils/hardhat/rpc';
 
 import { addCollateral, verifyCollateral } from './CollateralModule.helper';
 import { bootstrap } from '../../../bootstrap';
 import { verifyUsesFeatureFlag } from '../../../verifications';
+import { snapshotCheckpoint } from '../../../../utils/snapshot';
 
 describe('CollateralModule', function () {
   const { signers, systems, provider } = bootstrap();
@@ -160,6 +161,49 @@ describe('CollateralModule', function () {
               'withdraw',
               () => systems().Core.connect(user1).withdraw(1, Collateral.address, depositAmount)
             );
+
+            describe('when there is a account withdraw timeout set', async () => {
+              let restore = snapshotCheckpoint(provider);
+
+              let expireTime = 180;
+              before('set timeout', async () => {
+                // make sure the account has an interaction
+                await systems().Core.connect(owner).Account_set_lastInteraction(
+                  1,
+                  getTime(provider())
+                );
+
+                await systems().Core.connect(owner).setConfig(
+                  ethers.utils.formatBytes32String('accountTimeoutWithdraw'), 
+                  ethers.utils.zeroPad(ethers.BigNumber.from(expireTime).toHexString(), 32)
+                );
+              });
+
+              after(restore);
+
+              it('should not allow withdrawal because of account interaction', async () => {              
+                console.log('last interaction', await systems().Core.getAccountLastInteraction(1));
+                await assertRevert(
+                  systems()
+                    .Core.connect(user1)
+                    .withdraw(1, Collateral.address, depositAmount),
+                  'AccountActivityTimeoutPending',
+                  systems().Core
+                )
+              });
+
+              describe('time passes', () => {
+                before('fast forward', async () => {
+                  await fastForwardTo(parseInt(await systems().Core.getAccountLastInteraction(1)) + expireTime, provider());
+                });
+
+                it('works', async () => {
+                  await systems()
+                    .Core.connect(user1)
+                    .withdraw(1, Collateral.address, depositAmount);
+                });
+              });
+            });
 
             describe('when withdrawing collateral', () => {
               before('withdraw some collateral', async () => {

--- a/protocol/synthetix/test/integration/modules/core/CollateralModule/CollateralModule.deposit.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/CollateralModule/CollateralModule.deposit.test.ts
@@ -7,6 +7,7 @@ import { fastForwardTo, getTime } from '@synthetixio/core-utils/utils/hardhat/rp
 
 import { addCollateral, verifyCollateral } from './CollateralModule.helper';
 import { bootstrap } from '../../../bootstrap';
+import { verifyUsesFeatureFlag } from '../../../verifications';
 
 describe('CollateralModule', function () {
   const { signers, systems, provider } = bootstrap();
@@ -88,6 +89,12 @@ describe('CollateralModule', function () {
             });
           });
 
+          verifyUsesFeatureFlag(
+            () => systems().Core,
+            'deposit',
+            () => systems().Core.connect(user1).deposit(1, Collateral.address, 1)
+          );
+
           describe('when depositing collateral', () => {
             const depositAmount = ethers.utils.parseUnits('1', 6);
             const systemDepositAmount = ethers.utils.parseEther('1');
@@ -147,6 +154,12 @@ describe('CollateralModule', function () {
                 );
               });
             });
+
+            verifyUsesFeatureFlag(
+              () => systems().Core,
+              'withdraw',
+              () => systems().Core.connect(user1).withdraw(1, Collateral.address, depositAmount)
+            );
 
             describe('when withdrawing collateral', () => {
               before('withdraw some collateral', async () => {

--- a/protocol/synthetix/test/integration/modules/core/IssueUSDModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/IssueUSDModule.test.ts
@@ -103,7 +103,10 @@ describe('IssueUSDModule', function () {
     verifyUsesFeatureFlag(
       () => systems().Core,
       'mintUsd',
-      () => systems().Core.connect(user1).mintUsd(accountId, poolId, collateralAddress(), depositAmount.div(10))
+      () =>
+        systems()
+          .Core.connect(user1)
+          .mintUsd(accountId, poolId, collateralAddress(), depositAmount.div(10))
     );
 
     describe('successful mint', () => {
@@ -171,7 +174,10 @@ describe('IssueUSDModule', function () {
     verifyUsesFeatureFlag(
       () => systems().Core,
       'burnUsd',
-      () => systems().Core.connect(user1).burnUsd(accountId, poolId, collateralAddress(), depositAmount.div(10))
+      () =>
+        systems()
+          .Core.connect(user1)
+          .burnUsd(accountId, poolId, collateralAddress(), depositAmount.div(10))
     );
 
     describe('burn from other account', async () => {

--- a/protocol/synthetix/test/integration/modules/core/IssueUSDModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/IssueUSDModule.test.ts
@@ -5,6 +5,7 @@ import { ethers } from 'ethers';
 import Permissions from '../../mixins/AccountRBACMixin.permissions';
 import { bootstrapWithStakedPool } from '../../bootstrap';
 import { snapshotCheckpoint } from '../../../utils/snapshot';
+import { verifyUsesFeatureFlag } from '../../verifications';
 
 const MARKET_FEATURE_FLAG = ethers.utils.formatBytes32String('registerMarket');
 
@@ -99,6 +100,12 @@ describe('IssueUSDModule', function () {
       );
     });
 
+    verifyUsesFeatureFlag(
+      () => systems().Core,
+      'mintUsd',
+      () => systems().Core.connect(user1).mintUsd(accountId, poolId, collateralAddress(), depositAmount.div(10))
+    );
+
     describe('successful mint', () => {
       before('mint', async () => {
         await systems().Core.connect(user1).mintUsd(
@@ -160,6 +167,12 @@ describe('IssueUSDModule', function () {
         .Core.connect(user1)
         .mintUsd(accountId, poolId, collateralAddress(), depositAmount.div(10));
     });
+
+    verifyUsesFeatureFlag(
+      () => systems().Core,
+      'burnUsd',
+      () => systems().Core.connect(user1).burnUsd(accountId, poolId, collateralAddress(), depositAmount.div(10))
+    );
 
     describe('burn from other account', async () => {
       before('transfer burn collateral', async () => {

--- a/protocol/synthetix/test/integration/modules/core/LiquidationModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/LiquidationModule.test.ts
@@ -4,6 +4,7 @@ import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert
 import { ethers } from 'ethers';
 
 import { bootstrapWithMockMarketAndPool } from '../../bootstrap';
+import { verifyUsesFeatureFlag } from '../../verifications';
 
 describe('LiquidationModule', function () {
   const {
@@ -74,6 +75,12 @@ describe('LiquidationModule', function () {
           systems().Core
         );
       });
+
+      verifyUsesFeatureFlag(
+        () => systems().Core,
+        'liquidate',
+        () => systems().Core.connect(user1).liquidate(accountId, poolId, collateralAddress(), liquidatorAccountId)
+      );
 
       // a second account is required to "absorb" the debt which is coming from the first account
       describe('another account joins', () => {
@@ -227,6 +234,12 @@ describe('LiquidationModule', function () {
           debtAmount
         );
       });
+
+      verifyUsesFeatureFlag(
+        () => systems().Core,
+        'liquidateVault',
+        () => systems().Core.connect(user1).liquidateVault(poolId, collateralAddress(), accountId, debtAmount.div(4))
+      );
 
       describe('successful partial liquidation', () => {
         const liquidatorAccountId = 384572397362837;

--- a/protocol/synthetix/test/integration/modules/core/LiquidationModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/LiquidationModule.test.ts
@@ -79,7 +79,10 @@ describe('LiquidationModule', function () {
       verifyUsesFeatureFlag(
         () => systems().Core,
         'liquidate',
-        () => systems().Core.connect(user1).liquidate(accountId, poolId, collateralAddress(), liquidatorAccountId)
+        () =>
+          systems()
+            .Core.connect(user1)
+            .liquidate(accountId, poolId, collateralAddress(), liquidatorAccountId)
       );
 
       // a second account is required to "absorb" the debt which is coming from the first account
@@ -238,7 +241,10 @@ describe('LiquidationModule', function () {
       verifyUsesFeatureFlag(
         () => systems().Core,
         'liquidateVault',
-        () => systems().Core.connect(user1).liquidateVault(poolId, collateralAddress(), accountId, debtAmount.div(4))
+        () =>
+          systems()
+            .Core.connect(user1)
+            .liquidateVault(poolId, collateralAddress(), accountId, debtAmount.div(4))
       );
 
       describe('successful partial liquidation', () => {

--- a/protocol/synthetix/test/integration/modules/core/MarketCollateralModule/MarketCollateralModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/MarketCollateralModule/MarketCollateralModule.test.ts
@@ -205,7 +205,10 @@ describe('MarketCollateralModule', function () {
       verifyUsesFeatureFlag(
         () => systems().Core,
         'withdrawMarketCollateral',
-        () => MockMarket().connect(user1).withdraw(collateralAddress(), configuredMaxAmount.div(2).div(4))
+        () =>
+          MockMarket()
+            .connect(user1)
+            .withdraw(collateralAddress(), configuredMaxAmount.div(2).div(4))
       );
 
       describe('successful withdraw partial', async () => {

--- a/protocol/synthetix/test/integration/modules/core/MarketCollateralModule/MarketCollateralModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/MarketCollateralModule/MarketCollateralModule.test.ts
@@ -3,6 +3,7 @@ import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert
 import assertEvent from '@synthetixio/core-utils/utils/assertions/assert-event';
 import { ethers } from 'ethers';
 import { bootstrapWithMockMarketAndPool } from '../../../bootstrap';
+import { verifyUsesFeatureFlag } from '../../../verifications';
 
 describe('MarketCollateralModule', function () {
   const { signers, systems, MockMarket, marketId, collateralAddress, collateralContract, restore } =
@@ -69,7 +70,7 @@ describe('MarketCollateralModule', function () {
       });
     });
 
-    describe('deposit()', async () => {
+    describe('depositMarketCollateral()', async () => {
       before(restore);
 
       before('configure max', async () => {
@@ -107,6 +108,12 @@ describe('MarketCollateralModule', function () {
           systems().Core
         );
       });
+
+      verifyUsesFeatureFlag(
+        () => systems().Core,
+        'depositMarketCollateral',
+        () => MockMarket().connect(user1).deposit(collateralAddress(), configuredMaxAmount)
+      );
 
       describe('invoked successfully', () => {
         let tx: ethers.providers.TransactionReceipt;
@@ -150,7 +157,7 @@ describe('MarketCollateralModule', function () {
       });
     });
 
-    describe('Withdraw()', async () => {
+    describe('WithdrawMarketCollateral()', async () => {
       before(restore);
 
       before('configure max', async () => {
@@ -194,6 +201,12 @@ describe('MarketCollateralModule', function () {
           systems().Core
         );
       });
+
+      verifyUsesFeatureFlag(
+        () => systems().Core,
+        'withdrawMarketCollateral',
+        () => MockMarket().connect(user1).withdraw(collateralAddress(), configuredMaxAmount.div(2).div(4))
+      );
 
       describe('successful withdraw partial', async () => {
         let tx: ethers.providers.TransactionReceipt;

--- a/protocol/synthetix/test/integration/modules/core/MarketManagerModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/MarketManagerModule.test.ts
@@ -34,7 +34,7 @@ describe('MarketManagerModule', function () {
 
   describe('registerMarket()', async () => {
     before(restore);
-    
+
     verifyUsesFeatureFlag(
       () => systems().Core,
       'registerMarket',
@@ -161,7 +161,7 @@ describe('MarketManagerModule', function () {
 
         await MockMarket().connect(user1).setReportedDebt(reportedDebtBefore);
       });
-    
+
       verifyUsesFeatureFlag(
         () => systems().Core,
         'withdrawMarketUsd',

--- a/protocol/synthetix/test/integration/modules/core/MarketManagerModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/MarketManagerModule.test.ts
@@ -6,6 +6,7 @@ import { ethers } from 'ethers';
 
 import { bootstrapWithMockMarketAndPool } from '../../bootstrap';
 import { MockMarket__factory } from '../../../../typechain-types/index';
+import { verifyUsesFeatureFlag } from '../../verifications';
 
 describe('MarketManagerModule', function () {
   const {
@@ -33,13 +34,12 @@ describe('MarketManagerModule', function () {
 
   describe('registerMarket()', async () => {
     before(restore);
-
-    it('does not allow non-permissioned user to register market', async () => {
-      await assertRevert(
-        systems().Core.connect(user2).registerMarket(user1.getAddress()),
-        'FeatureUnavailable()'
-      );
-    });
+    
+    verifyUsesFeatureFlag(
+      () => systems().Core,
+      'registerMarket',
+      () => systems().Core.connect(user2).registerMarket(user1.getAddress())
+    );
 
     it('reverts when trying to register a market that does not support the IMarket interface', async function () {
       await assertRevert(
@@ -82,7 +82,7 @@ describe('MarketManagerModule', function () {
     });
   });
 
-  describe('deposit()', async () => {
+  describe('depositMarketUsd()', async () => {
     before(restore);
 
     before('acquire USD', async () => {
@@ -97,38 +97,49 @@ describe('MarketManagerModule', function () {
       );
     });
 
-    describe('success', async () => {
-      before('deposit', async () => {
+    describe('when funds have been approved', async () => {
+      before('approve usd', async () => {
         await systems().USD.connect(user1).approve(MockMarket().address, One);
-        txn = await MockMarket().connect(user1).buySynth(One);
       });
 
-      it('takes USD away', async () => {
-        assertBn.isZero(await systems().USD.balanceOf(await user1.getAddress()));
-      });
+      verifyUsesFeatureFlag(
+        () => systems().Core,
+        'depositMarketUsd',
+        () => MockMarket().connect(user1).buySynth(One)
+      );
 
-      it('increases withdrawableUsd', async () => {
-        assertBn.equal(
-          await systems().Core.connect(user1).getWithdrawableMarketUsd(marketId()),
-          depositAmount.add(One)
-        );
-      });
+      describe('success', async () => {
+        before('deposit', async () => {
+          txn = await MockMarket().connect(user1).buySynth(One);
+        });
 
-      it('leaves totalDebt the same', async () => {
-        assertBn.isZero(await systems().Core.connect(user1).getMarketTotalDebt(marketId()));
-      });
+        it('takes USD away', async () => {
+          assertBn.isZero(await systems().USD.balanceOf(await user1.getAddress()));
+        });
 
-      it('accrues no debt', async () => {
-        // should only have the one USD minted earlier
-        assertBn.equal(
-          await systems().Core.callStatic.getVaultDebt(poolId, collateralAddress()),
-          0
-        );
+        it('increases withdrawableUsd', async () => {
+          assertBn.equal(
+            await systems().Core.connect(user1).getWithdrawableMarketUsd(marketId()),
+            depositAmount.add(One)
+          );
+        });
+
+        it('leaves totalDebt the same', async () => {
+          assertBn.isZero(await systems().Core.connect(user1).getMarketTotalDebt(marketId()));
+        });
+
+        it('accrues no debt', async () => {
+          // should only have the one USD minted earlier
+          assertBn.equal(
+            await systems().Core.callStatic.getVaultDebt(poolId, collateralAddress()),
+            0
+          );
+        });
       });
     });
   });
 
-  describe('withdraw()', async () => {
+  describe('withdrawMarketUsd()', async () => {
     before(restore);
 
     describe('deposit into the pool', async () => {
@@ -150,6 +161,12 @@ describe('MarketManagerModule', function () {
 
         await MockMarket().connect(user1).setReportedDebt(reportedDebtBefore);
       });
+    
+      verifyUsesFeatureFlag(
+        () => systems().Core,
+        'withdrawMarketUsd',
+        () => MockMarket().connect(user1).sellSynth(One.div(2))
+      );
 
       describe('withdraw some from the market', async () => {
         before('mint USD to use market', async () => {

--- a/protocol/synthetix/test/integration/modules/core/PoolModuleOwnership.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/PoolModuleOwnership.test.ts
@@ -18,9 +18,7 @@ describe('PoolModule Create / Ownership', function () {
   verifyUsesFeatureFlag(
     () => systems().Core,
     'createPool',
-    () => systems()
-      .Core.connect(user1)
-      .createPool(1, ethers.constants.AddressZero)
+    () => systems().Core.connect(user1).createPool(1, ethers.constants.AddressZero)
   );
 
   describe('When creating a Pool', async () => {

--- a/protocol/synthetix/test/integration/modules/core/PoolModuleOwnership.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/PoolModuleOwnership.test.ts
@@ -4,6 +4,7 @@ import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert
 import { ethers } from 'ethers';
 
 import { bootstrap } from '../../bootstrap';
+import { verifyUsesFeatureFlag } from '../../verifications';
 
 describe('PoolModule Create / Ownership', function () {
   const { signers, systems } = bootstrap();
@@ -14,14 +15,13 @@ describe('PoolModule Create / Ownership', function () {
     [owner, user1, user2] = signers();
   });
 
-  it('should revert if user does not have permission to create pool', async () => {
-    await assertRevert(
-      systems()
-        .Core.connect(user1)
-        .createPool(1, await user1.getAddress()),
-      'FeatureUnavailable()'
-    );
-  });
+  verifyUsesFeatureFlag(
+    () => systems().Core,
+    'createPool',
+    () => systems()
+      .Core.connect(user1)
+      .createPool(1, ethers.constants.AddressZero)
+  );
 
   describe('When creating a Pool', async () => {
     let receipt: ethers.providers.TransactionReceipt;

--- a/protocol/synthetix/test/integration/modules/core/RewardsManagerModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/RewardsManagerModule.test.ts
@@ -482,13 +482,14 @@ describe('RewardsManagerModule', function () {
         systems().Core
       );
     });
-    
+
     verifyUsesFeatureFlag(
       () => systems().Core,
       'claimRewards',
-      () => systems()
-        .Core.connect(user1)
-        .claimRewards(accountId, poolId, collateralAddress(), RewardDistributor.address)
+      () =>
+        systems()
+          .Core.connect(user1)
+          .claimRewards(accountId, poolId, collateralAddress(), RewardDistributor.address)
     );
 
     describe('successful claim', () => {

--- a/protocol/synthetix/test/integration/modules/core/RewardsManagerModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/RewardsManagerModule.test.ts
@@ -7,6 +7,7 @@ import { fastForwardTo, getTime } from '@synthetixio/core-utils/utils/hardhat/rp
 import Permissions from '../../mixins/AccountRBACMixin.permissions';
 import { bootstrapWithStakedPool } from '../../bootstrap';
 import { snapshotCheckpoint } from '../../../utils/snapshot';
+import { verifyUsesFeatureFlag } from '../../verifications';
 
 // ---------------------------------------
 // If the tests are failing Make sure you run foundryup to update the anvil to latest version
@@ -481,6 +482,14 @@ describe('RewardsManagerModule', function () {
         systems().Core
       );
     });
+    
+    verifyUsesFeatureFlag(
+      () => systems().Core,
+      'claimRewards',
+      () => systems()
+        .Core.connect(user1)
+        .claimRewards(accountId, poolId, collateralAddress(), RewardDistributor.address)
+    );
 
     describe('successful claim', () => {
       before('claim', async () => {

--- a/protocol/synthetix/test/integration/modules/core/VaultModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/VaultModule.test.ts
@@ -195,13 +195,16 @@ describe('VaultModule', function () {
     verifyUsesFeatureFlag(
       () => systems().Core,
       'delegateCollateral',
-      () => systems().Core.connect(user1).delegateCollateral(
-        accountId,
-        42,
-        collateralAddress(),
-        depositAmount.div(50),
-        ethers.utils.parseEther('1')
-      )
+      () =>
+        systems()
+          .Core.connect(user1)
+          .delegateCollateral(
+            accountId,
+            42,
+            collateralAddress(),
+            depositAmount.div(50),
+            ethers.utils.parseEther('1')
+          )
     );
 
     describe('when collateral is disabled', async () => {

--- a/protocol/synthetix/test/integration/modules/core/VaultModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/VaultModule.test.ts
@@ -6,6 +6,7 @@ import { ethers } from 'ethers';
 import Permissions from '../../mixins/AccountRBACMixin.permissions';
 import { bootstrapWithStakedPool } from '../../bootstrap';
 import { snapshotCheckpoint } from '../../../utils/snapshot';
+import { verifyUsesFeatureFlag } from '../../verifications';
 
 describe('VaultModule', function () {
   const {
@@ -190,6 +191,18 @@ describe('VaultModule', function () {
         systems().Core
       );
     });
+
+    verifyUsesFeatureFlag(
+      () => systems().Core,
+      'delegateCollateral',
+      () => systems().Core.connect(user1).delegateCollateral(
+        accountId,
+        42,
+        collateralAddress(),
+        depositAmount.div(50),
+        ethers.utils.parseEther('1')
+      )
+    );
 
     describe('when collateral is disabled', async () => {
       const restore = snapshotCheckpoint(provider);

--- a/protocol/synthetix/test/integration/verifications.ts
+++ b/protocol/synthetix/test/integration/verifications.ts
@@ -1,7 +1,11 @@
 import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
 import { ethers } from 'ethers';
 
-export function verifyUsesFeatureFlag(c: () => ethers.Contract, flagName: string, txn: () => Promise<unknown>) {
+export function verifyUsesFeatureFlag(
+  c: () => ethers.Contract,
+  flagName: string,
+  txn: () => Promise<unknown>
+) {
   describe(`when ${flagName} feature disabled`, () => {
     before('disable feature', async () => {
       await c().setFeatureFlagDenyAll(ethers.utils.formatBytes32String(flagName), true);

--- a/protocol/synthetix/test/integration/verifications.ts
+++ b/protocol/synthetix/test/integration/verifications.ts
@@ -1,0 +1,22 @@
+import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
+import { ethers } from 'ethers';
+
+export function verifyUsesFeatureFlag(c: () => ethers.Contract, flagName: string, txn: () => Promise<unknown>) {
+  describe(`when ${flagName} feature disabled`, () => {
+    before('disable feature', async () => {
+      await c().setFeatureFlagDenyAll(ethers.utils.formatBytes32String(flagName), true);
+    });
+
+    after('re-enable feature', async () => {
+      await c().setFeatureFlagDenyAll(ethers.utils.formatBytes32String(flagName), false);
+    });
+
+    it('it fails with feature unavailable', async () => {
+      await assertRevert(
+        txn(),
+        `FeatureUnavailable("${ethers.utils.formatBytes32String(flagName)}")`,
+        c()
+      );
+    });
+  });
+}

--- a/utils/core-modules/contracts/interfaces/IFeatureFlagModule.sol
+++ b/utils/core-modules/contracts/interfaces/IFeatureFlagModule.sol
@@ -69,6 +69,13 @@ interface IFeatureFlagModule {
     function removeFromFeatureFlagAllowlist(bytes32 feature, address account) external;
 
     /**
+     * @notice Sets addresses which can disable a feature (but not enable it). Overwrites any preexisting data.
+     * @param feature The bytes32 id of the feature.
+     * @param deniers The addresses which should have the ability to unilaterally disable the feature
+     */
+    function setDeniers(bytes32 feature, address[] memory deniers) external;
+
+    /**
      * @notice Determines if the given feature is freely allowed to all users.
      * @param feature The bytes32 id of the feature.
      * @return True if anyone is allowed to use the feature, false if per-user control is used.

--- a/utils/core-modules/contracts/interfaces/IFeatureFlagModule.sol
+++ b/utils/core-modules/contracts/interfaces/IFeatureFlagModule.sol
@@ -17,28 +17,35 @@ interface IFeatureFlagModule {
      * @param feature The bytes32 id of the feature.
      * @param allowAll True if the feature was allowed for everyone and false if it is only allowed for those included in the allowlist.
      */
-    event FeatureFlagAllowAllSet(bytes32 feature, bool allowAll);
+    event FeatureFlagAllowAllSet(bytes32 indexed feature, bool allowAll);
 
     /**
      * @notice Emitted when general access has been blocked for a feature.
      * @param feature The bytes32 id of the feature.
      * @param denyAll True if the feature was blocked for everyone and false if it is only allowed for those included in the allowlist or if allowAll is set to true.
      */
-    event FeatureFlagDenyAllSet(bytes32 feature, bool denyAll);
+    event FeatureFlagDenyAllSet(bytes32 indexed feature, bool denyAll);
 
     /**
      * @notice Emitted when an address was given access to a feature.
      * @param feature The bytes32 id of the feature.
      * @param account The address that was given access to the feature.
      */
-    event FeatureFlagAllowlistAdded(bytes32 feature, address account);
+    event FeatureFlagAllowlistAdded(bytes32 indexed feature, address account);
 
     /**
      * @notice Emitted when access to a feature has been removed from an address.
      * @param feature The bytes32 id of the feature.
      * @param account The address that no longer has access to the feature.
      */
-    event FeatureFlagAllowlistRemoved(bytes32 feature, address account);
+    event FeatureFlagAllowlistRemoved(bytes32 indexed feature, address account);
+
+    /**
+     * @notice Emitted when the list of addresses which can block a feature has been updated
+     * @param feature The bytes32 id of the feature.
+     * @param deniers The list of addresses which are allowed to block a feature
+     */
+    event FeatureFlagDeniersReset(bytes32 indexed feature, address[] deniers);
 
     /**
      * @notice Enables or disables free access to a feature.
@@ -74,6 +81,12 @@ interface IFeatureFlagModule {
      * @param deniers The addresses which should have the ability to unilaterally disable the feature
      */
     function setDeniers(bytes32 feature, address[] memory deniers) external;
+
+    /**
+     * @notice Gets the list of address which can block a feature
+     * @param feature The bytes32 id of the feature.
+     */
+    function getDeniers(bytes32 feature) external returns (address[] memory);
 
     /**
      * @notice Determines if the given feature is freely allowed to all users.

--- a/utils/core-modules/contracts/modules/FeatureFlagModule.sol
+++ b/utils/core-modules/contracts/modules/FeatureFlagModule.sol
@@ -72,19 +72,18 @@ contract FeatureFlagModule is IFeatureFlagModule {
 
         // resize array (its really dumb how you have to do this)
         uint storageLen = flag.deniers.length;
-        for (uint i = storageLen;i > deniers.length;i--) {
+        for (uint i = storageLen; i > deniers.length; i--) {
             flag.deniers.pop();
         }
 
-        for (uint i = 0;i < deniers.length;i++) {
+        for (uint i = 0; i < deniers.length; i++) {
             if (i >= storageLen) {
                 flag.deniers.push(deniers[i]);
-            }
-            else {
+            } else {
                 flag.deniers[i] = deniers[i];
             }
         }
-        
+
         emit FeatureFlagDeniersReset(feature, deniers);
     }
 
@@ -94,7 +93,7 @@ contract FeatureFlagModule is IFeatureFlagModule {
     function getDeniers(bytes32 feature) external view override returns (address[] memory) {
         FeatureFlag.Data storage flag = FeatureFlag.load(feature);
         address[] memory addrs = new address[](flag.deniers.length);
-        for (uint i = 0;i < addrs.length;i++) {
+        for (uint i = 0; i < addrs.length; i++) {
             addrs[i] = flag.deniers[i];
         }
 

--- a/utils/core-modules/contracts/modules/FeatureFlagModule.sol
+++ b/utils/core-modules/contracts/modules/FeatureFlagModule.sol
@@ -34,7 +34,7 @@ contract FeatureFlagModule is IFeatureFlagModule {
     function setFeatureFlagDenyAll(bytes32 feature, bool denyAll) external override {
         FeatureFlag.Data storage flag = FeatureFlag.load(feature);
 
-        if (!flag.isDenier(msg.sender)) {
+        if (!denyAll || !flag.isDenier(msg.sender)) {
             OwnableStorage.onlyOwner();
         }
 

--- a/utils/core-modules/contracts/modules/FeatureFlagModule.sol
+++ b/utils/core-modules/contracts/modules/FeatureFlagModule.sol
@@ -63,13 +63,16 @@ contract FeatureFlagModule is IFeatureFlagModule {
         emit FeatureFlagAllowlistRemoved(feature, account);
     }
 
+    /**
+     * @inheritdoc IFeatureFlagModule
+     */
     function setDeniers(bytes32 feature, address[] memory deniers) external override {
         OwnableStorage.onlyOwner();
         FeatureFlag.Data storage flag = FeatureFlag.load(feature);
 
         // resize array (its really dumb how you have to do this)
         uint storageLen = flag.deniers.length;
-        for (uint i = storageLen;i > deniers.length;i++) {
+        for (uint i = storageLen;i > deniers.length;i--) {
             flag.deniers.pop();
         }
 
@@ -81,6 +84,21 @@ contract FeatureFlagModule is IFeatureFlagModule {
                 flag.deniers[i] = deniers[i];
             }
         }
+        
+        emit FeatureFlagDeniersReset(feature, deniers);
+    }
+
+    /**
+     * @inheritdoc IFeatureFlagModule
+     */
+    function getDeniers(bytes32 feature) external view override returns (address[] memory) {
+        FeatureFlag.Data storage flag = FeatureFlag.load(feature);
+        address[] memory addrs = new address[](flag.deniers.length);
+        for (uint i = 0;i < addrs.length;i++) {
+            addrs[i] = flag.deniers[i];
+        }
+
+        return addrs;
     }
 
     /**

--- a/utils/core-modules/contracts/storage/FeatureFlag.sol
+++ b/utils/core-modules/contracts/storage/FeatureFlag.sol
@@ -13,6 +13,7 @@ library FeatureFlag {
         bool allowAll;
         bool denyAll;
         SetUtil.AddressSet permissionedAddresses;
+        address[] deniers;
     }
 
     function load(bytes32 featureName) internal pure returns (Data storage store) {
@@ -36,5 +37,15 @@ library FeatureFlag {
         }
 
         return store.allowAll || store.permissionedAddresses.contains(value);
+    }
+
+    function isDenier(Data storage self, address possibleDenier) internal view returns (bool) {
+        for (uint i = 0;i < self.deniers.length;i++) {
+            if (self.deniers[i] == possibleDenier) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/utils/core-modules/contracts/storage/FeatureFlag.sol
+++ b/utils/core-modules/contracts/storage/FeatureFlag.sol
@@ -6,7 +6,7 @@ import "@synthetixio/core-contracts/contracts/utils/SetUtil.sol";
 library FeatureFlag {
     using SetUtil for SetUtil.AddressSet;
 
-    error FeatureUnavailable();
+    error FeatureUnavailable(bytes32 which);
 
     struct Data {
         bytes32 name;
@@ -25,7 +25,7 @@ library FeatureFlag {
 
     function ensureAccessToFeature(bytes32 feature) internal view {
         if (!hasAccess(feature, msg.sender)) {
-            revert FeatureUnavailable();
+            revert FeatureUnavailable(feature);
         }
     }
 

--- a/utils/core-modules/contracts/storage/FeatureFlag.sol
+++ b/utils/core-modules/contracts/storage/FeatureFlag.sol
@@ -40,7 +40,7 @@ library FeatureFlag {
     }
 
     function isDenier(Data storage self, address possibleDenier) internal view returns (bool) {
-        for (uint i = 0;i < self.deniers.length;i++) {
+        for (uint i = 0; i < self.deniers.length; i++) {
             if (self.deniers[i] == possibleDenier) {
                 return true;
             }

--- a/utils/core-modules/test/contracts/modules/FeatureFlagModule.test.ts
+++ b/utils/core-modules/test/contracts/modules/FeatureFlagModule.test.ts
@@ -230,6 +230,30 @@ describe('FeatureFlagModule', function () {
         );
       });
 
+      describe('when denier has denied', async () => {
+        before('deny', async () => {
+          await FeatureFlagModule.connect(denier1).setFeatureFlagDenyAll(FEATURE_FLAG_NAME, true);
+        });
+
+        it('cant be undone by the denier', async () => {
+          await assertRevert(
+            FeatureFlagModule.connect(denier1).setFeatureFlagDenyAll(
+              FEATURE_FLAG_NAME,
+              false // this is disabling the denyAll flag
+            ),
+            'Unauthorized(',
+            FeatureFlagModule
+          );
+        });
+
+        it('the owner can undo feature flag deny all', async () => {
+          await FeatureFlagModule.setFeatureFlagDenyAll(
+            FEATURE_FLAG_NAME,
+            false // this is disabling the denyAll flag
+          );
+        });
+      });
+
       describe('when invoked a second time', async () => {
         before('set deniers again', async () => {
           await FeatureFlagModule.setDeniers(FEATURE_FLAG_NAME, [

--- a/utils/core-modules/test/contracts/modules/FeatureFlagModule.test.ts
+++ b/utils/core-modules/test/contracts/modules/FeatureFlagModule.test.ts
@@ -178,26 +178,25 @@ describe('FeatureFlagModule', function () {
   });
 
   describe('setDeniers()', async () => {
-    it.skip('only allows owner to call', async () => {
-      assertRevert(
-        FeatureFlagModule.setDeniers(FEATURE_FLAG_NAME, []),
+    it('only allows owner to call', async () => {
+      await assertRevert(
+        FeatureFlagModule.connect(denier1).setDeniers(FEATURE_FLAG_NAME, []),
         'Unauthorized(',
         FeatureFlagModule
       );
     });
 
     describe('when invoked successfully', async () => {
-
       let txn: ethers.providers.TransactionReceipt;
-      
-      before('set deniers', async () => {
-        txn = await (await FeatureFlagModule.setDeniers(FEATURE_FLAG_NAME, [
-          await denier1.getAddress(),
-          await denier2.getAddress(), 
-          await denier3.getAddress()
-        ])).wait();
 
-        
+      before('set deniers', async () => {
+        txn = await (
+          await FeatureFlagModule.setDeniers(FEATURE_FLAG_NAME, [
+            await denier1.getAddress(),
+            await denier2.getAddress(),
+            await denier3.getAddress(),
+          ])
+        ).wait();
       });
 
       it('has correct deniers', async () => {
@@ -209,22 +208,34 @@ describe('FeatureFlagModule', function () {
       });
 
       it('emits event', async () => {
-        assertEvent(
+        await assertEvent(
           txn,
           `FeatureFlagDeniersReset("${FEATURE_FLAG_NAME}",`,
           FeatureFlagModule
-        )
+        );
       });
 
       it('does not revert when any of the deniers attempt to deny all', async () => {
-        await FeatureFlagModule.connect(denier1).callStatic.setFeatureFlagDenyAll(FEATURE_FLAG_NAME, true);
-        await FeatureFlagModule.connect(denier2).callStatic.setFeatureFlagDenyAll(FEATURE_FLAG_NAME, true);
-        await FeatureFlagModule.connect(denier3).callStatic.setFeatureFlagDenyAll(FEATURE_FLAG_NAME, true);
+        await FeatureFlagModule.connect(denier1).callStatic.setFeatureFlagDenyAll(
+          FEATURE_FLAG_NAME,
+          true
+        );
+        await FeatureFlagModule.connect(denier2).callStatic.setFeatureFlagDenyAll(
+          FEATURE_FLAG_NAME,
+          true
+        );
+        await FeatureFlagModule.connect(denier3).callStatic.setFeatureFlagDenyAll(
+          FEATURE_FLAG_NAME,
+          true
+        );
       });
 
       describe('when invoked a second time', async () => {
         before('set deniers again', async () => {
-          await FeatureFlagModule.setDeniers(FEATURE_FLAG_NAME, [await denier3.getAddress(), await denier2.getAddress()]);
+          await FeatureFlagModule.setDeniers(FEATURE_FLAG_NAME, [
+            await denier3.getAddress(),
+            await denier2.getAddress(),
+          ]);
         });
 
         it('sets new deniers correctly', async () => {
@@ -235,12 +246,12 @@ describe('FeatureFlagModule', function () {
         });
 
         it('removed signer should no longer have capability', async () => {
-          assertRevert(
+          await assertRevert(
             FeatureFlagModule.connect(denier1).setFeatureFlagDenyAll(FEATURE_FLAG_NAME, true),
-            `Unauthorized("${denier1}")`,
+            `Unauthorized("${await denier1.getAddress()}")`,
             FeatureFlagModule
           );
-        })
+        });
       });
     });
   });


### PR DESCRIPTION
these are things we should definitely have lined up for mainnet launch. in particular:

* interaction delay timeout for the account, which prevents user from withdrawing funds from the system in the case of an accounting error which allows for them to withdraw more than they should. this should theoretically allow for us to be able to recover from basically any attack by preventing loss of funds
* add a feature to feature flags which allows for denying to all if an address is in a list. this will allow for feature similar to the "SystemStatus" system of v2x, but with more granularity and improved code maintainability
* create new feature flags which are set to allowed automatically:
  * createAccount
  * deposit
  * withdraw
  * mintUsd
  * burnUsd
  * liquidate
  * liquidateVault
  * depositMarketCollateral
  * withdrawMarketCollateral
  * depositMarketUsd
  * withdrawMarketUsd
  * claimRewards
  * delegateCollateral

the existance of these feature flags will allow for us to selectively disable any of these features in the case of a discovered attack in progress/potentially exploitable.