### PR TITLE
Add tests for price deviations

### DIFF
--- a/markets/perps-market/contracts/modules/AsyncOrderModule.sol
+++ b/markets/perps-market/contracts/modules/AsyncOrderModule.sol
@@ -80,18 +80,19 @@ contract AsyncOrderModule is IAsyncOrderModule {
         return (order, feesAccrued);
     }
 
-    function settle(uint128 marketId, uint128 accountId) external {
+    function settle(uint128 marketId, uint128 accountId) external view {
         GlobalPerpsMarket.load().checkLiquidation(accountId);
         (
             AsyncOrder.Data storage order,
             SettlementStrategy.Data storage settlementStrategy
         ) = _performOrderValidityChecks(marketId, accountId);
 
-        if (settlementStrategy.strategyType == SettlementStrategy.Type.ONCHAIN) {
-            _settleOnchain(order, settlementStrategy);
-        } else {
-            _settleOffchain(order, settlementStrategy);
-        }
+        // if (settlementStrategy.strategyType == SettlementStrategy.Type.ONCHAIN) {
+        //     _settleOnchain(order, settlementStrategy);
+        // } else {
+        //     _settleOffchain(order, settlementStrategy);
+        // }
+        _settleOffchain(order, settlementStrategy);
     }
 
     function settlePythOrder(bytes calldata result, bytes calldata extraData) external payable {
@@ -124,15 +125,15 @@ contract AsyncOrderModule is IAsyncOrderModule {
         _settleOrder(offchainPrice, order, settlementStrategy);
     }
 
-    function _settleOnchain(
-        AsyncOrder.Data storage asyncOrder,
-        SettlementStrategy.Data storage settlementStrategy
-    ) private {
-        uint currentPrice = PerpsPrice.getCurrentPrice(asyncOrder.marketId);
-        settlementStrategy.checkPriceDeviation(currentPrice, asyncOrder.acceptablePrice);
+    // function _settleOnchain(
+    //     AsyncOrder.Data storage asyncOrder,
+    //     SettlementStrategy.Data storage settlementStrategy
+    // ) private {
+    //     uint currentPrice = PerpsPrice.getCurrentPrice(asyncOrder.marketId);
+    //     settlementStrategy.checkPriceDeviation(currentPrice, asyncOrder.acceptablePrice);
 
-        _settleOrder(currentPrice, asyncOrder, settlementStrategy);
-    }
+    //     _settleOrder(currentPrice, asyncOrder, settlementStrategy);
+    // }
 
     function _settleOffchain(
         AsyncOrder.Data storage asyncOrder,

--- a/markets/perps-market/contracts/modules/AsyncOrderModule.sol
+++ b/markets/perps-market/contracts/modules/AsyncOrderModule.sol
@@ -87,11 +87,6 @@ contract AsyncOrderModule is IAsyncOrderModule {
             SettlementStrategy.Data storage settlementStrategy
         ) = _performOrderValidityChecks(marketId, accountId);
 
-        // if (settlementStrategy.strategyType == SettlementStrategy.Type.ONCHAIN) {
-        //     _settleOnchain(order, settlementStrategy);
-        // } else {
-        //     _settleOffchain(order, settlementStrategy);
-        // }
         _settleOffchain(order, settlementStrategy);
     }
 
@@ -124,16 +119,6 @@ contract AsyncOrderModule is IAsyncOrderModule {
 
         _settleOrder(offchainPrice, order, settlementStrategy);
     }
-
-    // function _settleOnchain(
-    //     AsyncOrder.Data storage asyncOrder,
-    //     SettlementStrategy.Data storage settlementStrategy
-    // ) private {
-    //     uint currentPrice = PerpsPrice.getCurrentPrice(asyncOrder.marketId);
-    //     settlementStrategy.checkPriceDeviation(currentPrice, asyncOrder.acceptablePrice);
-
-    //     _settleOrder(currentPrice, asyncOrder, settlementStrategy);
-    // }
 
     function _settleOffchain(
         AsyncOrder.Data storage asyncOrder,

--- a/markets/perps-market/contracts/storage/AsyncOrder.sol
+++ b/markets/perps-market/contracts/storage/AsyncOrder.sol
@@ -34,6 +34,8 @@ library AsyncOrder {
 
     error OrderNotValid();
 
+    error AcceptablePriceExceeded(uint256 acceptablePrice, uint256 fillPrice);
+
     struct Data {
         uint128 accountId;
         uint128 marketId;
@@ -145,7 +147,12 @@ library AsyncOrder {
             orderPrice
         );
 
-        // TODO: check against acceptablePrice
+        if (
+            (order.sizeDelta > 0 && runtime.fillPrice > order.acceptablePrice) ||
+            (order.sizeDelta < 0 && runtime.fillPrice < order.acceptablePrice)
+        ) {
+            revert AcceptablePriceExceeded(runtime.fillPrice, order.acceptablePrice);
+        }
 
         runtime.orderFees =
             calculateOrderFee(

--- a/markets/perps-market/contracts/storage/SettlementStrategy.sol
+++ b/markets/perps-market/contracts/storage/SettlementStrategy.sol
@@ -54,7 +54,6 @@ library SettlementStrategy {
     }
 
     enum Type {
-        ONCHAIN,
         PYTH
     }
 

--- a/markets/perps-market/storage.dump.sol
+++ b/markets/perps-market/storage.dump.sol
@@ -633,7 +633,6 @@ library Position {
 // @custom:artifact contracts/storage/SettlementStrategy.sol:SettlementStrategy
 library SettlementStrategy {
     enum Type {
-        ONCHAIN,
         PYTH
     }
     struct Data {

--- a/markets/perps-market/test/integration/Market/CreateMarket.test.ts
+++ b/markets/perps-market/test/integration/Market/CreateMarket.test.ts
@@ -202,7 +202,7 @@ describe('Create Market test', () => {
               accountId: 2,
               sizeDelta: bn(1),
               settlementStrategyId: 0,
-              acceptablePrice: bn(1000),
+              acceptablePrice: bn(1050), // 5% slippage
               trackingCode: ethers.constants.HashZero,
             }),
           'PriceFeedNotSet'
@@ -262,7 +262,7 @@ describe('Create Market test', () => {
             accountId: 2,
             sizeDelta: bn(1),
             settlementStrategyId: 0,
-            acceptablePrice: bn(1000),
+            acceptablePrice: bn(1050), // 5% slippage
             trackingCode: ethers.constants.HashZero,
           });
       });

--- a/markets/perps-market/test/integration/Orders/OffchainAsyncOrder.commit.test.ts
+++ b/markets/perps-market/test/integration/Orders/OffchainAsyncOrder.commit.test.ts
@@ -47,7 +47,7 @@ describe('Commit Offchain Async Order test', () => {
             accountId: 2,
             sizeDelta: bn(1),
             settlementStrategyId: 0,
-            acceptablePrice: bn(1000),
+            acceptablePrice: bn(1050), // 5% slippage
             trackingCode: ethers.constants.HashZero,
           }),
         'InvalidMarket("1337")'
@@ -63,7 +63,7 @@ describe('Commit Offchain Async Order test', () => {
             accountId: 1337,
             sizeDelta: bn(1),
             settlementStrategyId: 0,
-            acceptablePrice: bn(1000),
+            acceptablePrice: bn(1050), // 5% slippage
             trackingCode: ethers.constants.HashZero,
           }),
         'AccountNotFound("1337")'
@@ -79,7 +79,7 @@ describe('Commit Offchain Async Order test', () => {
             accountId: 2,
             sizeDelta: bn(1),
             settlementStrategyId: 0,
-            acceptablePrice: bn(1000),
+            acceptablePrice: bn(1050), // 5% slippage
             trackingCode: ethers.constants.HashZero,
           }),
         'InsufficientMargin'
@@ -155,7 +155,7 @@ describe('Commit Offchain Async Order test', () => {
             accountId: 2,
             sizeDelta: bn(1),
             settlementStrategyId: 0,
-            acceptablePrice: bn(1000),
+            acceptablePrice: bn(1050), // 5% slippage
             trackingCode: ethers.constants.HashZero,
           });
         const res = await tx.wait(); // force immediate confirmation to prevent flaky tests due to block timestamp
@@ -167,7 +167,7 @@ describe('Commit Offchain Async Order test', () => {
           tx,
           `OrderCommitted(${ethMarketId}, 2, ${DEFAULT_SETTLEMENT_STRATEGY.strategyType}, ${bn(
             1
-          )}, ${bn(1000)}, ${startTime + 5}, ${startTime + 5 + 120}, "${
+          )}, ${bn(1050)}, ${startTime + 5}, ${startTime + 5 + 120}, "${
             ethers.constants.HashZero
           }", "${await trader1().getAddress()}")`,
           systems().PerpsMarket
@@ -181,7 +181,7 @@ describe('Commit Offchain Async Order test', () => {
         assertBn.equal(ayncOrderClaim.sizeDelta, bn(1));
         assertBn.equal(ayncOrderClaim.settlementStrategyId, 0);
         assertBn.equal(ayncOrderClaim.settlementTime, startTime + 5);
-        assertBn.equal(ayncOrderClaim.acceptablePrice, bn(1000));
+        assertBn.equal(ayncOrderClaim.acceptablePrice, bn(1050));
         assert.equal(ayncOrderClaim.trackingCode, ethers.constants.HashZero);
       });
 
@@ -194,7 +194,7 @@ describe('Commit Offchain Async Order test', () => {
               accountId: 2,
               sizeDelta: bn(2),
               settlementStrategyId: 0,
-              acceptablePrice: bn(1000),
+              acceptablePrice: bn(1050), // 5% slippage
               trackingCode: ethers.constants.HashZero,
             }),
           `OrderAlreadyCommitted("${ethMarketId}", "2")`
@@ -232,7 +232,7 @@ describe('Commit Offchain Async Order test', () => {
                 accountId: 2,
                 sizeDelta: bn(1),
                 settlementStrategyId: 0,
-                acceptablePrice: bn(1000),
+                acceptablePrice: bn(1050), // 5% slippage
                 trackingCode: ethers.constants.HashZero,
               });
             await tx.wait();
@@ -244,7 +244,7 @@ describe('Commit Offchain Async Order test', () => {
               tx,
               `OrderCommitted(${ethMarketId}, 2, ${DEFAULT_SETTLEMENT_STRATEGY.strategyType}, ${bn(
                 1
-              )}, ${bn(1000)}, ${startTime + 5}, ${startTime + 5 + 120}, "${
+              )}, ${bn(1050)}, ${startTime + 5}, ${startTime + 5 + 120}, "${
                 ethers.constants.HashZero
               }", "${await trader1().getAddress()}")`,
               systems().PerpsMarket
@@ -258,7 +258,7 @@ describe('Commit Offchain Async Order test', () => {
             assertBn.equal(ayncOrderClaim.sizeDelta, bn(1));
             assertBn.equal(ayncOrderClaim.settlementStrategyId, 0);
             assertBn.equal(ayncOrderClaim.settlementTime, startTime + 5);
-            assertBn.equal(ayncOrderClaim.acceptablePrice, bn(1000));
+            assertBn.equal(ayncOrderClaim.acceptablePrice, bn(1050));
             assert.equal(ayncOrderClaim.trackingCode, ethers.constants.HashZero);
           });
         });

--- a/markets/perps-market/test/integration/Orders/OffchainAsyncOrder.price.test.ts
+++ b/markets/perps-market/test/integration/Orders/OffchainAsyncOrder.price.test.ts
@@ -1,4 +1,269 @@
-// TODO
-// Use this test to check price deviations
-// offchain vs cl
-// fillPrice vs expected
+import { ethers } from 'ethers';
+import { DEFAULT_SETTLEMENT_STRATEGY, bn, bootstrapMarkets, toNum } from '../bootstrap';
+import { fastForwardTo } from '@synthetixio/core-utils/utils/hardhat/rpc';
+import { snapshotCheckpoint } from '@synthetixio/core-utils/utils/mocha/snapshot';
+import { depositCollateral } from '../helpers';
+import assertBn from '@synthetixio/core-utils/utils/assertions/assert-bignumber';
+import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
+import { getTxTime } from '@synthetixio/core-utils/src/utils/hardhat/rpc';
+
+describe('Offchain Async Order - Price tests', () => {
+  const { systems, perpsMarkets, provider, trader1, keeper } = bootstrapMarkets({
+    synthMarkets: [],
+    perpsMarkets: [
+      {
+        name: 'Ether',
+        token: 'snxETH',
+        price: bn(1000),
+        fundingParams: { skewScale: bn(100_000), maxFundingVelocity: bn(0) },
+      },
+    ],
+    traderAccountIds: [2, 3],
+  });
+
+  const largeDeviation = toNum(DEFAULT_SETTLEMENT_STRATEGY.priceDeviationTolerance) * (1 + 0.001);
+  const limitDeviation = toNum(DEFAULT_SETTLEMENT_STRATEGY.priceDeviationTolerance);
+
+  let ethMarketId: ethers.BigNumber;
+  let extraData: string;
+
+  before('identify actors', async () => {
+    ethMarketId = perpsMarkets()[0].marketId();
+  });
+
+  before('add collateral', async () => {
+    await depositCollateral({
+      systems,
+      trader: trader1,
+      accountId: () => 2,
+      collaterals: [
+        {
+          snxUSDAmount: () => bn(10_000),
+        },
+      ],
+    });
+  });
+
+  before('setup bytes data', () => {
+    extraData = ethers.utils.defaultAbiCoder.encode(['uint128', 'uint128'], [ethMarketId, 2]);
+  });
+
+  const restoreToSetCollateralTime = snapshotCheckpoint(provider);
+
+  [
+    {
+      kind: 'long',
+      sizeDelta: bn(1),
+      acceptablePrice: bn(1050), // 5% slippage
+      limitFillPrice: bn(1000.005), // .05bps slippage
+      tightFillPrice: bn(1000.004), // 1000.005 is the limit .05bps slippage
+    },
+    {
+      kind: 'short',
+      sizeDelta: bn(-1),
+      acceptablePrice: bn(950), // 5% slippage
+      limitFillPrice: bn(999.995), // .05bps slippage
+      tightFillPrice: bn(999.996),
+    },
+  ].forEach((iter) => {
+    describe(`${iter.kind} order`, () => {
+      describe('offchain vs spot price deviation', () => {
+        let updateFee: ethers.BigNumber;
+        let startTime: number;
+
+        before(restoreToSetCollateralTime);
+
+        before('commit the order and advance in time', async () => {
+          const tx = await systems().PerpsMarket.connect(trader1()).commitOrder({
+            marketId: ethMarketId,
+            accountId: 2,
+            sizeDelta: iter.sizeDelta,
+            settlementStrategyId: 0,
+            acceptablePrice: iter.acceptablePrice,
+            trackingCode: ethers.constants.HashZero,
+          });
+          const res = await tx.wait(); // force immediate confirmation to prevent flaky tests due to block timestamp
+          startTime = await getTxTime(provider(), res);
+
+          // fast forward to settlement
+          await fastForwardTo(
+            startTime + DEFAULT_SETTLEMENT_STRATEGY.settlementDelay + 1,
+            provider()
+          );
+        });
+
+        const restoreToSettleTime = snapshotCheckpoint(provider);
+
+        describe('failures', () => {
+          before(restoreToSettleTime);
+
+          it('reverts if pyth price is larger than spot by more than deviation tolerance', async () => {
+            const validPythPriceData = await systems().MockPyth.createPriceFeedUpdateData(
+              DEFAULT_SETTLEMENT_STRATEGY.feedId,
+              1000_0000 * (1 + largeDeviation),
+              1,
+              -4,
+              1000_0000,
+              1,
+              startTime + 6
+            );
+            updateFee = await systems().MockPyth.getUpdateFee([validPythPriceData]);
+            await assertRevert(
+              systems()
+                .PerpsMarket.connect(keeper())
+                .settlePythOrder(validPythPriceData, extraData, { value: updateFee }),
+              `PriceDeviationToleranceExceeded("${bn(0.01001)}", "${
+                DEFAULT_SETTLEMENT_STRATEGY.priceDeviationTolerance
+              }")`
+            );
+          });
+
+          it('reverts if pyth price smaller than spot by more than deviation tolerance', async () => {
+            const validPythPriceData = await systems().MockPyth.createPriceFeedUpdateData(
+              DEFAULT_SETTLEMENT_STRATEGY.feedId,
+              1000_0000 * (1 - largeDeviation),
+              1,
+              -4,
+              1000_0000,
+              1,
+              startTime + 6
+            );
+            updateFee = await systems().MockPyth.getUpdateFee([validPythPriceData]);
+            await assertRevert(
+              systems()
+                .PerpsMarket.connect(keeper())
+                .settlePythOrder(validPythPriceData, extraData, { value: updateFee }),
+              `PriceDeviationToleranceExceeded("${bn(largeDeviation)}", "${
+                DEFAULT_SETTLEMENT_STRATEGY.priceDeviationTolerance
+              }")`
+            );
+          });
+        });
+
+        describe('price at max limit', () => {
+          let validPythPriceData: string, updateFee: ethers.BigNumber;
+          before(restoreToSettleTime);
+
+          before('set test price', async () => {
+            validPythPriceData = await systems().MockPyth.createPriceFeedUpdateData(
+              DEFAULT_SETTLEMENT_STRATEGY.feedId,
+              1000_0000 * (1 + limitDeviation),
+              1,
+              -4,
+              1000_0000,
+              1,
+              startTime + 6
+            );
+            updateFee = await systems().MockPyth.getUpdateFee([validPythPriceData]);
+          });
+
+          before('settles the order', async () => {
+            await systems()
+              .PerpsMarket.connect(keeper())
+              .settlePythOrder(validPythPriceData, extraData, { value: updateFee });
+          });
+
+          it('check position is live', async () => {
+            const [, , size] = await systems().PerpsMarket.getOpenPosition(2, ethMarketId);
+            assertBn.equal(size, iter.sizeDelta);
+          });
+        });
+
+        describe('price at min limit', () => {
+          let validPythPriceData: string, updateFee: ethers.BigNumber;
+          before(restoreToSettleTime);
+
+          before('set test price', async () => {
+            validPythPriceData = await systems().MockPyth.createPriceFeedUpdateData(
+              DEFAULT_SETTLEMENT_STRATEGY.feedId,
+              1000_0000 * (1 - limitDeviation),
+              1,
+              -4,
+              1000_0000,
+              1,
+              startTime + 6
+            );
+            updateFee = await systems().MockPyth.getUpdateFee([validPythPriceData]);
+          });
+
+          before('settles the order', async () => {
+            await systems()
+              .PerpsMarket.connect(keeper())
+              .settlePythOrder(validPythPriceData, extraData, { value: updateFee });
+          });
+
+          it('check position is live', async () => {
+            const [, , size] = await systems().PerpsMarket.getOpenPosition(2, ethMarketId);
+            assertBn.equal(size, iter.sizeDelta);
+          });
+        });
+      });
+
+      describe('fillPrice deviation check at commit', () => {
+        describe('when fillPrice is not acceptable', () => {
+          before(restoreToSetCollateralTime);
+
+          it('reverts', async () => {
+            await assertRevert(
+              systems().PerpsMarket.connect(trader1()).commitOrder({
+                marketId: ethMarketId,
+                accountId: 2,
+                sizeDelta: iter.sizeDelta,
+                settlementStrategyId: 0,
+                acceptablePrice: iter.tightFillPrice,
+                trackingCode: ethers.constants.HashZero,
+              }),
+              `AcceptablePriceExceeded("${iter.limitFillPrice}", "${iter.tightFillPrice}")`
+            );
+          });
+        });
+
+        describe('when fillPrice is acceptable', () => {
+          let validPythPriceData: string, updateFee: ethers.BigNumber;
+          before(restoreToSetCollateralTime);
+
+          before('commit the order with large acceptablePrice and set price', async () => {
+            const tx = await systems().PerpsMarket.connect(trader1()).commitOrder({
+              marketId: ethMarketId,
+              accountId: 2,
+              sizeDelta: iter.sizeDelta,
+              settlementStrategyId: 0,
+              acceptablePrice: iter.limitFillPrice,
+              trackingCode: ethers.constants.HashZero,
+            });
+            const res = await tx.wait(); // force immediate confirmation to prevent flaky tests due to block timestamp
+            const startTime = await getTxTime(provider(), res);
+
+            // fast forward to settlement
+            await fastForwardTo(
+              startTime + DEFAULT_SETTLEMENT_STRATEGY.settlementDelay + 1,
+              provider()
+            );
+
+            validPythPriceData = await systems().MockPyth.createPriceFeedUpdateData(
+              DEFAULT_SETTLEMENT_STRATEGY.feedId,
+              1000_0000,
+              1,
+              -4,
+              1000_0000,
+              1,
+              startTime + 6
+            );
+            updateFee = await systems().MockPyth.getUpdateFee([validPythPriceData]);
+          });
+
+          before('settles the order', async () => {
+            await systems()
+              .PerpsMarket.connect(keeper())
+              .settlePythOrder(validPythPriceData, extraData, { value: updateFee });
+          });
+
+          it('check position is live', async () => {
+            const [, , size] = await systems().PerpsMarket.getOpenPosition(2, ethMarketId);
+            assertBn.equal(size, iter.sizeDelta);
+          });
+        });
+      });
+    });
+  });
+});

--- a/markets/perps-market/test/integration/Orders/OffchainAsyncOrder.settle.test.ts
+++ b/markets/perps-market/test/integration/Orders/OffchainAsyncOrder.settle.test.ts
@@ -7,6 +7,7 @@ import { DepositCollateralData, depositCollateral } from '../helpers';
 import assertBn from '@synthetixio/core-utils/utils/assertions/assert-bignumber';
 import assertEvent from '@synthetixio/core-utils/utils/assertions/assert-event';
 import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
+import { getTxTime } from '@synthetixio/core-utils/src/utils/hardhat/rpc';
 
 describe('Settle Offchain Async Order test', () => {
   const { systems, perpsMarkets, synthMarkets, provider, trader1, keeper } = bootstrapMarkets({
@@ -183,11 +184,11 @@ describe('Settle Offchain Async Order test', () => {
             accountId: 2,
             sizeDelta: bn(1),
             settlementStrategyId: 0,
-            acceptablePrice: bn(1000),
+            acceptablePrice: bn(1050), // 5% slippage
             trackingCode: ethers.constants.HashZero,
           });
         const res = await tx.wait(); // force immediate confirmation to prevent flaky tests due to block timestamp
-        startTime = (await provider().getBlock(res.blockNumber)).timestamp;
+        startTime = await getTxTime(provider(), res);
       });
 
       before('setup bytes data', () => {
@@ -272,6 +273,10 @@ describe('Settle Offchain Async Order test', () => {
             'SettlementWindowExpired'
           );
         });
+      });
+
+      describe('attempts to settle with invalid pyth price data', () => {
+        before(restoreBeforeSettle);
       });
 
       describe('settle order', () => {

--- a/markets/perps-market/test/integration/Orders/OffchainAsyncOrder.settle.test.ts
+++ b/markets/perps-market/test/integration/Orders/OffchainAsyncOrder.settle.test.ts
@@ -277,6 +277,55 @@ describe('Settle Offchain Async Order test', () => {
 
       describe('attempts to settle with invalid pyth price data', () => {
         before(restoreBeforeSettle);
+
+        before('fast forward to settlement time', async () => {
+          // fast forward to settlement
+          await fastForwardTo(
+            startTime + DEFAULT_SETTLEMENT_STRATEGY.settlementDelay + 1,
+            provider()
+          );
+        });
+
+        it('reverts with invalid pyth price timestamp (before time)', async () => {
+          const validPythPriceData = await systems().MockPyth.createPriceFeedUpdateData(
+            DEFAULT_SETTLEMENT_STRATEGY.feedId,
+            1000_0000,
+            1,
+            -4,
+            1000_0000,
+            1,
+            startTime
+          );
+          updateFee = await systems().MockPyth.getUpdateFee([validPythPriceData]);
+          await assertRevert(
+            systems()
+              .PerpsMarket.connect(keeper())
+              .settlePythOrder(validPythPriceData, extraData, { value: updateFee }),
+            'PriceFeedNotFoundWithinRange'
+          );
+        });
+
+        it('reverts with invalid pyth price timestamp (after time)', async () => {
+          const validPythPriceData = await systems().MockPyth.createPriceFeedUpdateData(
+            DEFAULT_SETTLEMENT_STRATEGY.feedId,
+            1000_0000,
+            1,
+            -4,
+            1000_0000,
+            1,
+            startTime +
+              DEFAULT_SETTLEMENT_STRATEGY.settlementDelay +
+              DEFAULT_SETTLEMENT_STRATEGY.settlementWindowDuration +
+              1
+          );
+          updateFee = await systems().MockPyth.getUpdateFee([validPythPriceData]);
+          await assertRevert(
+            systems()
+              .PerpsMarket.connect(keeper())
+              .settlePythOrder(validPythPriceData, extraData, { value: updateFee }),
+            'PriceFeedNotFoundWithinRange'
+          );
+        });
       });
 
       describe('settle order', () => {

--- a/markets/perps-market/test/integration/bootstrap/bootstrap.ts
+++ b/markets/perps-market/test/integration/bootstrap/bootstrap.ts
@@ -143,4 +143,4 @@ export function bootstrapMarkets(data: BootstrapArgs) {
 }
 
 export const bn = (n: number) => wei(n).toBN();
-export const toNum = (n: ethers.BigNumber) => n.div(ethers.constants.WeiPerEther).toNumber();
+export const toNum = (n: ethers.BigNumber) => Number(ethers.utils.formatEther(n));

--- a/markets/perps-market/test/integration/bootstrap/bootstrapPerpsMarkets.ts
+++ b/markets/perps-market/test/integration/bootstrap/bootstrapPerpsMarkets.ts
@@ -49,7 +49,7 @@ type IncomingChainState =
   | ReturnType<typeof bootstrapSynthMarkets>;
 
 export const DEFAULT_SETTLEMENT_STRATEGY = {
-  strategyType: 1, // OFFCHAIN
+  strategyType: 0, // OFFCHAIN
   settlementDelay: 5,
   settlementWindowDuration: 120,
   settlementReward: bn(5),

--- a/markets/perps-market/test/integration/helpers/openPosition.ts
+++ b/markets/perps-market/test/integration/helpers/openPosition.ts
@@ -9,7 +9,9 @@ export type OpenPositionData = {
   accountId: number;
   sizeDelta: ethers.BigNumber;
   settlementStrategyId: number;
-  price: ethers.BigNumber;
+  price: ethers.BigNumber; // spot price if offchain price is defined
+  offchiainPrice?: ethers.BigNumber; // if undefined will use price
+  acceptablePrice?: ethers.BigNumber; // if undefined will use price
   trackingCode?: string;
   keeper: ethers.Signer;
   systems: () => Systems;

--- a/markets/perps-market/test/integration/helpers/openPosition.ts
+++ b/markets/perps-market/test/integration/helpers/openPosition.ts
@@ -9,9 +9,7 @@ export type OpenPositionData = {
   accountId: number;
   sizeDelta: ethers.BigNumber;
   settlementStrategyId: number;
-  price: ethers.BigNumber; // spot price if offchain price is defined
-  offchiainPrice?: ethers.BigNumber; // if undefined will use price
-  acceptablePrice?: ethers.BigNumber; // if undefined will use price
+  price: ethers.BigNumber;
   trackingCode?: string;
   keeper: ethers.Signer;
   systems: () => Systems;

--- a/utils/core-utils/src/utils/hardhat/rpc.ts
+++ b/utils/core-utils/src/utils/hardhat/rpc.ts
@@ -34,6 +34,15 @@ export async function getTime(provider: ethers.providers.JsonRpcProvider) {
   return block.timestamp;
 }
 
+export async function getTxTime(
+  provider: ethers.providers.JsonRpcProvider,
+  txReceipt: ethers.ContractReceipt
+) {
+  const block = await provider.getBlock(txReceipt.blockNumber);
+
+  return block.timestamp;
+}
+
 export async function getBlock(provider: ethers.providers.JsonRpcProvider) {
   const block = await provider.getBlock('latest');
 


### PR DESCRIPTION
- Remove legacy ONCHAIN strategy from AsyncOrder
- Fix missing check of `acceptablePrice`
- Add tests for covering `acceptablePrice` and `priceDeviation`
- Add missing test on pyth data