### PR TITLE
Liquidation rewards perps v3

### DIFF
--- a/markets/perps-market/contracts/storage/AsyncOrder.sol
+++ b/markets/perps-market/contracts/storage/AsyncOrder.sol
@@ -161,7 +161,7 @@ library AsyncOrder {
         runtime.newNotionalValue = MathUtil.abs(
             runtime.newPositionSize.to256().mulDecimal(runtime.fillPrice.toInt())
         );
-        (, , runtime.initialRequiredMargin, ) = marketConfig.calculateRequiredMargins(
+        (, , runtime.initialRequiredMargin, , ) = marketConfig.calculateRequiredMargins(
             runtime.newNotionalValue
         );
 

--- a/markets/perps-market/contracts/storage/GlobalPerpsMarketConfiguration.sol
+++ b/markets/perps-market/contracts/storage/GlobalPerpsMarketConfiguration.sol
@@ -41,7 +41,7 @@ library GlobalPerpsMarketConfiguration {
     function liquidationReward(
         Data storage self,
         uint256 totalLiquidationRewards
-    ) internal view returns (uint) {
+    ) internal view returns (uint256) {
         return
             MathUtil.min(
                 MathUtil.max(totalLiquidationRewards, self.minLiquidationRewardUsd),

--- a/markets/perps-market/contracts/storage/GlobalPerpsMarketConfiguration.sol
+++ b/markets/perps-market/contracts/storage/GlobalPerpsMarketConfiguration.sol
@@ -1,6 +1,8 @@
 //SPDX-License-Identifier: MIT
 pragma solidity >=0.8.11 <0.9.0;
 
+import {MathUtil} from "../utils/MathUtil.sol";
+
 /*
     Note: This library contains all global perps market configuration data
 */

--- a/markets/perps-market/contracts/storage/GlobalPerpsMarketConfiguration.sol
+++ b/markets/perps-market/contracts/storage/GlobalPerpsMarketConfiguration.sol
@@ -34,4 +34,18 @@ library GlobalPerpsMarketConfiguration {
             globalMarketConfig.slot := s
         }
     }
+
+    /**
+     * @dev returns the liquidation reward based on total liquidation rewards from all markets compared against min/max
+     */
+    function liquidationReward(
+        Data storage self,
+        uint256 totalLiquidationRewards
+    ) internal view returns (uint) {
+        return
+            MathUtil.min(
+                MathUtil.max(totalLiquidationRewards, self.minLiquidationRewardUsd),
+                self.maxLiquidationRewardUsd
+            );
+    }
 }

--- a/markets/perps-market/contracts/storage/PerpsMarketConfiguration.sol
+++ b/markets/perps-market/contracts/storage/PerpsMarketConfiguration.sol
@@ -62,7 +62,7 @@ library PerpsMarketConfiguration {
         return notionalValue.mulDecimal(self.liquidationRewardRatioD18);
     }
 
-    function calculateMarginRatios(
+    function calculateRequiredMargins(
         Data storage self,
         uint256 notionalValue
     )

--- a/markets/perps-market/contracts/storage/PerpsMarketConfiguration.sol
+++ b/markets/perps-market/contracts/storage/PerpsMarketConfiguration.sol
@@ -40,6 +40,10 @@ library PerpsMarketConfiguration {
          * @dev This multiplier is applied to the max liquidation value when calculating max liquidation for a given market
          */
         uint256 maxLiquidationLimitAccumulationMultiplier;
+        /**
+         * @dev This value is multiplied by the notional value of a position to determine liquidation reward
+         */
+        uint256 liquidationRewardRatioD18;
     }
 
     function load(uint128 marketId) internal pure returns (Data storage store) {
@@ -49,6 +53,13 @@ library PerpsMarketConfiguration {
         assembly {
             store.slot := s
         }
+    }
+
+    function calculateLiquidationMargin(
+        Data storage self,
+        uint256 notionalValue
+    ) internal view returns (uint256) {
+        return notionalValue.mulDecimal(self.liquidationRewardRatioD18);
     }
 
     function calculateMarginRatios(
@@ -61,7 +72,8 @@ library PerpsMarketConfiguration {
             uint256 initialMarginRatio,
             uint256 maintenanceMarginRatio,
             uint256 initialMargin,
-            uint256 maintenanceMargin
+            uint256 maintenanceMargin,
+            uint256 liquidationMargin
         )
     {
         uint256 impactOnSkew = notionalValue.divDecimal(self.skewScale);
@@ -70,5 +82,7 @@ library PerpsMarketConfiguration {
         maintenanceMarginRatio = impactOnSkew.mulDecimal(self.maintenanceMarginFraction);
         initialMargin = notionalValue.mulDecimal(initialMarginRatio);
         maintenanceMargin = notionalValue.mulDecimal(maintenanceMarginRatio);
+
+        liquidationMargin = calculateLiquidationMargin(self, notionalValue);
     }
 }

--- a/markets/perps-market/storage.dump.sol
+++ b/markets/perps-market/storage.dump.sol
@@ -523,7 +523,8 @@ library PerpsAccount {
     }
     struct RuntimeLiquidationData {
         uint totalLosingPnl;
-        uint totalLiquidationRewards;
+        uint accumulatedLiquidationRewards;
+        uint liquidationReward;
         uint losingMarketsLength;
         uint profitableMarketsLength;
         uint128[] profitableMarkets;
@@ -584,6 +585,7 @@ library PerpsMarketConfiguration {
         uint256 maintenanceMarginFraction;
         uint256 lockedOiPercent;
         uint256 maxLiquidationLimitAccumulationMultiplier;
+        uint256 liquidationRewardRatioD18;
     }
     function load(uint128 marketId) internal pure returns (Data storage store) {
         bytes32 s = keccak256(abi.encode("io.synthetix.perps-market.PerpsMarketConfiguration", marketId));


### PR DESCRIPTION
- added `liquidationRewardRatioD18`
- calculated liquidationReward based on the above ratio * notional value.  
- checked against global min/max liquidation reward values.

- applied to maintenance margin to determine liquidations and withdrawal of margin.
- refactored `liquidate` on account to take into account liquidation rewards and pay them out properly.