### PR TITLE
N-15: gas optimizations

### DIFF
--- a/markets/legacy-market/contracts/LegacyMarket.sol
+++ b/markets/legacy-market/contracts/LegacyMarket.sol
@@ -157,6 +157,9 @@ contract LegacyMarket is ILegacyMarket, Ownable, UUPSImplementation, IMarket {
      * @dev Migrates {staker} from V2 to {accountId} in V3.
      */
     function _migrate(address staker, uint128 accountId) internal {
+        // start building the staker's v3 account
+        v3System.createAccount(accountId);
+
         // find out how much debt is on the v2x system
         tmpLockedDebt = reportedDebt(marketId);
 
@@ -173,9 +176,6 @@ contract LegacyMarket is ILegacyMarket, Ownable, UUPSImplementation, IMarket {
 
         // transfer all collateral from the user to our account
         (uint256 collateralMigrated, uint256 debtValueMigrated) = _gatherFromV2(staker);
-
-        // start building the staker's v3 account
-        v3System.createAccount(accountId);
 
         // put the collected collateral into their v3 account
         v3System.deposit(accountId, address(oldSynthetix), collateralMigrated);

--- a/protocol/synthetix/contracts/modules/core/CollateralModule.sol
+++ b/protocol/synthetix/contracts/modules/core/CollateralModule.sol
@@ -49,11 +49,6 @@ contract CollateralModule is ICollateralModule {
 
         address self = address(this);
 
-        uint256 allowance = IERC20(collateralType).allowance(depositFrom, self);
-        if (allowance < tokenAmount) {
-            revert IERC20.InsufficientAllowance(tokenAmount, allowance);
-        }
-
         collateralType.safeTransferFrom(depositFrom, self, tokenAmount);
 
         account.collaterals[collateralType].increaseAvailableCollateral(

--- a/protocol/synthetix/contracts/modules/core/CollateralModule.sol
+++ b/protocol/synthetix/contracts/modules/core/CollateralModule.sol
@@ -49,6 +49,11 @@ contract CollateralModule is ICollateralModule {
 
         address self = address(this);
 
+        uint256 allowance = IERC20(collateralType).allowance(depositFrom, self);
+        if (allowance < tokenAmount) {
+            revert IERC20.InsufficientAllowance(tokenAmount, allowance);
+        }
+
         collateralType.safeTransferFrom(depositFrom, self, tokenAmount);
 
         account.collaterals[collateralType].increaseAvailableCollateral(

--- a/protocol/synthetix/contracts/modules/core/LiquidationModule.sol
+++ b/protocol/synthetix/contracts/modules/core/LiquidationModule.sol
@@ -161,7 +161,7 @@ contract LiquidationModule is ILiquidationModule {
             );
         }
 
-        uint256 vaultDebt = rawVaultDebt < 0 ? 0 : rawVaultDebt.toUint();
+        uint256 vaultDebt = rawVaultDebt.toUint();
 
         if (vaultDebt <= maxUsd) {
             // Conduct a full vault liquidation

--- a/protocol/synthetix/contracts/modules/core/MarketCollateralModule.sol
+++ b/protocol/synthetix/contracts/modules/core/MarketCollateralModule.sol
@@ -32,12 +32,14 @@ contract MarketCollateralModule is IMarketCollateralModule {
         FeatureFlag.ensureAccessToFeature(_DEPOSIT_MARKET_COLLATERAL_FEATURE_FLAG);
         Market.Data storage marketData = Market.load(marketId);
 
+        // Ensure the sender is the market address associated with the specified marketId
+        if (msg.sender != marketData.marketAddress) {
+            revert AccessError.Unauthorized(msg.sender);
+        }
+
         uint256 systemAmount = CollateralConfiguration
             .load(collateralType)
             .convertTokenToSystemAmount(tokenAmount);
-
-        // Ensure the sender is the market address associated with the specified marketId
-        if (msg.sender != marketData.marketAddress) revert AccessError.Unauthorized(msg.sender);
 
         uint256 maxDepositable = marketData.maximumDepositableD18[collateralType];
         uint256 depositedCollateralEntryIndex = _findOrCreateDepositEntryIndex(

--- a/protocol/synthetix/contracts/storage/Distribution.sol
+++ b/protocol/synthetix/contracts/storage/Distribution.sol
@@ -87,10 +87,7 @@ library Distribution {
         self.totalSharesD18 = self.totalSharesD18 + sharesUint128D18 - actor.sharesD18;
 
         actor.sharesD18 = sharesUint128D18;
-
-        actor.lastValuePerShareD27 = newActorSharesD18 == 0
-            ? SafeCastI128.zero()
-            : self.valuePerShareD27;
+        _updateLastValuePerShare(self, actor, newActorSharesD18);
     }
 
     /**
@@ -101,7 +98,8 @@ library Distribution {
         Data storage self,
         bytes32 actorId
     ) internal returns (int valueChangeD18) {
-        return setActorShares(self, actorId, getActorShares(self, actorId));
+        DistributionActor.Data storage actor = self.actorInfo[actorId];
+        return _updateLastValuePerShare(self, actor, actor.sharesD18);
     }
 
     /**
@@ -117,11 +115,7 @@ library Distribution {
         Data storage self,
         bytes32 actorId
     ) internal view returns (int valueChangeD18) {
-        DistributionActor.Data storage actor = self.actorInfo[actorId];
-        int256 deltaValuePerShareD27 = self.valuePerShareD27 - actor.lastValuePerShareD27;
-
-        int256 changedValueD45 = deltaValuePerShareD27 * actor.sharesD18.toInt();
-        valueChangeD18 = changedValueD45 / DecimalMath.UNIT_PRECISE_INT;
+        return _getActorValueChange(self, self.actorInfo[actorId]);
     }
 
     /**
@@ -141,5 +135,27 @@ library Distribution {
      */
     function getValuePerShare(Data storage self) internal view returns (int) {
         return self.valuePerShareD27.to256().downscale(DecimalMath.PRECISION_FACTOR);
+    }
+
+    function _updateLastValuePerShare(
+        Data storage self,
+        DistributionActor.Data storage actor,
+        uint256 newActorShares
+    ) private returns (int valueChangeD18) {
+        valueChangeD18 = _getActorValueChange(self, actor);
+
+        actor.lastValuePerShareD27 = newActorShares == 0
+            ? SafeCastI128.zero()
+            : self.valuePerShareD27;
+    }
+
+    function _getActorValueChange(
+        Data storage self,
+        DistributionActor.Data storage actor
+    ) private view returns (int valueChangeD18) {
+        int256 deltaValuePerShareD27 = self.valuePerShareD27 - actor.lastValuePerShareD27;
+
+        int256 changedValueD45 = deltaValuePerShareD27 * actor.sharesD18.toInt();
+        valueChangeD18 = changedValueD45 / DecimalMath.UNIT_PRECISE_INT;
     }
 }

--- a/protocol/synthetix/contracts/storage/Market.sol
+++ b/protocol/synthetix/contracts/storage/Market.sol
@@ -214,6 +214,10 @@ library Market {
             CollateralConfiguration.Data storage collateralConfiguration = CollateralConfiguration
                 .load(entry.collateralType);
 
+            if (entry.amountD18 == 0) {
+                continue;
+            }
+
             uint256 priceD18 = CollateralConfiguration.getCollateralPrice(collateralConfiguration);
 
             totalDepositedCollateralValueD18 += priceD18.mulDecimal(entry.amountD18);

--- a/protocol/synthetix/contracts/storage/RewardDistribution.sol
+++ b/protocol/synthetix/contracts/storage/RewardDistribution.sol
@@ -86,7 +86,7 @@ library RewardDistribution {
         uint256 curTime = block.timestamp;
 
         // Unlocks the entry's distributed amount into its value per share.
-        diffD18 += updateEntry(self, dist.totalSharesD18);
+        diffD18 += updateEntry(self, totalSharesD18);
 
         // If the current time is past the end of the entry's duration,
         // update any rewards which may have accrued since last run.
@@ -108,7 +108,7 @@ library RewardDistribution {
             // The amount is actually the amount distributed already *plus* whatever has been specified now.
             self.lastUpdate = 0;
 
-            diffD18 += updateEntry(self, dist.totalSharesD18);
+            diffD18 += updateEntry(self, totalSharesD18);
         }
     }
 

--- a/protocol/synthetix/contracts/storage/ScalableMapping.sol
+++ b/protocol/synthetix/contracts/storage/ScalableMapping.sol
@@ -111,7 +111,7 @@ library ScalableMapping {
      */
     function get(Data storage self, bytes32 actorId) internal view returns (uint256 valueD18) {
         uint256 totalSharesD18 = self.totalSharesD18;
-        if (self.totalSharesD18 == 0) {
+        if (totalSharesD18 == 0) {
             return 0;
         }
 


### PR DESCRIPTION
- [x] When depositing market collateral, authorized access is checked after converting the
tokenAmount into systemAmount (18 decimals). This performs an external call to
check the token decimals which can be avoided if authorized access is checked first.
- [x] Line 159 in the LiquidationModule is redundant, since rawVaultDebt can never
be negative at this point because isLiquidatable would have returned false and reverted
earlier. It can be safely casted to uint without checking whether it is a non-negative
value.
- [x] In line 77 of RewardDistribution , the contract is first defining the variable
totalSharesD18 but then is not using it in line 89.
- [x] When calculating the total deposited collateral value in USD for a Market , it loops
through all DepositedCollateral entries and queries the current USD price through
the Oracle. Consider first checking whether the amount of collateral is larger than zero, in
order to avoid querying the Oracle in that case.
- [x] The accumulateActor function is called as a ticker from several parts of the system,
with the goal of updating a specific actor's last value per share and recovering the value
change since the last interaction. In order to update this value in storage, the actor's number of shares is read from storage and re-updated to the same value in order to
leverage the setActorShares logic which includes updating this inner value
( lastValuePerShareD27 ). Consider isolating this piece of logic in a separate internal
function so that it can be reused without the need for two unnecessary SSTORE
opcodes (updating actor's shares and total shares within the Distribution since
those values have not changed).
- [x] In the ScalableMapping storage at the get function, the self.totalSharesD18
is first read, but then it is read again internally in the totalAmount function called
inside.
- [x] In the createLock function of the CollateralModule contract, the account is first
loaded internally in the onlyWithPermission function, and then again in the next line.
In the RewardDistribution storage, the block.timestamp is first casted to
int256 , then to int128 to be stored in the curTime variable, and then it is
converted back again to uint256 in the if statement.
- [x] When calling distribute within RewardDistribution , the first step is to read total
shares from storage and keep the value on the local totalSharesD18 variable.
However, it is then read again from storage instead of using the cached value.
- [x] When migrating a position from v2x within LegacyMarket , consider creating the
account on V3 before attempting to gather all assets from v2x, including vesting rewards,
since the selected accountId might already be used, saving the user some gas by
reverting early if this is the case.