### PR TITLE
add check to verify that the initial proxy has not been deployed

### DIFF
--- a/.github/workflows/simulate-release.yml
+++ b/.github/workflows/simulate-release.yml
@@ -43,7 +43,9 @@ jobs:
         cd ${{ matrix.project }}
         npx hardhat cannon:build --upgrade-from ${{ matrix.cannonPackage }} \
           --network ${{ matrix.network }} --dry-run \
-          --impersonate ${{ matrix.impersonate}}
-    
+          --impersonate ${{ matrix.impersonate}} | tee deployment.txt
+    # verify that a new proxy has not been deployed, we cannot edit the proxy
+    # this is kind of hacky but sufficient for the time being
+    - run: '! grep "exec: contract.InitialProxy" ${{ matrix.project }}/deployment.txt'
 
         


### PR DESCRIPTION
it is important to make sure that a new version of the initial proxy isnt being created at this point.

this is done by doing a simple string search after the deployment is created. If it contains `exec: contract.InitialProxy`, that means that the proxy is redeployed and we don't want that, so the build will fail on whatever PR it is or whatever.