### PR TITLE
Change location of async order

### DIFF
--- a/markets/perps-market/contracts/modules/AsyncOrderSettlementModule.sol
+++ b/markets/perps-market/contracts/modules/AsyncOrderSettlementModule.sol
@@ -205,12 +205,12 @@ contract AsyncOrderSettlementModule is IAsyncOrderSettlementModule, IMarketEvent
         uint128 marketId,
         uint128 accountId
     ) private view returns (AsyncOrder.Data storage, SettlementStrategy.Data storage) {
-        AsyncOrder.Data storage order = PerpsMarket.loadValid(marketId).asyncOrders[accountId];
+        AsyncOrder.Data storage order = PerpsAccount.load(accountId).getValidOrder(marketId);
+
         SettlementStrategy.Data storage settlementStrategy = PerpsMarketConfiguration
             .load(marketId)
             .settlementStrategies[order.settlementStrategyId];
 
-        order.checkValidity();
         order.checkWithinSettlementWindow(settlementStrategy);
 
         return (order, settlementStrategy);

--- a/markets/perps-market/contracts/storage/AsyncOrder.sol
+++ b/markets/perps-market/contracts/storage/AsyncOrder.sol
@@ -37,8 +37,6 @@ library AsyncOrder {
         uint256 settlementExpiration
     );
 
-    error OrderNotValid();
-
     error AcceptablePriceExceeded(uint256 acceptablePrice, uint256 fillPrice);
 
     struct Data {
@@ -107,12 +105,6 @@ library AsyncOrder {
                 self.settlementTime,
                 settlementExpiration
             );
-        }
-    }
-
-    function checkValidity(Data storage self) internal view {
-        if (self.sizeDelta == 0) {
-            revert OrderNotValid();
         }
     }
 

--- a/markets/perps-market/contracts/storage/PerpsMarket.sol
+++ b/markets/perps-market/contracts/storage/PerpsMarket.sol
@@ -45,8 +45,6 @@ library PerpsMarket {
         // liquidation data
         uint128 lastTimeLiquidationCapacityUpdated;
         uint128 lastUtilizedLiquidationCapacity;
-        // accountId => asyncOrder
-        mapping(uint => AsyncOrder.Data) asyncOrders;
         // accountId => position
         mapping(uint => Position.Data) positions;
     }

--- a/markets/perps-market/test/integration/Orders/OffchainAsyncOrder.settle.test.ts
+++ b/markets/perps-market/test/integration/Orders/OffchainAsyncOrder.settle.test.ts
@@ -45,7 +45,7 @@ describe('Settle Offchain Async Order test', () => {
       it('reverts if market id is incorrect', async () => {
         await assertRevert(
           systems().PerpsMarket.connect(trader1()).settle(1337, 2),
-          'InvalidMarket("1337")'
+          'OrderNotValid()'
         );
       });
 
@@ -88,7 +88,7 @@ describe('Settle Offchain Async Order test', () => {
           systems()
             .PerpsMarket.connect(keeper())
             .settlePythOrder(pythPriceData, extraData, { value: updateFee }),
-          'InvalidMarket("1337")'
+          'OrderNotValid()'
         );
       });
 


### PR DESCRIPTION
move location of AsyncOrder from markets as mapping to single instance on Account since we are only supporting one pending order per account.