### PR TITLE
fix reward distributor removal should be permanent

### DIFF
--- a/protocol/synthetix/contracts/interfaces/IRewardsManagerModule.sol
+++ b/protocol/synthetix/contracts/interfaces/IRewardsManagerModule.sol
@@ -77,6 +77,14 @@ interface IRewardsManagerModule {
 
     /**
      * @notice Called by pool owner to remove a registered rewards distributor for vault participants.
+     * WARNING: if you remove a rewards distributor, the same address can never be re-registered again. If you
+     * simply want to turn off
+     * rewards, call `distributeRewards` with 0 emission. If you need to completely reset the rewards distributor
+     * again, create a new rewards distributor at a new address and register the new one.
+     * This function is provided since the number of rewards distributors added to an account is finite,
+     * so you can remove an unused rewards distributor if need be.
+     * NOTE: unclaimed rewards can still be claimed after a rewards distributor is removed (though any
+     * rewards-over-time will be halted)
      * @param poolId The id of the pool whose rewards are to be managed by the specified distributor.
      * @param collateralType The address of the collateral used in the pool's rewards.
      * @param distributor The address of the reward distributor to be registered.

--- a/protocol/synthetix/contracts/modules/core/RewardsManagerModule.sol
+++ b/protocol/synthetix/contracts/modules/core/RewardsManagerModule.sol
@@ -68,6 +68,9 @@ contract RewardsManagerModule is IRewardsManagerModule {
         if (rewardIds.contains(rewardId)) {
             revert ParameterError.InvalidParameter("distributor", "is already registered");
         }
+        if (address(pool.vaults[collateralType].rewards[rewardId].distributor) != address(0)) {
+            revert ParameterError.InvalidParameter("distributor", "cant be re-registered");
+        }
 
         rewardIds.add(rewardId);
         if (distributor == address(0)) {
@@ -153,30 +156,26 @@ contract RewardsManagerModule is IRewardsManagerModule {
         Vault.Data storage vault = Pool.load(poolId).vaults[collateralType];
         bytes32 rewardId = keccak256(abi.encode(poolId, collateralType, distributor));
 
-        if (!vault.rewardIds.contains(rewardId)) {
+        if (address(vault.rewards[rewardId].distributor) != distributor) {
             revert ParameterError.InvalidParameter("invalid-params", "reward is not found");
         }
 
-        uint256 reward = vault.updateReward(accountId, rewardId);
+        uint256 rewardAmount = vault.updateReward(accountId, rewardId);
 
-        vault.rewards[rewardId].claimStatus[accountId].pendingSendD18 = 0;
-        vault.rewards[rewardId].distributor.payout(
-            accountId,
-            poolId,
-            collateralType,
-            msg.sender,
-            reward
-        );
+        RewardDistribution.Data storage reward = vault.rewards[rewardId];
+
+        reward.claimStatus[accountId].pendingSendD18 = 0;
+        reward.distributor.payout(accountId, poolId, collateralType, msg.sender, rewardAmount);
 
         emit RewardsClaimed(
             accountId,
             poolId,
             collateralType,
             address(vault.rewards[rewardId].distributor),
-            reward
+            rewardAmount
         );
 
-        return reward;
+        return rewardAmount;
     }
 
     /**
@@ -245,7 +244,16 @@ contract RewardsManagerModule is IRewardsManagerModule {
         if (distributor == address(0)) {
             revert ParameterError.InvalidParameter("distributor", "must be non-zero");
         }
-        pool.vaults[collateralType].rewards[rewardId].distributor = IRewardDistributor(address(0));
+
+        RewardDistribution.Data storage reward = pool.vaults[collateralType].rewards[rewardId];
+
+        // ensure rewards emission is stopped (users can still come in to claim rewards after the fact)
+        reward.distribute(
+            pool.vaults[collateralType].currentEpoch().accountsDebtDistribution,
+            0,
+            0,
+            0
+        );
 
         emit RewardsDistributorRemoved(poolId, collateralType, distributor);
     }

--- a/protocol/synthetix/test/integration/modules/core/RewardsManagerModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/RewardsManagerModule.test.ts
@@ -586,24 +586,42 @@ describe('RewardsManagerModule', function () {
       );
     });
 
-    it('pool owner can remove reward distributor', async () => {
-      await systems()
-        .Core.connect(owner)
-        .removeRewardsDistributor(poolId, collateralAddress(), RewardDistributor.address);
-    });
+    describe('successful invoke', async () => {
+      before('remove', async () => {
+        await systems()
+          .Core.connect(owner)
+          .removeRewardsDistributor(poolId, collateralAddress(), RewardDistributor.address);
+      });
 
-    it('make sure distributor is removed', async () => {
-      await assertRevert(
-        RewardDistributor.connect(owner).distributeRewards(
-          poolId,
-          collateralAddress(),
-          rewardAmount,
-          0, // timestamp
-          0
-        ),
-        'InvalidParameter("poolId-collateralType-distributor", "reward is not registered")',
-        systems().Core
-      );
+      it('make sure distributor is removed', async () => {
+        await assertRevert(
+          RewardDistributor.connect(owner).distributeRewards(
+            poolId,
+            collateralAddress(),
+            rewardAmount,
+            0, // timestamp
+            0
+          ),
+          'InvalidParameter("poolId-collateralType-distributor", "reward is not registered")',
+          systems().Core
+        );
+      });
+
+      it('can still claim accumulated rewards', async () => {
+        await systems()
+          .Core.connect(user1)
+          .claimRewards(accountId, poolId, collateralAddress(), RewardDistributor.address);
+      });
+
+      it('cannot be re-registered', async () => {
+        await assertRevert(
+          systems()
+            .Core.connect(owner)
+            .registerRewardsDistributor(poolId, collateralAddress(), RewardDistributor.address),
+          'InvalidParameter("distributor", "cant be re-registered")',
+          systems().Core
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
a rewards distributor being re-registered after removal can lead to dangerous edge cases (either within the system or with the associated rewards distributor). To prevent this, only allow rewards distributors to be registered once. Also, fix some edge cases to make sure users can claim entitled rewards even after a rewards distributor has been removed.

cc @Rickk137 