### PR TITLE
fixes for collateral locks

### DIFF
--- a/protocol/synthetix/contracts/modules/core/CollateralModule.sol
+++ b/protocol/synthetix/contracts/modules/core/CollateralModule.sol
@@ -3,12 +3,12 @@ pragma solidity >=0.8.11 <0.9.0;
 
 import "@synthetixio/core-contracts/contracts/token/ERC20Helper.sol";
 import "@synthetixio/core-contracts/contracts/errors/ArrayError.sol";
+import "@synthetixio/core-contracts/contracts/errors/ParameterError.sol";
 
 import "../../interfaces/ICollateralModule.sol";
 
 import "../../storage/Account.sol";
 import "../../storage/CollateralConfiguration.sol";
-import "../../storage/CollateralLock.sol";
 import "../../storage/Config.sol";
 
 import "@synthetixio/core-modules/contracts/storage/FeatureFlag.sol";
@@ -132,31 +132,69 @@ contract CollateralModule is ICollateralModule {
         uint128 accountId,
         address collateralType,
         uint256 offset,
-        uint256 items
-    ) external override {
+        uint256 count
+    ) external override returns (uint cleared) {
         CollateralLock.Data[] storage locks = Account
             .load(accountId)
             .collaterals[collateralType]
             .locks;
 
-        if (offset > locks.length || items > locks.length) {
-            revert ArrayError.OutOfBounds();
-        }
-
         uint64 currentTime = block.timestamp.to64();
 
-        if (offset == 0 && items == 0) {
-            items = locks.length;
+        uint len = locks.length;
+
+        if (offset >= len) {
+            return 0;
         }
 
-        uint256 index = offset;
-        while (index < locks.length) {
+        if (count == 0 || offset + count >= len) {
+            count = len - offset;
+        }
+
+        uint index = offset;
+        for (uint i = 0;i < count;i++) {
             if (locks[index].lockExpirationTime <= currentTime) {
+                emit CollateralLockExpired(
+                    accountId, 
+                    collateralType, 
+                    locks[index].amountD18, 
+                    locks[index].lockExpirationTime
+                );
+
                 locks[index] = locks[locks.length - 1];
                 locks.pop();
+
             } else {
                 index++;
             }
+        }
+
+        return count + offset - index;
+    }
+
+    /**
+     * @inheritdoc ICollateralModule
+     */
+    function getLocks(
+        uint128 accountId,
+        address collateralType,
+        uint256 offset,
+        uint256 count
+    ) external view override returns (CollateralLock.Data[] memory locks) {
+        CollateralLock.Data[] storage storageLocks = Account
+            .load(accountId)
+            .collaterals[collateralType]
+            .locks;
+        uint len = storageLocks.length;
+
+        if (count == 0 || offset + count >= len) {
+            count = offset < len ? len - offset : 0;
+        }
+
+        locks = new CollateralLock.Data[](count);
+
+        for (uint i = 0;i < count;i++) {
+            locks[i] = storageLocks[offset + i];
         }
     }
 
@@ -178,12 +216,22 @@ contract CollateralModule is ICollateralModule {
             collateralType
         );
 
-        if (totalDeposited - totalLocked < amount) {
+        if (expireTimestamp <= block.timestamp) {
+            revert ParameterError.InvalidParameter("expireTimestamp", "must be in the future");
+        }
+
+        if (amount == 0) {
+            revert ParameterError.InvalidParameter("amount", "must be nonzero");
+        }
+
+        if (amount > totalDeposited - totalLocked) {
             revert InsufficientAccountCollateral(amount);
         }
 
         account.collaterals[collateralType].locks.push(
-            CollateralLock.Data(amount, expireTimestamp)
+            CollateralLock.Data(amount.to128(), expireTimestamp)
         );
+
+        emit CollateralLockCreated(accountId, collateralType, amount, expireTimestamp);
     }
 }

--- a/protocol/synthetix/contracts/modules/core/CollateralModule.sol
+++ b/protocol/synthetix/contracts/modules/core/CollateralModule.sol
@@ -152,18 +152,17 @@ contract CollateralModule is ICollateralModule {
         }
 
         uint index = offset;
-        for (uint i = 0;i < count;i++) {
+        for (uint i = 0; i < count; i++) {
             if (locks[index].lockExpirationTime <= currentTime) {
                 emit CollateralLockExpired(
-                    accountId, 
-                    collateralType, 
-                    locks[index].amountD18, 
+                    accountId,
+                    collateralType,
+                    locks[index].amountD18,
                     locks[index].lockExpirationTime
                 );
 
                 locks[index] = locks[locks.length - 1];
                 locks.pop();
-
             } else {
                 index++;
             }
@@ -193,7 +192,7 @@ contract CollateralModule is ICollateralModule {
 
         locks = new CollateralLock.Data[](count);
 
-        for (uint i = 0;i < count;i++) {
+        for (uint i = 0; i < count; i++) {
             locks[i] = storageLocks[offset + i];
         }
     }

--- a/protocol/synthetix/contracts/storage/CollateralLock.sol
+++ b/protocol/synthetix/contracts/storage/CollateralLock.sol
@@ -9,7 +9,7 @@ library CollateralLock {
         /**
          * @dev The amount of collateral that has been locked.
          */
-        uint256 amountD18;
+        uint128 amountD18;
         /**
          * @dev The date when the locked amount becomes unlocked.
          */

--- a/protocol/synthetix/test/integration/modules/core/CollateralModule/CollateralModule.locks.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/CollateralModule/CollateralModule.locks.test.ts
@@ -1,0 +1,190 @@
+import assert from 'assert/strict';
+import assertBn from '@synthetixio/core-utils/utils/assertions/assert-bignumber';
+import assertEvent from '@synthetixio/core-utils/utils/assertions/assert-event';
+import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
+import { ethers as Ethers } from 'ethers';
+import { fastForwardTo, getTime } from '@synthetixio/core-utils/utils/hardhat/rpc';
+
+import { bootstrapWithStakedPool } from '../../../bootstrap';
+import { snapshotCheckpoint } from '../../../../utils/snapshot';
+
+describe('CollateralModule', function () {
+  const { signers, systems, provider, accountId, collateralAddress, depositAmount } =
+    bootstrapWithStakedPool();
+
+  let user1: Ethers.Signer, user2: Ethers.Signer;
+
+  before('identify signers', async () => {
+    [, user1, user2] = signers();
+  });
+
+  const restore = snapshotCheckpoint(provider);
+
+  describe('createLock()', function () {
+    before(restore);
+    it('can only be called by owner or user', async () => {
+      await assertRevert(
+        systems()
+          .Core.connect(user2)
+          .createLock(1, collateralAddress(), depositAmount.div(10), 1234123412341),
+        'PermissionDenied(',
+        systems().Core
+      );
+    });
+
+    it('fails when expire time is in the past', async () => {
+      await assertRevert(
+        systems().Core.connect(user1).createLock(
+          1,
+          collateralAddress(),
+          depositAmount.div(10),
+          1 // timestamp is definitely in the past
+        ),
+        'InvalidParameter("expireTimestamp"',
+        systems().Core
+      );
+    });
+
+    it('fails when insufficient collateral in account to lock', async () => {
+      await assertRevert(
+        systems().Core.connect(user1).createLock(
+          1,
+          collateralAddress(),
+          0, // 0 is invalid for amount to lock
+          1234123412341
+        ),
+        'InvalidParameter("amount"',
+        systems().Core
+      );
+    });
+
+    it('fails when insufficient collateral in account to lock', async () => {
+      await assertRevert(
+        systems().Core.connect(user1).createLock(
+          1,
+          collateralAddress(),
+          depositAmount.mul(10).add(1),
+          1234123412341 // timestamp is definitely in the past
+        ),
+        'InsufficientAccountCollateral(',
+        systems().Core
+      );
+    });
+
+    describe('successful invoke', async () => {
+      let txn;
+      before('invoked', async () => {
+        txn = await systems()
+          .Core.connect(user1)
+          .createLock(1, collateralAddress(), depositAmount.div(10), 1234123412341);
+
+        // create a second one also
+        await systems()
+          .Core.connect(user1)
+          .createLock(1, collateralAddress(), depositAmount.div(10).mul(4), 1234123412342);
+      });
+
+      it('increments account locked amount', async () => {
+        assertBn.equal(
+          (await systems().Core.getAccountCollateral(accountId, collateralAddress()))[2],
+          depositAmount.div(2)
+        );
+      });
+
+      it('created locks with the given specification', async () => {
+        const locks = await systems().Core.getLocks(accountId, collateralAddress(), 0, 0);
+        assert(locks.length === 2);
+        assertBn.equal(locks[0].amountD18, depositAmount.div(10));
+        assertBn.equal(locks[0].lockExpirationTime, 1234123412341);
+        assertBn.equal(locks[1].amountD18, depositAmount.div(10).mul(4));
+        assertBn.equal(locks[1].lockExpirationTime, 1234123412342);
+      });
+
+      it('emits event', async () => {
+        await assertEvent(
+          txn,
+          `CollateralLockCreated(${accountId}, "${collateralAddress()}", ${depositAmount
+            .div(10)
+            .toString()}, 1234123412341)`,
+          systems().Core
+        );
+      });
+    });
+  });
+
+  describe('cleanExpiredLocks()', function () {
+    before(restore);
+
+    let ts: number;
+
+    before('create locks', async () => {
+      ts = await getTime(provider());
+      await systems()
+        .Core.connect(user1)
+        .createLock(1, collateralAddress(), depositAmount.div(10), ts + 200);
+      await systems()
+        .Core.connect(user1)
+        .createLock(1, collateralAddress(), depositAmount.div(10), ts + 400);
+      await systems()
+        .Core.connect(user1)
+        .createLock(1, collateralAddress(), depositAmount.div(10), ts + 300);
+      await systems()
+        .Core.connect(user1)
+        .createLock(1, collateralAddress(), depositAmount.div(10), ts + 100);
+
+      await fastForwardTo(ts + 300, provider());
+    });
+
+    const cleanRestore = snapshotCheckpoint(provider);
+
+    describe('invoke on the whole thing', async () => {
+      let txn;
+      before(cleanRestore);
+      before('clean', async () => {
+        txn = await systems()
+          .Core.connect(user1)
+          .cleanExpiredLocks(accountId, collateralAddress(), 0, 0);
+      });
+
+      it('only has the one unexpired lock remaining', async () => {
+        const locks = await systems().Core.getLocks(accountId, collateralAddress(), 0, 0);
+        assert(locks.length === 1);
+      });
+
+      it('emits event', async () => {
+        await assertEvent(
+          txn,
+          `CollateralLockExpired(${accountId}, "${collateralAddress()}", ${depositAmount
+            .div(10)
+            .toString()}, ${ts + 200})`,
+          systems().Core
+        );
+      });
+    });
+
+    describe('invoke on a portion', async () => {
+      before(cleanRestore);
+      before('clean', async () => {
+        await systems().Core.connect(user1).cleanExpiredLocks(accountId, collateralAddress(), 1, 2);
+      });
+
+      it('only one expired lock could be removed', async () => {
+        const locks = await systems().Core.getLocks(accountId, collateralAddress(), 0, 0);
+        assert(locks.length === 3);
+      });
+
+      describe('partial remove from off the end', async () => {
+        before('clean', async () => {
+          await systems()
+            .Core.connect(user1)
+            .cleanExpiredLocks(accountId, collateralAddress(), 1, 10000);
+        });
+
+        it('only one additional expired lock could be removed', async () => {
+          const locks = await systems().Core.getLocks(accountId, collateralAddress(), 0, 0);
+          assert(locks.length === 2);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
fixes a number of issues identified during the audit related to collateral locks:

* `cleanExpiredLocks` was not correctly limiting its iteration
* `createLock` was not validating inputs enough (ex. creating lock in the past)
* lack of emitted events

found as part of the OZ audit