### PR TITLE
fix: remove unnecessary call to account module when minting an account token

### DIFF
--- a/protocol/synthetix/contracts/modules/account/AccountTokenModule.sol
+++ b/protocol/synthetix/contracts/modules/account/AccountTokenModule.sol
@@ -17,11 +17,9 @@ contract AccountTokenModule is IAccountTokenModule, NftModule {
     /**
      * @dev Updates account RBAC storage to track the current owner of the token.
      */
-    function _postTransfer(
-        address, // from (unused)
-        address to,
-        uint256 tokenId
-    ) internal virtual override {
-        IAccountModule(OwnableStorage.getOwner()).notifyAccountTransfer(to, tokenId.to128());
+    function _postTransfer(address from, address to, uint256 tokenId) internal virtual override {
+        if (from != address(0)) {
+            IAccountModule(OwnableStorage.getOwner()).notifyAccountTransfer(to, tokenId.to128());
+        }
     }
 }


### PR DESCRIPTION
When calling `createAccount` in AccountModule the owner is set in the Account storage, so calling `notifyAccountTransfer` in the AccountTokenModule after minting only consume extra gas.

Because minting an account token is only available to the owner in the NftModule, there is no risk for it to be minted from other addresses.