### PR TITLE
Audit fixes

### DIFF
--- a/markets/spot-market/README.md
+++ b/markets/spot-market/README.md
@@ -41,7 +41,7 @@ quoteSellExactOut(uint128 marketId,uint usdAmount)
 #### Fees
 
 - `uint atomicFixedFee` - This fee (denominated as a percentage with 18 decimals) is applied to both buy and sell atomic orders.
-- `mapping(address => uint) atomicFixedFeeOverrides` - This is a mapping of fees (denominated as a percentage with 18 decimals) that will be used instead of `atomicFixedFee` when `msg.sender` is found in the mapping.
+- `mapping(address => uint) fixedFeeOverrides` - This is a mapping of fees (denominated as a percentage with 18 decimals) that will be used instead of the configured `atomicFixedFee` or `asyncFixedFee` when `msg.sender` is found in the mapping.
 - See Additional Fees section below for other applicable fees.
 
 ### Asyncronous Orders

--- a/markets/spot-market/contracts/modules/MarketConfigurationModule.sol
+++ b/markets/spot-market/contracts/modules/MarketConfigurationModule.sol
@@ -132,7 +132,7 @@ contract MarketConfigurationModule is IMarketConfigurationModule {
         uint256 fixedFeeAmount
     ) external override {
         SpotMarketFactory.load().onlyMarketOwner(synthMarketId);
-        MarketConfiguration.setAtomicFixedFeeOverride(synthMarketId, transactor, fixedFeeAmount);
+        MarketConfiguration.setFixedFeeOverride(synthMarketId, transactor, fixedFeeAmount);
 
         emit TransactorFixedFeeSet(synthMarketId, transactor, fixedFeeAmount);
     }
@@ -144,7 +144,7 @@ contract MarketConfigurationModule is IMarketConfigurationModule {
         uint128 synthMarketId,
         address transactor
     ) external view override returns (uint256 fixedFeeAmount) {
-        fixedFeeAmount = MarketConfiguration.getAtomicFixedFeeOverride(synthMarketId, transactor);
+        fixedFeeAmount = MarketConfiguration.getFixedFeeOverride(synthMarketId, transactor);
     }
 
     /**

--- a/markets/spot-market/contracts/modules/WrapperModule.sol
+++ b/markets/spot-market/contracts/modules/WrapperModule.sol
@@ -36,7 +36,7 @@ contract WrapperModule is IWrapperModule {
     ) external override {
         SpotMarketFactory.load().onlyMarketOwner(marketId);
 
-        Wrapper.update(marketId, wrapCollateralType, maxWrappableAmount);
+        Wrapper.updateValid(marketId, wrapCollateralType, maxWrappableAmount);
 
         emit WrapperSet(marketId, wrapCollateralType, maxWrappableAmount);
     }

--- a/markets/spot-market/contracts/storage/MarketConfiguration.sol
+++ b/markets/spot-market/contracts/storage/MarketConfiguration.sol
@@ -28,9 +28,9 @@ library MarketConfiguration {
 
     struct Data {
         /**
-         * @dev The atomic fixed fee rate for a specific transactor.  Useful for direct integrations to set custom fees for specific addresses.
+         * @dev The fixed fee rate for a specific transactor.  Useful for direct integrations to set custom fees for specific addresses.
          */
-        mapping(address => uint256) atomicFixedFeeOverrides;
+        mapping(address => uint256) fixedFeeOverrides;
         /**
          * @dev atomic buy/sell fixed fee that's applied on all trades. Percentage, 18 decimals
          */
