### PR TITLE
Update `OrderSettled` event

### DIFF
--- a/markets/perps-market/contracts/interfaces/IAsyncOrderModule.sol
+++ b/markets/perps-market/contracts/interfaces/IAsyncOrderModule.sol
@@ -28,7 +28,7 @@ interface IAsyncOrderModule {
         int128 sizeDelta,
         int128 newSize,
         uint256 collectedFees,
-        uint256 settelementReward,
+        uint256 settlementReward,
         bytes32 indexed trackingCode,
         address settler
     );

--- a/markets/perps-market/contracts/interfaces/IAsyncOrderModule.sol
+++ b/markets/perps-market/contracts/interfaces/IAsyncOrderModule.sol
@@ -60,6 +60,7 @@ interface IAsyncOrderModule {
     struct SettleOrderRuntime {
         uint128 marketId;
         uint128 accountId;
+        int128 sizeDelta;
         int128 newPositionSize;
         int256 pnl;
         uint256 pnlUint;

--- a/markets/perps-market/contracts/interfaces/IAsyncOrderModule.sol
+++ b/markets/perps-market/contracts/interfaces/IAsyncOrderModule.sol
@@ -25,6 +25,7 @@ interface IAsyncOrderModule {
         uint128 indexed accountId,
         uint256 fillPrice,
         int256 accountPnlRealized,
+        int128 sizeDelta,
         int128 newSize,
         uint256 collectedFees,
         uint256 settelementReward,

--- a/markets/perps-market/contracts/modules/AsyncOrderModule.sol
+++ b/markets/perps-market/contracts/modules/AsyncOrderModule.sol
@@ -224,6 +224,7 @@ contract AsyncOrderModule is IAsyncOrderModule {
 
         // exctracted from asyncOrder before order is reset
         bytes32 trackingCode = asyncOrder.trackingCode;
+        int128 sizeDelta = asyncOrder.sizeDelta;
 
         asyncOrder.reset();
 
@@ -233,6 +234,7 @@ contract AsyncOrderModule is IAsyncOrderModule {
             runtime.accountId,
             fillPrice,
             runtime.pnl,
+            sizeDelta,
             runtime.newPositionSize,
             totalFees,
             runtime.settlementReward,

--- a/markets/perps-market/contracts/modules/AsyncOrderModule.sol
+++ b/markets/perps-market/contracts/modules/AsyncOrderModule.sol
@@ -97,11 +97,11 @@ contract AsyncOrderModule is IAsyncOrderModule {
     }
 
     function settlePythOrder(bytes calldata result, bytes calldata extraData) external payable {
-        (uint128 marketId, uint128 asyncOrderId) = abi.decode(extraData, (uint128, uint128));
+        (uint128 marketId, uint128 accountId) = abi.decode(extraData, (uint128, uint128));
         (
             AsyncOrder.Data storage order,
             SettlementStrategy.Data storage settlementStrategy
-        ) = _performOrderValidityChecks(marketId, asyncOrderId);
+        ) = _performOrderValidityChecks(marketId, accountId);
 
         bytes32[] memory priceIds = new bytes32[](1);
         priceIds[0] = settlementStrategy.feedId;

--- a/markets/perps-market/contracts/modules/AsyncOrderModule.sol
+++ b/markets/perps-market/contracts/modules/AsyncOrderModule.sol
@@ -177,6 +177,7 @@ contract AsyncOrderModule is IAsyncOrderModule {
 
         runtime.accountId = asyncOrder.accountId;
         runtime.marketId = asyncOrder.marketId;
+        runtime.sizeDelta = asyncOrder.sizeDelta;
 
         // check if account is flagged
         GlobalPerpsMarket.load().checkLiquidation(runtime.accountId);
@@ -224,7 +225,6 @@ contract AsyncOrderModule is IAsyncOrderModule {
 
         // exctracted from asyncOrder before order is reset
         bytes32 trackingCode = asyncOrder.trackingCode;
-        int128 sizeDelta = asyncOrder.sizeDelta;
 
         asyncOrder.reset();
 
@@ -234,7 +234,7 @@ contract AsyncOrderModule is IAsyncOrderModule {
             runtime.accountId,
             fillPrice,
             runtime.pnl,
-            sizeDelta,
+            runtime.sizeDelta,
             runtime.newPositionSize,
             totalFees,
             runtime.settlementReward,

--- a/markets/spot-market/docs/index.md
+++ b/markets/spot-market/docs/index.md
@@ -201,7 +201,7 @@ To determine the fee, the client should first call getUpdateFee() from Pyth's ve
 ### OrderSettled
 
   ```solidity
-  event OrderSettled(uint128 marketId, uint128 asyncOrderId, uint256 finalOrderAmount, struct OrderFees.Data fees, uint256 collectedFees, address settler, uint256 price)
+  event OrderSettled(uint128 marketId, uint128 asyncOrderId, uint256 finalOrderAmount, struct OrderFees.Data fees, uint256 collectedFees, address settler, uint256 price, enum Transaction.Type orderType)
   ```
 
   Gets fired when an order is settled.
@@ -214,6 +214,7 @@ To determine the fee, the client should first call getUpdateFee() from Pyth's ve
 * `collectedFees` (*uint256*) - fees collected by the configured fee collector.
 * `settler` (*address*) - address that settled the order.
 * `price` (*uint256*) - 
+* `orderType` (*enum Transaction.Type*) - 
 
 ## Atomic Order Module
 

--- a/protocol/oracle-manager/docs/index.md
+++ b/protocol/oracle-manager/docs/index.md
@@ -35,7 +35,7 @@
 ### getNode
 
   ```solidity
-  function getNode(bytes32 nodeId) external view returns (struct NodeDefinition.Data node)
+  function getNode(bytes32 nodeId) external pure returns (struct NodeDefinition.Data node)
   ```
 
   Returns a node's definition (type, parameters, and parents)
@@ -249,25 +249,5 @@
 
   ```solidity
   function isValid(struct NodeDefinition.Data nodeDefinition) internal view returns (bool valid)
-  ```
-
-## Router
-
-### fallback
-
-  ```solidity
-  fallback() external payable
-  ```
-
-### receive
-
-  ```solidity
-  receive() external payable
-  ```
-
-### _forward
-
-  ```solidity
-  function _forward() internal
   ```
 


### PR DESCRIPTION
* Add `sizeDelta` to the `OrderSettled` event - This will help calculate volume (`sizeDelta * fillPrice`)
* Fix a typo in the `OrderSettled` event
* Renames a variable - A variable named `asyncOrderId` actually represents the `accountId`
* Updates all docs using docgen