### PR TITLE
L-05 fix decay token inheritance

### DIFF
--- a/markets/spot-market/contracts/utils/SynthUtil.sol
+++ b/markets/spot-market/contracts/utils/SynthUtil.sol
@@ -1,7 +1,7 @@
 //SPDX-License-Identifier: MIT
 pragma solidity >=0.8.11 <0.9.0;
 
-import "@synthetixio/core-modules/contracts/interfaces/ITokenModule.sol";
+import "../interfaces/ISynthTokenModule.sol";
 import "@synthetixio/core-modules/contracts/storage/AssociatedSystem.sol";
 import "@synthetixio/core-contracts/contracts/proxy/UUPSProxy.sol";
 
@@ -10,9 +10,13 @@ import "../storage/AsyncOrder.sol";
 library SynthUtil {
     using AssociatedSystem for AssociatedSystem.Data;
 
-    function getToken(uint128 marketId) internal view returns (ITokenModule) {
+    function getToken(uint128 marketId) internal view returns (ISynthTokenModule) {
         bytes32 synthId = getSystemId(marketId);
-        return AssociatedSystem.load(synthId).asToken();
+
+        // ISynthTokenModule inherits from IDecayTokenModule, which inherits from ITokenModule so
+        // this is a safe conversion as long as you know that the ITokenModule returned by the token
+        // type was initialized by us
+        return ISynthTokenModule(AssociatedSystem.load(synthId).proxy);
     }
 
     function getSystemId(uint128 marketId) internal pure returns (bytes32) {

--- a/utils/core-modules/contracts/interfaces/IDecayTokenModule.sol
+++ b/utils/core-modules/contracts/interfaces/IDecayTokenModule.sol
@@ -1,50 +1,13 @@
 //SPDX-License-Identifier: MIT
 pragma solidity >=0.8.11 <0.9.0;
 
-import "@synthetixio/core-contracts/contracts/interfaces/IERC20.sol";
+import "./ITokenModule.sol";
 
 /**
  * @title Module wrapping an ERC20 token implementation.
  * @notice the contract uses A = P(1 + r/n)**nt formula compounded every second to calculate decay amount at any moment
  */
-interface IDecayTokenModule is IERC20 {
-    /**
-     * @notice Returns wether the token has been initialized.
-     * @return A boolean with the result of the query.
-     */
-    function isInitialized() external returns (bool);
-
-    /**
-     * @notice Initializes the token with name, symbol, and decimals.
-     */
-    function initialize(
-        string memory tokenName,
-        string memory tokenSymbol,
-        uint8 tokenDecimals
-    ) external;
-
-    /**
-     * @notice Allows the owner to mint tokens.
-     * @param to The address to receive the newly minted tokens.
-     * @param amount The amount of tokens to mint.
-     */
-    function mint(address to, uint256 amount) external;
-
-    /**
-     * @notice Allows the owner to burn tokens.
-     * @param to The address whose tokens will be burnt.
-     * @param amount The amount of tokens to burn.
-     */
-    function burn(address to, uint256 amount) external;
-
-    /**
-     * @notice Allows an address that holds tokens to provide allowance to another.
-     * @param from The address that is providing allowance.
-     * @param spender The address that is given allowance.
-     * @param amount The amount of shares as allowance being given.
-     */
-    function setAllowance(address from, address spender, uint256 amount) external;
-
+interface IDecayTokenModule is ITokenModule {
     /**
      * @notice Updates the decay rate for a year
      * @param _rate The decay rate with 18 decimals (1e16 means 1% decay per year).

--- a/utils/core-modules/contracts/modules/DecayTokenModule.sol
+++ b/utils/core-modules/contracts/modules/DecayTokenModule.sol
@@ -9,7 +9,9 @@ import "@synthetixio/core-contracts/contracts/initializable/InitializableMixin.s
 import "../interfaces/IDecayTokenModule.sol";
 import "../storage/DecayToken.sol";
 
-contract DecayTokenModule is IDecayTokenModule, ERC20, InitializableMixin {
+import "./TokenModule.sol";
+
+contract DecayTokenModule is IDecayTokenModule, TokenModule {
     using DecimalMath for uint256;
 
     modifier _advanceEpoch() {
@@ -19,13 +21,13 @@ contract DecayTokenModule is IDecayTokenModule, ERC20, InitializableMixin {
     }
 
     /**
-     * @inheritdoc IDecayTokenModule
+     * @inheritdoc ITokenModule
      */
     function initialize(
         string memory tokenName,
         string memory tokenSymbol,
         uint8 tokenDecimals
-    ) public {
+    ) public override(TokenModule, ITokenModule) {
         OwnableStorage.onlyOwner();
         super._initialize(tokenName, tokenSymbol, tokenDecimals);
 
@@ -34,16 +36,19 @@ contract DecayTokenModule is IDecayTokenModule, ERC20, InitializableMixin {
     }
 
     /**
-     * @inheritdoc IDecayTokenModule
+     * @inheritdoc ITokenModule
      */
-    function isInitialized() external view returns (bool) {
+    function isInitialized() external view override(TokenModule, ITokenModule) returns (bool) {
         return _isInitialized();
     }
 
     /**
-     * @inheritdoc IDecayTokenModule
+     * @inheritdoc ITokenModule
      */
-    function burn(address from, uint256 amount) external override _advanceEpoch {
+    function burn(
+        address from,
+        uint256 amount
+    ) external override(TokenModule, ITokenModule) _advanceEpoch {
         OwnableStorage.onlyOwner();
 
         uint256 shareAmount = _tokenToShare(amount);
@@ -54,9 +59,12 @@ contract DecayTokenModule is IDecayTokenModule, ERC20, InitializableMixin {
     }
 
     /**
-     * @inheritdoc IDecayTokenModule
+     * @inheritdoc ITokenModule
      */
-    function mint(address to, uint256 amount) external override _advanceEpoch {
+    function mint(
+        address to,
+        uint256 amount
+    ) external override(TokenModule, ITokenModule) _advanceEpoch {
         OwnableStorage.onlyOwner();
 
         uint256 shareAmount = _tokenToShare(amount);
@@ -105,20 +113,6 @@ contract DecayTokenModule is IDecayTokenModule, ERC20, InitializableMixin {
         return super.balanceOf(user).mulDecimal(_tokensPerShare());
     }
 
-    function allowance(
-        address user,
-        address spender
-    ) public view virtual override(ERC20, IERC20) returns (uint256) {
-        return super.allowance(user, spender);
-    }
-
-    function approve(
-        address spender,
-        uint256 amount
-    ) public virtual override(ERC20, IERC20) returns (bool) {
-        return super.approve(spender, amount);
-    }
-
     function transferFrom(
         address from,
         address to,
@@ -138,14 +132,6 @@ contract DecayTokenModule is IDecayTokenModule, ERC20, InitializableMixin {
         _transfer(from, to, _tokenToShare(amount));
 
         return true;
-    }
-
-    /**
-     * @inheritdoc IDecayTokenModule
-     */
-    function setAllowance(address from, address spender, uint256 amount) external override {
-        OwnableStorage.onlyOwner();
-        ERC20Storage.load().allowance[from][spender] = amount;
     }
 
     function transfer(

--- a/utils/core-modules/contracts/modules/TokenModule.sol
+++ b/utils/core-modules/contracts/modules/TokenModule.sol
@@ -15,7 +15,7 @@ contract TokenModule is ITokenModule, ERC20, InitializableMixin {
     /**
      * @inheritdoc ITokenModule
      */
-    function isInitialized() external view returns (bool) {
+    function isInitialized() external view virtual returns (bool) {
         return _isInitialized();
     }
 
@@ -26,7 +26,7 @@ contract TokenModule is ITokenModule, ERC20, InitializableMixin {
         string memory tokenName,
         string memory tokenSymbol,
         uint8 tokenDecimals
-    ) public {
+    ) public virtual {
         OwnableStorage.onlyOwner();
         _initialize(tokenName, tokenSymbol, tokenDecimals);
     }
@@ -34,7 +34,7 @@ contract TokenModule is ITokenModule, ERC20, InitializableMixin {
     /**
      * @inheritdoc ITokenModule
      */
-    function burn(address from, uint256 amount) external override {
+    function burn(address from, uint256 amount) external virtual override {
         OwnableStorage.onlyOwner();
         _burn(from, amount);
     }
@@ -42,7 +42,7 @@ contract TokenModule is ITokenModule, ERC20, InitializableMixin {
     /**
      * @inheritdoc ITokenModule
      */
-    function mint(address to, uint256 amount) external override {
+    function mint(address to, uint256 amount) external virtual override {
         OwnableStorage.onlyOwner();
         _mint(to, amount);
     }
@@ -50,12 +50,12 @@ contract TokenModule is ITokenModule, ERC20, InitializableMixin {
     /**
      * @inheritdoc ITokenModule
      */
-    function setAllowance(address from, address spender, uint amount) external override {
+    function setAllowance(address from, address spender, uint amount) external virtual override {
         OwnableStorage.onlyOwner();
         ERC20Storage.load().allowance[from][spender] = amount;
     }
 
-    function _isInitialized() internal view override returns (bool) {
+    function _isInitialized() internal view virtual override returns (bool) {
         return ERC20Storage.load().decimals != 0;
     }
 }


### PR DESCRIPTION
fixes open zeppelin audit feedback regarding types in the `ISpotMarketFactory` being contrary to their actual purpose. additionally, `IDecayTokenModule` did not inherit from `TokenModule` even though they share nearly the same interface. so this was corrected, as well as changing `SynthUtil` to return `ISynthTokenModule`