### PR TITLE
fix account permissions not fully cleared on transfer

### DIFF
--- a/protocol/synthetix/contracts/modules/core/AccountModule.sol
+++ b/protocol/synthetix/contracts/modules/core/AccountModule.sol
@@ -71,10 +71,10 @@ contract AccountModule is IAccountModule {
         Account.Data storage account = Account.load(accountId);
 
         address[] memory permissionedAddresses = account.rbac.permissionAddresses.values();
-        for (uint i = 0;i < permissionedAddresses.length;i++) {
+        for (uint i = 0; i < permissionedAddresses.length; i++) {
             account.rbac.revokeAllPermissions(permissionedAddresses[i]);
         }
-        
+
         account.rbac.setOwner(to);
     }
 

--- a/protocol/synthetix/contracts/modules/core/AccountModule.sol
+++ b/protocol/synthetix/contracts/modules/core/AccountModule.sol
@@ -70,7 +70,11 @@ contract AccountModule is IAccountModule {
 
         Account.Data storage account = Account.load(accountId);
 
-        account.rbac.revokeAllPermissions(account.rbac.owner);
+        address[] memory permissionedAddresses = account.rbac.permissionAddresses.values();
+        for (uint i = 0;i < permissionedAddresses.length;i++) {
+            account.rbac.revokeAllPermissions(permissionedAddresses[i]);
+        }
+        
         account.rbac.setOwner(to);
     }
 

--- a/protocol/synthetix/contracts/storage/AccountRBAC.sol
+++ b/protocol/synthetix/contracts/storage/AccountRBAC.sol
@@ -95,13 +95,20 @@ library AccountRBAC {
 
     /**
      * @dev Revokes all permissions for the specified target address.
+     * @notice only removes permissions for the given address, not for the entire account
      */
     function revokeAllPermissions(Data storage self, address target) internal {
         bytes32[] memory permissions = self.permissions[target].values();
 
-        for (uint256 i = 1; i <= permissions.length; i++) {
-            revokePermission(self, permissions[i - 1], target);
+        if (permissions.length == 0) {
+            return;
         }
+
+        for (uint256 i = 0; i < permissions.length; i++) {
+            self.permissions[target].remove(permissions[i]);
+        }
+
+        self.permissionAddresses.remove(target);
     }
 
     /**

--- a/protocol/synthetix/test/integration/modules/core/AccountModule/AccountModule.transfer.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/AccountModule/AccountModule.transfer.test.ts
@@ -21,9 +21,15 @@ describe('AccountModule', function () {
     });
 
     before('grant some permissions', async () => {
-      await systems().Core.connect(user1).grantPermission(1, Permissions.REWARDS, await user1.getAddress());
-      await systems().Core.connect(user1).grantPermission(1, Permissions.WITHDRAW, await user3.getAddress());
-      await systems().Core.connect(user1).grantPermission(1, Permissions.DELEGATE, await user3.getAddress());
+      await systems()
+        .Core.connect(user1)
+        .grantPermission(1, Permissions.REWARDS, await user1.getAddress());
+      await systems()
+        .Core.connect(user1)
+        .grantPermission(1, Permissions.WITHDRAW, await user3.getAddress());
+      await systems()
+        .Core.connect(user1)
+        .grantPermission(1, Permissions.DELEGATE, await user3.getAddress());
     });
 
     describe('when an account NFT is transferred', function () {

--- a/protocol/synthetix/test/integration/modules/core/AccountModule/AccountModule.transfer.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/AccountModule/AccountModule.transfer.test.ts
@@ -9,14 +9,21 @@ describe('AccountModule', function () {
 
   let user1: ethers.Signer;
   let user2: ethers.Signer;
+  let user3: ethers.Signer;
 
   describe('AccountModule - Account transfering', function () {
     before('identify signers', async () => {
-      [, user1, user2] = signers();
+      [, user1, user2, user3] = signers();
     });
 
     before('create the account', async function () {
       await systems().Core.connect(user1).createAccount(1);
+    });
+
+    before('grant some permissions', async () => {
+      await systems().Core.connect(user1).grantPermission(1, Permissions.REWARDS, await user1.getAddress());
+      await systems().Core.connect(user1).grantPermission(1, Permissions.WITHDRAW, await user3.getAddress());
+      await systems().Core.connect(user1).grantPermission(1, Permissions.DELEGATE, await user3.getAddress());
     });
 
     describe('when an account NFT is transferred', function () {
@@ -45,6 +52,17 @@ describe('AccountModule', function () {
       it('shows the previous owner permissions have been revoked', async () => {
         assert.equal(
           await systems().Core.hasPermission(1, Permissions.DELEGATE, await user1.getAddress()),
+          false
+        );
+      });
+
+      it('shows that other accounts permissions have been revoked', async () => {
+        assert.equal(
+          await systems().Core.hasPermission(1, Permissions.WITHDRAW, await user3.getAddress()),
+          false
+        );
+        assert.equal(
+          await systems().Core.hasPermission(1, Permissions.ADMIN, await user3.getAddress()),
           false
         );
       });


### PR DESCRIPTION
All permissions granted by the previous owner should be cleared on account transfer

identified in oz audit