### PR TITLE
Use tsconfig.eslint.json for ts files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,9 +33,7 @@ module.exports = {
     {
       files: ['**/*.ts'],
       extends: ['plugin:@typescript-eslint/recommended'],
-      parserOptions: {
-        project: ['./tsconfig.json'],
-      },
+
       rules: {
         '@typescript-eslint/no-floating-promises': 'error',
         '@typescript-eslint/no-var-requires': 0,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,11 +12,8 @@ module.exports = {
     Promise: 'readonly',
   },
   plugins: ['progress', 'no-only-tests'],
-  parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 12,
-    tsconfigRootDir: __dirname,
-    project: ['./tsconfig.eslint.json'],
   },
   ignorePatterns: ['/*.js'],
   rules: {
@@ -33,7 +30,10 @@ module.exports = {
     {
       files: ['**/*.ts'],
       extends: ['plugin:@typescript-eslint/recommended'],
-
+      parser: '@typescript-eslint/parser',
+      parserOptions: {
+        project: ['./tsconfig.eslint.json'],
+      },
       rules: {
         '@typescript-eslint/no-floating-promises': 'error',
         '@typescript-eslint/no-var-requires': 0,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "yarn workspaces foreach --parallel --verbose run test",
     "coverage": "yarn workspaces foreach --verbose run coverage",
     "lint:progress": "ESLINT_PROGRESS=true eslint --max-warnings=0 .",
-    "lint:js": "prettier --check '**/*.{t,j}s' && eslint --max-warnings=0 '**/*.{t,j}s'",
+    "lint:js": "prettier --check '**/*.{t,j}s' && eslint --debug --max-warnings=0 '**/*.{t,j}s'",
     "lint:js:fix": "prettier --write '**/*.{t,j}s' && eslint --max-warnings=0 --fix '**/*.{t,j}s'",
     "lint:sol": "prettier --check '(protocol|utils|markets)/**/*.sol' && solhint utils/*/contracts/**/*.sol protocol/*/contracts/**/*.sol  markets/*/contracts/**/*.sol",
     "lint:sol:fix": "prettier --write '(protocol|utils|markets)/**/*.sol' && solhint --fix utils/*/contracts/**/*.sol protocol/*/contracts/**/*.sol markets/*/contracts/**/*.sol",


### PR DESCRIPTION
We configure eslint to use:
```
  parserOptions: {
    ecmaVersion: 12,
    tsconfigRootDir: __dirname,
    project: ['./tsconfig.eslint.json'],
  },
```
But then we override it to 
```
   parserOptions: {
        project: ['./tsconfig.json'],
      },
```

Removing this override helped with my running out of memory issue..  I think previosly it didn't lint properly since it now finds two instances of lint errors locally.. 
