### PR TITLE
fix credit capacity handling with market deposited collateral

### DIFF
--- a/protocol/synthetix/contracts/modules/core/MarketManagerModule.sol
+++ b/protocol/synthetix/contracts/modules/core/MarketManagerModule.sol
@@ -53,9 +53,10 @@ contract MarketManagerModule is IMarketManagerModule {
      * @inheritdoc IMarketManagerModule
      */
     function getWithdrawableMarketUsd(uint128 marketId) public view override returns (uint256) {
-        return
-            Market.load(marketId).creditCapacityD18 +
-            Market.load(marketId).getDepositedCollateralValue();
+        int256 withdrawable = Market.load(marketId).creditCapacityD18 +
+            Market.load(marketId).getDepositedCollateralValue().toInt();
+
+        return withdrawable < 0 ? 0 : withdrawable.toUint();
     }
 
     /**
@@ -118,7 +119,7 @@ contract MarketManagerModule is IMarketManagerModule {
         ITokenModule usdToken = AssociatedSystem.load(_USD_TOKEN).asToken();
 
         // Adjust accounting.
-        market.creditCapacityD18 += amount.to128();
+        market.creditCapacityD18 += amount.toInt().to128();
         market.netIssuanceD18 -= amount.toInt().to128();
 
         // Burn the incoming USD.
@@ -145,7 +146,7 @@ contract MarketManagerModule is IMarketManagerModule {
             revert NotEnoughLiquidity(marketId, amount);
 
         // Adjust accounting.
-        marketData.creditCapacityD18 -= amount.to128();
+        marketData.creditCapacityD18 -= amount.toInt().to128();
         marketData.netIssuanceD18 += amount.toInt().to128();
 
         // Mint the requested USD.

--- a/protocol/synthetix/contracts/storage/Market.sol
+++ b/protocol/synthetix/contracts/storage/Market.sol
@@ -75,8 +75,11 @@ library Market {
          *
          * The Market's credit capacity also has a dependency on the external market reported debt as it will respond to that debt (and hence change the credit capacity if it increases or decreases)
          *
+         * The credit capacity can go negative if all of the collateral provided by pools is exhausted, and there is market provided collateral available to consume. in this case, the debt is still being
+         * appropriately assigned, but the market has a dynamic cap based on deposited collateral types.
+         *
          */
-        uint128 creditCapacityD18;
+        int128 creditCapacityD18;
         /**
          * @dev The total balance that the market had the last time that its debt was distributed.
          *
@@ -243,12 +246,12 @@ library Market {
         Data storage self,
         uint256 creditCapacitySharesD18,
         int256 maxShareValueD18
-    ) internal view returns (uint256 contributionD18) {
+    ) internal view returns (int256 contributionD18) {
         // Determine how much the current value per share deviates from the maximum.
         uint256 deltaValuePerShareD18 = (maxShareValueD18 -
             self.poolsDebtDistribution.getValuePerShare()).toUint();
 
-        return deltaValuePerShareD18.mulDecimal(creditCapacitySharesD18);
+        return deltaValuePerShareD18.mulDecimal(creditCapacitySharesD18).toInt();
     }
 
     /**
@@ -256,7 +259,7 @@ library Market {
      *
      */
     function isCapacityLocked(Data storage self) internal view returns (bool) {
-        return self.creditCapacityD18 < getLockedCreditCapacity(self);
+        return self.creditCapacityD18 < getLockedCreditCapacity(self).toInt();
     }
 
     /**

--- a/protocol/synthetix/test/integration/modules/core/MarketCollateralModule/MarketCollateralModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/MarketCollateralModule/MarketCollateralModule.test.ts
@@ -154,6 +154,20 @@ describe('MarketCollateralModule', function () {
             systems().Core
           );
         });
+
+        describe('when withdrawing all usd', async () => {
+          let withdrawable: ethers.BigNumber;
+          before('do it', async () => {
+            withdrawable = await systems().Core.getWithdrawableMarketUsd(marketId());
+            // because of the way the mock market works we must first increase reported debt
+            await MockMarket().connect(user1).setReportedDebt(withdrawable);
+          });
+
+          it('should be able to withdrawn', async () => {
+            // now actually withdraw
+            await (await MockMarket().connect(user1).sellSynth(withdrawable)).wait();
+          });
+        });
       });
     });
 


### PR DESCRIPTION
when there is market deposited collateral, it should be possible for creditCapacity to go negative in order to protect against overruns when more collateral is withdrawn from the market than capacity provided by the pools.

when there is no deposited collateral, then creditcapacity functions same as before.

found as part of oz audit