### PR TITLE
Add missing typescript dependency

### DIFF
--- a/utils/core-utils/package.json
+++ b/utils/core-utils/package.json
@@ -13,10 +13,10 @@
   ],
   "scripts": {
     "build": "tsc --project src/tsconfig.json",
-    "watch": "yarn build -- --watch",
+    "watch": "yarn build --watch",
     "test": "mocha --require ts-node/register",
     "coverage": "nyc yarn test",
-    "test:watch": "yarn test -- --watch",
+    "test:watch": "yarn test --watch",
     "prepublishOnly": "yarn build"
   },
   "peerDependencies": {
@@ -33,7 +33,8 @@
     "nyc": "15.1.0",
     "sinon": "11.1.2",
     "solc": "^0.8.17",
-    "solidity-ast": "0.4.46"
+    "solidity-ast": "0.4.46",
+    "typescript": "4.9.3"
   },
   "dependencies": {
     "@ethersproject/abi": "5.7.0",

--- a/utils/hardhat-storage/package.json
+++ b/utils/hardhat-storage/package.json
@@ -23,10 +23,10 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc --project src/tsconfig.json",
-    "watch": "yarn build -- --watch",
+    "watch": "yarn build --watch",
     "test": "jest",
-    "coverage": "yarn test -- --coverage",
-    "test:watch": "yarn test -- --watch",
+    "coverage": "yarn test --coverage",
+    "test:watch": "yarn test --watch",
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
@@ -39,6 +39,7 @@
     "@types/mustache": "4.2.2",
     "hardhat": "2.13.0",
     "jest": "29.4.3",
-    "ts-jest": "29.0.5"
+    "ts-jest": "29.0.5",
+    "typescript": "4.9.3"
   }
 }

--- a/utils/router/package.json
+++ b/utils/router/package.json
@@ -23,10 +23,10 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc --project tsconfig.json",
-    "watch": "yarn build -- --watch",
+    "watch": "yarn build --watch",
     "test": "mocha --require ts-node/register",
     "coverage": "nyc yarn test",
-    "test:watch": "yarn test -- --watch",
+    "test:watch": "yarn test --watch",
     "prepublishOnly": "yarn build"
   },
   "peerDependencies": {
@@ -40,7 +40,8 @@
     "@usecannon/builder": "^2.1.7",
     "mocha": "9.1.1",
     "nyc": "15.1.0",
-    "typechain": "8.1.1"
+    "typechain": "8.1.1",
+    "typescript": "4.9.3"
   },
   "dependencies": {
     "@ethersproject/abi": "5.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2481,6 +2481,7 @@ __metadata:
     sinon: 11.1.2
     solc: ^0.8.17
     solidity-ast: 0.4.46
+    typescript: 4.9.3
   peerDependencies:
     ethers: ^5.0.0
     solidity-ast: ^0.4.0
@@ -2529,6 +2530,7 @@ __metadata:
     mustache: 4.2.0
     solidity-ast: 0.4.46
     ts-jest: 29.0.5
+    typescript: 4.9.3
   languageName: unknown
   linkType: soft
 
@@ -2629,6 +2631,7 @@ __metadata:
     nyc: 15.1.0
     solc: ^0.8.17
     typechain: 8.1.1
+    typescript: 4.9.3
   peerDependencies:
     "@usecannon/builder": ^2.1.7
     hardhat: ^2.0.0


### PR DESCRIPTION
NOTE: All locally used (in package) deps must be declared explicitly. No duplication, and they will be installed in root node_modules anyway. But this is made for safety and consistency afaik

- added typescript to packages that use tsc but did not have it declared
- removed unnecessary ` -- ` separator