### PR TITLE
M-03 Missing validation in Uniswap Oracle's configuration

### DIFF
--- a/protocol/oracle-manager/contracts/nodes/UniswapNode.sol
+++ b/protocol/oracle-manager/contracts/nodes/UniswapNode.sol
@@ -128,6 +128,10 @@ library UniswapNode {
             return false;
         }
 
+        if (secondsAgo == 0) {
+            return false;
+        }
+
         // Must return relevant function without error
         uint32[] memory secondsAgos = new uint32[](2);
         secondsAgos[0] = secondsAgo;

--- a/protocol/oracle-manager/test/integration/nodes/UniswapNode.test.ts
+++ b/protocol/oracle-manager/test/integration/nodes/UniswapNode.test.ts
@@ -64,4 +64,16 @@ describe('UniswapNode', function () {
     assertBn.equal(output.price, 1000000);
     assertBn.equal(timestamp, output.timestamp);
   });
+
+  it('reverts with secondAgo = 0', async () => {
+    const NodeParameters = abi.encode(
+      ['address', 'address', 'uint8', 'uint8', 'address', 'uint32'],
+      [token0.address, token1.address, 6, 18, MockObservable.address, 0]
+    );
+
+    await assertRevert(
+      NodeModule.registerNode(NodeTypes.UNISWAP, NodeParameters, []),
+      'InvalidNodeDefinition'
+    );
+  });
 });


### PR DESCRIPTION
- If secondsAgo is equal to 0 the oracle would revert at any process call. This change would make sure no uniswap node with secondsAgo == 0 can be created.