### PR TITLE
M-01 fix cannot set decay rate

### DIFF
--- a/markets/spot-market/contracts/interfaces/ISpotMarketFactoryModule.sol
+++ b/markets/spot-market/contracts/interfaces/ISpotMarketFactoryModule.sol
@@ -104,6 +104,15 @@ interface ISpotMarketFactoryModule is IMarket {
     function getSynth(uint128 marketId) external view returns (address);
 
     /**
+     * @notice Get the implementation address of the synth for the provided marketId.
+     * This address should not be used directly--use `getSynth` instead
+     * @dev Uses associated systems module to retrieve the token address.
+     * @param marketId id of the market
+     * @return implAddress address of the proxy for the synth
+     */
+    function getSynthImpl(uint128 marketId) external view returns (address implAddress);
+
+    /**
      * @notice Update the price data for a given market.
      * @dev Only the market owner can call this function.
      * @param marketId id of the market
@@ -113,13 +122,19 @@ interface ISpotMarketFactoryModule is IMarket {
     function updatePriceData(uint128 marketId, bytes32 buyFeedId, bytes32 sellFeedId) external;
 
     /**
-     * @notice upgrades the synth implementation for a given market.
-     * @dev Only the market owner can call this function.
+     * @notice upgrades the synth implementation to the current implementation for the specified market.
+     * Anyone who is willing and able to spend the gas can call this method.
      * @dev The synth implementation is upgraded via the proxy.
      * @param marketId id of the market
-     * @param synthImpl new synth implementation
      */
-    function upgradeSynthImpl(uint128 marketId, address synthImpl) external;
+    function upgradeSynthImpl(uint128 marketId) external;
+
+    /**
+     * @notice Allows market to adjust decay rate of the synth
+     * @param marketId the market to update the synth decay rate for
+     * @param rate APY to decay of the synth to decay by, as a 18 decimal ratio
+     */
+    function setDecayRate(uint128 marketId, uint256 rate) external;
 
     /**
      * @notice Allows the current market owner to nominate a new owner.

--- a/markets/spot-market/contracts/modules/SpotMarketFactoryModule.sol
+++ b/markets/spot-market/contracts/modules/SpotMarketFactoryModule.sol
@@ -120,17 +120,24 @@ contract SpotMarketFactoryModule is ISpotMarketFactoryModule, AssociatedSystemsM
     /**
      * @inheritdoc ISpotMarketFactoryModule
      */
-    function upgradeSynthImpl(uint128 marketId, address synthImpl) external override {
-        SpotMarketFactory.load().onlyMarketOwner(marketId);
+    function getSynthImpl(uint128 marketId) external view returns (address implAddress) {
+        return AssociatedSystem.load(SynthUtil.getSystemId(marketId)).impl;
+    }
 
+    /**
+     * @inheritdoc ISpotMarketFactoryModule
+     */
+    function upgradeSynthImpl(uint128 marketId) external override {
+        address newImpl = SpotMarketFactory.load().synthImplementation;
         bytes32 synthId = SynthUtil.getSystemId(marketId);
-        _upgradeToken(synthId, synthImpl);
+        _upgradeToken(synthId, newImpl);
 
-        emit SynthImplementationUpgraded(
-            marketId,
-            address(SynthUtil.getToken(marketId)),
-            synthImpl
-        );
+        emit SynthImplementationUpgraded(marketId, address(SynthUtil.getToken(marketId)), newImpl);
+    }
+
+    function setDecayRate(uint128 marketId, uint256 rate) external override {
+        SpotMarketFactory.load().onlyMarketOwner(marketId);
+        SynthUtil.getToken(marketId).setDecayRate(rate);
     }
 
     /**

--- a/markets/spot-market/test/SpotMarketFactory.test.ts
+++ b/markets/spot-market/test/SpotMarketFactory.test.ts
@@ -78,7 +78,9 @@ describe('SpotMarketFactory', () => {
       it('emits event', async () => {
         await assertEvent(
           tx,
-          'SynthImplementationUpgraded(1, "0x6196F7E7496a7d8fC73e556DF23011d43392a09F", "0xe9D713be74592723F294Fb2DdFd06E550eEC28c1")',
+          `SynthImplementationUpgraded(${marketId()}, "${await systems().SpotMarket.getSynth(
+            marketId()
+          )}", "${systems().USDRouter.address}")`,
           systems().SpotMarket
         );
       });
@@ -94,6 +96,8 @@ describe('SpotMarketFactory', () => {
     });
 
     describe('success', () => {
+      before(restore);
+
       before('set decay', async () => {
         await systems().SpotMarket.connect(marketOwner).setDecayRate(marketId(), 1234);
       });

--- a/markets/spot-market/test/SpotMarketFactory.test.ts
+++ b/markets/spot-market/test/SpotMarketFactory.test.ts
@@ -1,9 +1,12 @@
-import { ethers as Ethers } from 'ethers';
+import { ethers as Ethers, ethers } from 'ethers';
 import { bn, bootstrapTraders, bootstrapWithSynth } from './bootstrap';
 import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
 import assert from 'assert';
 import assertBn from '@synthetixio/core-utils/src/utils/assertions/assert-bignumber';
 import { SynthRouter } from '../generated/typechain';
+import assertEvent from '@synthetixio/core-utils/utils/assertions/assert-event';
+
+import { ISynthTokenModule__factory } from '../typechain-types/index';
 
 describe('SpotMarketFactory', () => {
   const { systems, signers, marketId, aggregator, restore } = bootstrapTraders(
@@ -45,6 +48,64 @@ describe('SpotMarketFactory', () => {
 
     it('check market name', async () => {
       assert.equal(await systems().SpotMarket.name(2), tokenName + ' Spot Market');
+    });
+  });
+
+  describe('upgrade synth', () => {
+    it('fails if no upgrade is available', async () => {
+      await assertRevert(
+        systems().SpotMarket.upgradeSynthImpl(marketId()),
+        'NoChange()',
+        systems().SpotMarket
+      );
+    });
+
+    describe('when upgraded impl is set', () => {
+      let tx: ethers.providers.TransactionResponse;
+      before(async () => {
+        // just set it to USD for testing purposes
+        await systems().SpotMarket.setSynthImplementation(systems().USDRouter.address);
+        tx = await systems().SpotMarket.upgradeSynthImpl(marketId());
+      });
+
+      it('has upgraded impl address', async () => {
+        assert.equal(
+          await systems().SpotMarket.getSynthImpl(marketId()),
+          systems().USDRouter.address
+        );
+      });
+
+      it('emits event', async () => {
+        await assertEvent(
+          tx,
+          'SynthImplementationUpgraded(1, "0x6196F7E7496a7d8fC73e556DF23011d43392a09F", "0xe9D713be74592723F294Fb2DdFd06E550eEC28c1")',
+          systems().SpotMarket
+        );
+      });
+    });
+  });
+
+  describe('set decay rate', () => {
+    it('only works for market owner', async () => {
+      await assertRevert(
+        systems().SpotMarket.connect(user1).setDecayRate(marketId(), 1234),
+        'OnlyMarketOwner'
+      );
+    });
+
+    describe('success', () => {
+      before('set decay', async () => {
+        await systems().SpotMarket.connect(marketOwner).setDecayRate(marketId(), 1234);
+      });
+
+      it('sets the decay rate on the underlying synth', async () => {
+        const decayRate = await ISynthTokenModule__factory.connect(
+          await systems().SpotMarket.getSynth(marketId()),
+          user1
+        ).callStatic.decayRate();
+
+        assertBn.equal(decayRate, 1234);
+      });
     });
   });
 

--- a/markets/spot-market/test/bootstrap.ts
+++ b/markets/spot-market/test/bootstrap.ts
@@ -25,12 +25,14 @@ type Proxies = {
   SynthRouter: SynthRouter;
   FeeCollectorMock: FeeCollectorMock;
   OracleVerifierMock: OracleVerifierMock;
+  ['synthetix.USDRouter']: SynthetixUSDProxy;
 };
 
 export type Systems = {
   SpotMarket: SpotMarketProxy;
   Core: SynthetixCoreProxy;
   USD: SynthetixUSDProxy;
+  USDRouter: SynthetixUSDProxy;
   CollateralMock: SynthetixCollateralMock;
   OracleManager: SynthetixOracle_managerProxy;
   OracleVerifierMock: OracleVerifierMock;
@@ -59,6 +61,7 @@ before('load contracts', () => {
   contracts = {
     Core: getContract('synthetix.CoreProxy'),
     USD: getContract('synthetix.USDProxy'),
+    USDRouter: getContract('synthetix.USDRouter'),
     SpotMarket: getContract('SpotMarketProxy'),
     OracleManager: getContract('synthetix.oracle_manager.Proxy'),
     CollateralMock: getContract('synthetix.CollateralMock'),


### PR DESCRIPTION
add a function to `setDecayRate` on `SpotMarketFactory`

additionally, it was identified that if we do this, we need to keep a leash on what the supported types of collateral token implementations are. so, this PR also limits the `upgradeSynthImpl` function to only upgrading to the *current* synth implementation

also, there wer emissing tests for `upgradeSynthImpl`, so those have been added.