@@ -89,22 +89,18 @@ library MarketConfiguration {
     /**
      * @dev Set custom fee for transactor
      */
-    function setAtomicFixedFeeOverride(
-        uint128 marketId,
-        address transactor,
-        uint256 fixedFee
-    ) internal {
-        load(marketId).atomicFixedFeeOverrides[transactor] = fixedFee;
+    function setFixedFeeOverride(uint128 marketId, address transactor, uint256 fixedFee) internal {
+        load(marketId).fixedFeeOverrides[transactor] = fixedFee;
     }
 
     /**
      * @dev Get custom fee for transactor
      */
-    function getAtomicFixedFeeOverride(
+    function getFixedFeeOverride(
         uint128 marketId,
         address transactor
     ) internal view returns (uint256 fixedFee) {
-        fixedFee = load(marketId).atomicFixedFeeOverrides[transactor];
+        fixedFee = load(marketId).fixedFeeOverrides[transactor];
     }
 
     /**
@@ -435,8 +431,8 @@ library MarketConfiguration {
         address transactor,
         bool async
     ) private view returns (uint256 fixedFee) {
-        if (self.atomicFixedFeeOverrides[transactor] > 0) {
-            fixedFee = self.atomicFixedFeeOverrides[transactor];
+        if (self.fixedFeeOverrides[transactor] > 0) {
+            fixedFee = self.fixedFeeOverrides[transactor];
         } else {
             fixedFee = async ? self.asyncFixedFee : self.atomicFixedFee;
         }

--- a/markets/spot-market/contracts/storage/Wrapper.sol
+++ b/markets/spot-market/contracts/storage/Wrapper.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.11 <0.9.0;
 
 import {ISynthetixSystem} from "../interfaces/external/ISynthetixSystem.sol";
+import {SpotMarketFactory} from "./SpotMarketFactory.sol";
 
 /**
  * @title Wrapper library servicing the wrapper module
@@ -65,9 +66,11 @@ library Wrapper {
 
         // you are only allowed to update the collateral type once for each market
         // we currently do not support multiple collateral types/market
-        if (
-            configuredCollateralType != address(0) && configuredCollateralType != wrapCollateralType
-        ) {
+        uint currentMarketCollateralAmount = SpotMarketFactory
+            .load()
+            .synthetix
+            .getMarketCollateralAmount(marketId, configuredCollateralType);
+        if (currentMarketCollateralAmount != 0) {
             revert InvalidCollateralType("Already set");
         }
 

--- a/markets/spot-market/storage.dump.sol
+++ b/markets/spot-market/storage.dump.sol
@@ -263,7 +263,7 @@ library AsyncOrderConfiguration {
 // @custom:artifact contracts/storage/MarketConfiguration.sol:MarketConfiguration
 library MarketConfiguration {
     struct Data {
-        mapping(address => uint256) atomicFixedFeeOverrides;
+        mapping(address => uint256) fixedFeeOverrides;
         uint256 atomicFixedFee;
         uint256 asyncFixedFee;
         uint256 utilizationFeeRate;

--- a/markets/spot-market/test/WrapperModule.test.ts
+++ b/markets/spot-market/test/WrapperModule.test.ts
@@ -65,18 +65,6 @@ describe('WrapperModule', () => {
         systems().SpotMarket
       );
     });
-
-    describe('does not allow you to update collateral type once set', () => {
-      it('reverts on update with different collateral type', async () => {
-        await assertRevert(
-          systems()
-            .SpotMarket.connect(marketOwner)
-            // use random address
-            .setWrapper(marketId(), systems().FeeCollectorMock.address, bn(500)),
-          'InvalidCollateralType'
-        );
-      });
-    });
   });
 
   describe('wrap', () => {
@@ -163,6 +151,18 @@ describe('WrapperModule', () => {
           txn,
           `SynthWrapped(${marketId()}, ${bn(0.99)}, [0, 0, 0, ${bn(9)}], ${bn(4.5)})`,
           systems().SpotMarket
+        );
+      });
+    });
+
+    describe('does not allow you to update collateral type with oustanding collateral deposited', () => {
+      it('reverts on update with different collateral type', async () => {
+        await assertRevert(
+          systems()
+            .SpotMarket.connect(marketOwner)
+            // use random address
+            .setWrapper(marketId(), systems().FeeCollectorMock.address, bn(500)),
+          'InvalidCollateralType'
         );
       });
     });

--- a/markets/spot-market/test/WrapperModule.test.ts
+++ b/markets/spot-market/test/WrapperModule.test.ts
@@ -65,6 +65,18 @@ describe('WrapperModule', () => {
         systems().SpotMarket
       );
     });
+
+    describe('does not allow you to update collateral type once set', () => {
+      it('reverts on update with different collateral type', async () => {
+        await assertRevert(
+          systems()
+            .SpotMarket.connect(marketOwner)
+            // use random address
+            .setWrapper(marketId(), systems().FeeCollectorMock.address, bn(500)),
+          'InvalidCollateralType'
+        );
+      });
+    });
   });
 
   describe('wrap', () => {


### PR DESCRIPTION
- [x] WrapperModule.sol#L32 - Using the setWrapper() function to set a new wrapCollateralType for a market locks any deposited collateral of the previous asset and also disregards the previous collateral from any market calculations. To prevent this case, the setWrapper() function should only be callable once.
- [x] MarketConfiguration.sol#L433 - As atomicFixedFeeOverrides overrides both atomic and async fees set for a user, the variable should be renamed to fixedFeeOverrides. It may be desirable to enforce different fee overrides for atomic and async overrides for a user, in which case adding a asyncFixedFeeOverrides mapping and updating the logic of _getFixedFee() would be required.