### PR TITLE
handle `false` response from reward distributor `payout`

### DIFF
--- a/protocol/synthetix/contracts/interfaces/IRewardsManagerModule.sol
+++ b/protocol/synthetix/contracts/interfaces/IRewardsManagerModule.sol
@@ -6,6 +6,14 @@ pragma solidity >=0.8.11 <0.9.0;
  */
 interface IRewardsManagerModule {
     /**
+     * @notice Emitted when a reward distributor returns `false` from `payout` indicating a problem
+     * preventing the payout from being executed. In this case, it is advised to check with the
+     * project maintainers, and possibly try again in the future.
+     * @param distributor the distributor which originated the issue
+     */
+    error RewardUnavailable(address distributor);
+
+    /**
      * @notice Emitted when the pool owner or an existing reward distributor sets up rewards for vault participants.
      * @param poolId The id of the pool on which rewards were distributed.
      * @param collateralType The collateral type of the pool on which rewards were distributed.

--- a/protocol/synthetix/contracts/interfaces/external/IRewardDistributor.sol
+++ b/protocol/synthetix/contracts/interfaces/external/IRewardDistributor.sol
@@ -9,6 +9,7 @@ interface IRewardDistributor is IERC165 {
     function name() external returns (string memory);
 
     /// @notice This function should revert if msg.sender is not the Synthetix CoreProxy address.
+    /// @return whether or not the payout was executed
     function payout(
         uint128 accountId,
         uint128 poolId,

--- a/protocol/synthetix/contracts/mocks/RewardDistributorMock.sol
+++ b/protocol/synthetix/contracts/mocks/RewardDistributorMock.sol
@@ -12,6 +12,8 @@ contract RewardDistributorMock is IRewardDistributor {
     address private _token;
     string private _name;
 
+    bool public shouldFailPayout;
+
     function initialize(address rewardManager, address token_, string memory name_) public {
         _rewardManager = rewardManager;
         _token = token_;
@@ -26,6 +28,10 @@ contract RewardDistributorMock is IRewardDistributor {
         return _token;
     }
 
+    function setShouldFailPayout(bool fail) external {
+        shouldFailPayout = fail;
+    }
+
     function payout(
         uint128,
         uint128,
@@ -38,7 +44,7 @@ contract RewardDistributorMock is IRewardDistributor {
             revert AccessError.Unauthorized(msg.sender);
         }
         IERC20(_token).transfer(sender, amount);
-        return true;
+        return !shouldFailPayout;
     }
 
     function distributeRewards(

--- a/protocol/synthetix/contracts/modules/core/RewardsManagerModule.sol
+++ b/protocol/synthetix/contracts/modules/core/RewardsManagerModule.sol
@@ -160,13 +160,17 @@ contract RewardsManagerModule is IRewardsManagerModule {
         uint256 reward = vault.updateReward(accountId, rewardId);
 
         vault.rewards[rewardId].claimStatus[accountId].pendingSendD18 = 0;
-        vault.rewards[rewardId].distributor.payout(
+        bool success = vault.rewards[rewardId].distributor.payout(
             accountId,
             poolId,
             collateralType,
             msg.sender,
             reward
         );
+
+        if (!success) {
+            revert RewardUnavailable(distributor);
+        }
 
         emit RewardsClaimed(
             accountId,

--- a/protocol/synthetix/test/integration/modules/core/RewardsManagerModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/RewardsManagerModule.test.ts
@@ -492,6 +492,26 @@ describe('RewardsManagerModule', function () {
           .claimRewards(accountId, poolId, collateralAddress(), RewardDistributor.address)
     );
 
+    describe('when distributor payout returns false', async () => {
+      before('set fail', async () => {
+        await RewardDistributor.connect(owner).setShouldFailPayout(true);
+      });
+
+      after('set fail', async () => {
+        await RewardDistributor.connect(owner).setShouldFailPayout(false);
+      });
+
+      it('reverts', async () => {
+        await assertRevert(
+          systems()
+            .Core.connect(user1)
+            .claimRewards(accountId, poolId, collateralAddress(), RewardDistributor.address),
+          `RewardUnavailable("${RewardDistributor.address}")`,
+          systems().Core
+        );
+      });
+    });
+
     describe('successful claim', () => {
       before('claim', async () => {
         await systems()


### PR DESCRIPTION
if a reward distributor returns false, it means something went wrong with the payout, but the distributor doesn't want to revert itself for some reason. ensure that this case is properly handled.

part of oz audit