### PR TITLE
L-17: safe transfers

### DIFF
--- a/markets/spot-market/contracts/storage/AsyncOrder.sol
+++ b/markets/spot-market/contracts/storage/AsyncOrder.sol
@@ -1,7 +1,6 @@
 //SPDX-License-Identifier: MIT
 pragma solidity >=0.8.11 <0.9.0;
 
-import "@synthetixio/core-contracts/contracts/token/ERC20Helper.sol";
 import "@synthetixio/core-modules/contracts/interfaces/ITokenModule.sol";
 import "../utils/SynthUtil.sol";
 
@@ -9,8 +8,6 @@ import "../utils/SynthUtil.sol";
  * @title Async order top level data storage
  */
 library AsyncOrder {
-    using ERC20Helper for address;
-
     struct Data {
         /**
          * @dev tracking total shares for share calculation of synths escrowed.  instead of storing direct synth amounts, we store shares in case of token decay.
@@ -47,7 +44,7 @@ library AsyncOrder {
                 token.balanceOf(address(this));
 
         asyncOrderData.totalEscrowedSynthShares += sharesAmount;
-        address(token).safeTransferFrom(from, address(this), synthAmount);
+        token.transferFrom(from, address(this), synthAmount);
     }
 
     function burnFromEscrow(uint128 marketId, uint256 sharesAmount) internal {
@@ -65,7 +62,7 @@ library AsyncOrder {
 
         asyncOrderData.totalEscrowedSynthShares -= sharesAmount;
 
-        address(SynthUtil.getToken(marketId)).safeTransferFrom(address(this), to, synthAmount);
+        SynthUtil.getToken(marketId).transferFrom(address(this), to, synthAmount);
     }
 
     function convertSharesToSynth(

--- a/markets/spot-market/contracts/storage/AsyncOrder.sol
+++ b/markets/spot-market/contracts/storage/AsyncOrder.sol
@@ -51,7 +51,7 @@ library AsyncOrder {
                 token.balanceOf(address(this));
 
         token.transferFrom(from, address(this), synthAmount);
-        
+
         asyncOrderData.totalEscrowedSynthShares += sharesAmount;
 
         // sanity check to ensure the right shares amount is calculated

--- a/markets/spot-market/contracts/storage/AsyncOrder.sol
+++ b/markets/spot-market/contracts/storage/AsyncOrder.sol
@@ -1,6 +1,7 @@
 //SPDX-License-Identifier: MIT
 pragma solidity >=0.8.11 <0.9.0;
 
+import "@synthetixio/core-contracts/contracts/token/ERC20Helper.sol";
 import "@synthetixio/core-modules/contracts/interfaces/ITokenModule.sol";
 import "../utils/SynthUtil.sol";
 
@@ -8,6 +9,8 @@ import "../utils/SynthUtil.sol";
  * @title Async order top level data storage
  */
 library AsyncOrder {
+    using ERC20Helper for address;
+
     struct Data {
         /**
          * @dev tracking total shares for share calculation of synths escrowed.  instead of storing direct synth amounts, we store shares in case of token decay.
@@ -43,8 +46,8 @@ library AsyncOrder {
             : (synthAmount * asyncOrderData.totalEscrowedSynthShares) /
                 token.balanceOf(address(this));
 
-        token.transferFrom(from, address(this), synthAmount);
         asyncOrderData.totalEscrowedSynthShares += sharesAmount;
+        address(token).safeTransferFrom(from, address(this), synthAmount);
     }
 
     function burnFromEscrow(uint128 marketId, uint256 sharesAmount) internal {
@@ -62,7 +65,7 @@ library AsyncOrder {
 
         asyncOrderData.totalEscrowedSynthShares -= sharesAmount;
 
-        SynthUtil.getToken(marketId).transferFrom(address(this), to, synthAmount);
+        address(SynthUtil.getToken(marketId)).safeTransferFrom(address(this), to, synthAmount);
     }
 
     function convertSharesToSynth(


### PR DESCRIPTION
- for wrappers and escrowing synths, use `safeTransfer` and `safeTransferFrom`.

for other tokens (such as USD token) and when transferring into the spot market system, using the normal `transfer` function to save gas.