### PR TITLE
(M-4) Add storage slot validation on all contracts

### DIFF
--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -23,10 +23,5 @@ jobs:
       # forgot to update it.
       - name: Check package-lock.json was correctly submmitted by the user
         run: |
-          cp package-lock.json package-lock.original.json
           npm i --package-lock-only
-      - uses: GuillaumeFalourd/diff-action@v1
-        with:
-          first_file_path: package-lock.json
-          second_file_path: package-lock.original.json
-          expected_result: PASSED
+          git diff --exit-code -- package-lock.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,10 +66,10 @@ jobs:
         name: Execute size command
         run: npm run --workspace=${{ matrix.workspace }} size-contracts
       - if: matrix.storage-check
-        name: Check storage.dump.sol
+        name: Check storage.dump.sol is up-to-date
         run: |
           npm explore ${{ matrix.workspace }}
-          git diff --exit-code storage.dump.sol
+          git diff --exit-code -- storage.dump.sol
       - name: Execute tests
         run: REPORT_GAS=true npm run --workspace=${{ matrix.workspace }} coverage
       - if: ${{ matrix.coverage-file }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,11 +38,13 @@ jobs:
             coverage-file: utils/router/coverage/lcov.info
           - package: sample-project
             workspace: "@synthetixio/sample-project"
+            storage-check: true
           - package: oracle-manager
             workspace: "@synthetixio/oracle-manager"
           - package: main
             workspace: "@synthetixio/main"
             size-contracts: true
+            storage-check: true
     steps:
       - run: mkdir -p ~/.local/share/cannon && echo '{"ipfsUrl":"http://localhost:5001"}' > ~/.local/share/cannon/settings.json
       - name: Install Foundry (Cannon)
@@ -60,9 +62,14 @@ jobs:
           run_daemon: true
       - run: npm ci
       - run: npm run build
-      - if: ${{ matrix.size-contracts }}
+      - if: matrix.size-contracts
         name: Execute size command
         run: npm run --workspace=${{ matrix.workspace }} size-contracts
+      - if: matrix.storage-check
+        name: Check storage.dump.sol
+        run: |
+          npm explore ${{ matrix.workspace }}
+          git diff --exit-code storage.dump.sol
       - name: Execute tests
         run: REPORT_GAS=true npm run --workspace=${{ matrix.workspace }} coverage
       - if: ${{ matrix.coverage-file }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,13 +38,11 @@ jobs:
             coverage-file: utils/router/coverage/lcov.info
           - package: sample-project
             workspace: "@synthetixio/sample-project"
-            storage-check: true
           - package: oracle-manager
             workspace: "@synthetixio/oracle-manager"
           - package: main
             workspace: "@synthetixio/main"
             size-contracts: true
-            storage-check: true
     steps:
       - run: mkdir -p ~/.local/share/cannon && echo '{"ipfsUrl":"http://localhost:5001"}' > ~/.local/share/cannon/settings.json
       - name: Install Foundry (Cannon)
@@ -65,11 +63,8 @@ jobs:
       - if: matrix.size-contracts
         name: Execute size command
         run: npm run --workspace=${{ matrix.workspace }} size-contracts
-      - if: matrix.storage-check
-        name: Check storage.dump.sol is up-to-date
-        run: |
-          npm explore ${{ matrix.workspace }}
-          git diff --exit-code -- storage.dump.sol
+      - name: Check storage.dump.sol is up-to-date
+        run: npm explore ${{ matrix.workspace }} -- git diff --exit-code -- storage.dump.sol
       - name: Execute tests
         run: REPORT_GAS=true npm run --workspace=${{ matrix.workspace }} coverage
       - if: ${{ matrix.coverage-file }}

--- a/markets/spot-market/storage.dump.sol
+++ b/markets/spot-market/storage.dump.sol
@@ -51,43 +51,6 @@ library ERC20Storage {
     }
 }
 
-// @custom:artifact @synthetixio/core-contracts/contracts/token/ERC721EnumerableStorage.sol:ERC721EnumerableStorage
-library ERC721EnumerableStorage {
-    bytes32 private constant _SLOT_ERC721_ENUMERABLE_STORAGE = keccak256(abi.encode("io.synthetix.core-contracts.ERC721Enumerable"));
-    struct Data {
-        mapping(uint256 => uint256) ownedTokensIndex;
-        mapping(uint256 => uint256) allTokensIndex;
-        mapping(address => mapping(uint256 => uint256)) ownedTokens;
-        uint256[] allTokens;
-    }
-    function load() internal pure returns (Data storage store) {
-        bytes32 s = _SLOT_ERC721_ENUMERABLE_STORAGE;
-        assembly {
-            store.slot := s
-        }
-    }
-}
-
-// @custom:artifact @synthetixio/core-contracts/contracts/token/ERC721Storage.sol:ERC721Storage
-library ERC721Storage {
-    bytes32 private constant _SLOT_ERC721_STORAGE = keccak256(abi.encode("io.synthetix.core-contracts.ERC721"));
-    struct Data {
-        string name;
-        string symbol;
-        string baseTokenURI;
-        mapping(uint256 => address) ownerOf;
-        mapping(address => uint256) balanceOf;
-        mapping(uint256 => address) tokenApprovals;
-        mapping(address => mapping(address => bool)) operatorApprovals;
-    }
-    function load() internal pure returns (Data storage store) {
-        bytes32 s = _SLOT_ERC721_STORAGE;
-        assembly {
-            store.slot := s
-        }
-    }
-}
-
 // @custom:artifact @synthetixio/core-contracts/contracts/utils/DecimalMath.sol:DecimalMath
 library DecimalMath {
     uint256 public constant UNIT = 1e18;
@@ -112,11 +75,6 @@ library SetUtil {
         bytes32[] _values;
         mapping(bytes32 => uint) _positions;
     }
-}
-
-// @custom:artifact @synthetixio/core-modules/contracts/modules/NftModule.sol:NftModule
-contract NftModule {
-    bytes32 internal constant _INITIALIZED_NAME = "NftModule";
 }
 
 // @custom:artifact @synthetixio/core-modules/contracts/storage/AssociatedSystem.sol:AssociatedSystem
@@ -158,23 +116,12 @@ library FeatureFlag {
     struct Data {
         bytes32 name;
         bool allowAll;
+        bool denyAll;
         SetUtil.AddressSet permissionedAddresses;
+        address[] deniers;
     }
     function load(bytes32 featureName) internal pure returns (Data storage store) {
         bytes32 s = keccak256(abi.encode("io.synthetix.core-modules.FeatureFlag", featureName));
-        assembly {
-            store.slot := s
-        }
-    }
-}
-
-// @custom:artifact @synthetixio/core-modules/contracts/storage/Initialized.sol:Initialized
-library Initialized {
-    struct Data {
-        bool initialized;
-    }
-    function load(bytes32 id) internal pure returns (Data storage store) {
-        bytes32 s = keccak256(abi.encode("io.synthetix.code-modules.Initialized", id));
         assembly {
             store.slot := s
         }
@@ -198,10 +145,10 @@ library NodeDefinition {
         bytes parameters;
         bytes32[] parents;
     }
-    function load(bytes32 id) internal pure returns (Data storage data) {
+    function load(bytes32 id) internal pure returns (Data storage node) {
         bytes32 s = keccak256(abi.encode("io.synthetix.oracle-manager.Node", id));
         assembly {
-            data.slot := s
+            node.slot := s
         }
     }
 }
@@ -231,48 +178,62 @@ interface IPythVerifier {
     }
 }
 
+// @custom:artifact contracts/modules/AsyncOrderModule.sol:AsyncOrderModule
+contract AsyncOrderModule {
+    int256 public constant PRECISION = 18;
+}
+
 // @custom:artifact contracts/modules/SpotMarketFactoryModule.sol:SpotMarketFactoryModule
 contract SpotMarketFactoryModule {
     bytes32 private constant _CREATE_SYNTH_FEATURE_FLAG = "createSynth";
 }
 
-// @custom:artifact contracts/storage/AsyncOrderClaim.sol:AsyncOrderClaim
-library AsyncOrderClaim {
+// @custom:artifact contracts/storage/AsyncOrder.sol:AsyncOrder
+library AsyncOrder {
     struct Data {
-        SpotMarketFactory.TransactionType orderType;
-        uint256 amountEscrowed;
-        uint256 settlementStrategyId;
-        uint256 settlementTime;
-        int256 utilizationDelta;
-        uint256 cancellationFee;
-    }
-}
-
-// @custom:artifact contracts/storage/AsyncOrderConfiguration.sol:AsyncOrderConfiguration
-library AsyncOrderConfiguration {
-    enum SettlementStrategyType {
-        ONCHAIN,
-        CHAINLINK,
-        PYTH
-    }
-    struct Data {
-        mapping(uint256 => AsyncOrderClaim.Data) asyncOrderClaims;
-        mapping(address => uint256) escrowedSynthShares;
         uint256 totalEscrowedSynthShares;
-        SettlementStrategy[] settlementStrategies;
-        int256 asyncUtilizationDelta;
-    }
-    struct SettlementStrategy {
-        SettlementStrategyType strategyType;
-        uint256 fixedFee;
-        uint256 settlementDelay;
-        uint256 settlementWindowDuration;
-        address priceVerificationContract;
+        int256 totalCommittedUsdAmount;
+        uint128 totalClaims;
     }
     function load(uint128 marketId) internal pure returns (Data storage store) {
         bytes32 s = keccak256(abi.encode("io.synthetix.spot-market.AsyncOrder", marketId));
         assembly {
             store.slot := s
+        }
+    }
+}
+
+// @custom:artifact contracts/storage/AsyncOrderClaim.sol:AsyncOrderClaim
+library AsyncOrderClaim {
+    struct Data {
+        uint128 id;
+        address owner;
+        SpotMarketFactory.TransactionType orderType;
+        uint256 amountEscrowed;
+        uint256 settlementStrategyId;
+        uint256 settlementTime;
+        int256 committedAmountUsd;
+        uint256 minimumSettlementAmount;
+        uint256 commitmentBlockNum;
+        uint256 settledAt;
+    }
+    function load(uint128 marketId, uint256 claimId) internal pure returns (Data storage store) {
+        bytes32 s = keccak256(abi.encode("io.synthetix.spot-market.AsyncOrderClaim", marketId, claimId));
+        assembly {
+            store.slot := s
+        }
+    }
+}
+
+// @custom:artifact contracts/storage/AsyncOrderConfiguration.sol:AsyncOrderConfiguration
+library AsyncOrderConfiguration {
+    struct Data {
+        SettlementStrategy.Data[] settlementStrategies;
+    }
+    function load(uint128 marketId) internal pure returns (Data storage asyncOrderConfiguration) {
+        bytes32 s = keccak256(abi.encode("io.synthetix.spot-market.AsyncOrderConfiguration", marketId));
+        assembly {
+            asyncOrderConfiguration.slot := s
         }
     }
 }
@@ -289,10 +250,10 @@ library FeeConfiguration {
         uint skewScale;
         address feeCollector;
     }
-    function load(uint128 marketId) internal pure returns (Data storage store) {
+    function load(uint128 marketId) internal pure returns (Data storage feeConfiguration) {
         bytes32 s = keccak256(abi.encode("io.synthetix.spot-market.Fee", marketId));
         assembly {
-            store.slot := s
+            feeConfiguration.slot := s
         }
     }
 }
@@ -303,11 +264,31 @@ library Price {
         bytes32 buyFeedId;
         bytes32 sellFeedId;
     }
-    function load(uint128 marketId) internal pure returns (Data storage store) {
+    function load(uint128 marketId) internal pure returns (Data storage price) {
         bytes32 s = keccak256(abi.encode("io.synthetix.spot-market.Price", marketId));
         assembly {
-            store.slot := s
+            price.slot := s
         }
+    }
+}
+
+// @custom:artifact contracts/storage/SettlementStrategy.sol:SettlementStrategy
+library SettlementStrategy {
+    enum Type {
+        ONCHAIN,
+        CHAINLINK,
+        PYTH
+    }
+    struct Data {
+        Type strategyType;
+        uint256 settlementDelay;
+        uint256 settlementWindowDuration;
+        address priceVerificationContract;
+        bytes32 feedId;
+        string url;
+        uint256 settlementReward;
+        uint256 priceDeviationTolerance;
+        bool disabled;
     }
 }
 
@@ -327,14 +308,13 @@ library SpotMarketFactory {
         address oracle;
         address synthetix;
         address initialSynthImplementation;
-        address initialAsyncOrderClaimImplementation;
         mapping(uint128 => address) marketOwners;
         mapping(uint128 => address) nominatedMarketOwners;
     }
-    function load() internal pure returns (Data storage store) {
+    function load() internal pure returns (Data storage spotMarketFactory) {
         bytes32 s = _SLOT_SPOT_MARKET_FACTORY;
         assembly {
-            store.slot := s
+            spotMarketFactory.slot := s
         }
     }
 }
@@ -345,10 +325,10 @@ library Wrapper {
         address wrapCollateralType;
         uint256 maxWrappableAmount;
     }
-    function load(uint128 marketId) internal pure returns (Data storage store) {
+    function load(uint128 marketId) internal pure returns (Data storage wrapper) {
         bytes32 s = keccak256(abi.encode("io.synthetix.spot-market.Wrapper", marketId));
         assembly {
-            store.slot := s
+            wrapper.slot := s
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "homepage": "https://github.com/Synthetixio/synthetix-v3#readme",
   "scripts": {
-    "build": "npm run -w @synthetixio/core-utils -w @synthetixio/hardhat-storage -w @synthetixio/router -w @synthetixio/oracle-manager -w @synthetixio/synthetix build",
+    "build": "npm run -w @synthetixio/core-utils -w @synthetixio/hardhat-storage -w @synthetixio/router -w @synthetixio/sample-project -w @synthetixio/oracle-manager -w @synthetixio/synthetix build",
     "test": "npm run --workspaces --if-present test",
     "coverage": "npm run --workspaces --if-present coverage",
     "lint:js": "prettier --check '**/*.{t,j}s' && eslint --max-warnings=0 '**/*.{t,j}s'",

--- a/utils/hardhat-storage/README.md
+++ b/utils/hardhat-storage/README.md
@@ -40,7 +40,7 @@ npx hardhat storage:verify
 
 Which will do the following steps:
 
-1. It will execute the static storage validations on the contracts located at `contracts/modules/**`.
+1. It will execute the static storage validations on the contracts located at `contracts/**`.
 2. If it exists, it will load the `storage.dump.sol` file and check for invalid storage mutations.
 3. And, if all the previous validations passed, it will create or update the `storage.dump.sol` file, including the all the storage usage from your contracts.
 

--- a/utils/hardhat-storage/src/tasks/verify.ts
+++ b/utils/hardhat-storage/src/tasks/verify.ts
@@ -27,7 +27,7 @@ task(
   .addOptionalParam(
     'contracts',
     'Optional whitelist of contracts to get the storage values from',
-    ['contracts/modules/**'],
+    ['contracts/**', '!contracts/routers/**', '!contracts/generated/**', '!contracts/mocks/**'],
     types.stringArray
   )
   .addOptionalParam(

--- a/utils/sample-project/contracts/storage/GlobalStorage.sol
+++ b/utils/sample-project/contracts/storage/GlobalStorage.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.11 <0.9.0;
 
 contract GlobalStorage {
     bytes32 private constant _SLOT_GLOBAL_STORAGE =
-        keccak256(abi.encode("io.synthetix.sample-project.Global"));
+        keccak256(abi.encode("io.synthetix.sample-project.GlobalTest"));
 
     struct GlobalStore {
         uint value;

--- a/utils/sample-project/contracts/storage/GlobalStorage.sol
+++ b/utils/sample-project/contracts/storage/GlobalStorage.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.11 <0.9.0;
 
 contract GlobalStorage {
     bytes32 private constant _SLOT_GLOBAL_STORAGE =
-        keccak256(abi.encode("io.synthetix.sample-project.GlobalTest"));
+        keccak256(abi.encode("io.synthetix.sample-project.Global"));
 
     struct GlobalStore {
         uint value;


### PR DESCRIPTION
This PR fixes the following:
1. Adds all the contracts from `contracts/` folders to the storage check, not only the ones in `contracts/modules/**`
2. Adds a github action to check that the developer has updated the storage dump file (meaning that it was checked)
3. Updates the old ci package-lock check to not use an unnecessary github action dependency