### PR TITLE
emit `NodeRegistered` even if node is already registered

### DIFF
--- a/protocol/oracle-manager/contracts/modules/NodeModule.sol
+++ b/protocol/oracle-manager/contracts/modules/NodeModule.sol
@@ -92,6 +92,13 @@ contract NodeModule is INodeModule {
         // If the node has already been registered with the system, return its ID.
         nodeId = _getNodeId(nodeDefinition);
         if (_isNodeRegistered(nodeId)) {
+            # even though we do nothing else node is considered "re-registered" and returns as such
+            emit NodeRegistered(
+                nodeId,
+                nodeDefinition.nodeType,
+                nodeDefinition.parameters,
+                nodeDefinition.parents
+            );
             return nodeId;
         }
 


### PR DESCRIPTION
It causes massive problems for cannon when it cannot get the node ID due to the node already being registered. I have tried working around this issue to my ruin.

Think of it as a re-registration with same data.