### PR TITLE
Use load instead of mapping for AsyncOrder

### DIFF
--- a/markets/perps-market/contracts/modules/AsyncOrderModule.sol
+++ b/markets/perps-market/contracts/modules/AsyncOrderModule.sol
@@ -103,13 +103,12 @@ contract AsyncOrderModule is IAsyncOrderModule {
     function getOrder(
         uint128 marketId,
         uint128 accountId
-    ) external view override returns (AsyncOrder.Data memory) {
-        AsyncOrder.Data memory order = AsyncOrder.load(accountId);
+    ) external view override returns (AsyncOrder.Data memory order) {
+        order = AsyncOrder.load(accountId);
         if (order.marketId != marketId) {
             // return emtpy order if marketId does not match
-            return AsyncOrder.Data(0, 0, 0, 0, 0, 0, 0);
+            order = AsyncOrder.Data(0, 0, 0, 0, 0, 0, 0);
         }
-        return order;
     }
 
     /**

--- a/markets/perps-market/contracts/modules/AsyncOrderModule.sol
+++ b/markets/perps-market/contracts/modules/AsyncOrderModule.sol
@@ -59,7 +59,7 @@ contract AsyncOrderModule is IAsyncOrderModule {
 
         GlobalPerpsMarket.load().checkLiquidation(commitment.accountId);
 
-        AsyncOrder.Data storage order = PerpsAccount.load(commitment.accountId).asyncOrder[0];
+        AsyncOrder.Data storage order = AsyncOrder.load(commitment.accountId);
 
         if (order.sizeDelta != 0 && order.marketId == commitment.marketId) {
             revert OrderAlreadyCommitted(commitment.marketId, commitment.accountId);
@@ -104,7 +104,7 @@ contract AsyncOrderModule is IAsyncOrderModule {
         uint128 marketId,
         uint128 accountId
     ) external view override returns (AsyncOrder.Data memory) {
-        AsyncOrder.Data memory order = PerpsAccount.load(accountId).asyncOrder[0];
+        AsyncOrder.Data memory order = AsyncOrder.load(accountId);
         if (order.marketId != marketId) {
             // return emtpy order if marketId does not match
             return AsyncOrder.Data(0, 0, 0, 0, 0, 0, 0);
@@ -116,7 +116,7 @@ contract AsyncOrderModule is IAsyncOrderModule {
      * @inheritdoc IAsyncOrderModule
      */
     function cancelOrder(uint128 marketId, uint128 accountId) external override {
-        AsyncOrder.Data storage order = PerpsAccount.load(accountId).getValidOrder(marketId);
+        AsyncOrder.Data storage order = AsyncOrder.loadValid(accountId, marketId);
 
         SettlementStrategy.Data storage settlementStrategy = PerpsMarketConfiguration
             .load(marketId)

--- a/markets/perps-market/contracts/modules/AsyncOrderSettlementModule.sol
+++ b/markets/perps-market/contracts/modules/AsyncOrderSettlementModule.sol
@@ -203,7 +203,7 @@ contract AsyncOrderSettlementModule is IAsyncOrderSettlementModule, IMarketEvent
         uint128 marketId,
         uint128 accountId
     ) private view returns (AsyncOrder.Data storage, SettlementStrategy.Data storage) {
-        AsyncOrder.Data storage order = PerpsAccount.load(accountId).getValidOrder(marketId);
+        AsyncOrder.Data storage order = AsyncOrder.loadValid(accountId, marketId);
 
         SettlementStrategy.Data storage settlementStrategy = PerpsMarketConfiguration
             .load(marketId)

--- a/markets/perps-market/contracts/modules/PerpsAccountModule.sol
+++ b/markets/perps-market/contracts/modules/PerpsAccountModule.sol
@@ -55,7 +55,7 @@ contract PerpsAccountModule is IAccountModule {
         }
 
         // Check if there are pending orders
-        if (account.asyncOrder[0].sizeDelta != 0) {
+        if (AsyncOrder.load(accountId).sizeDelta != 0) {
             revert PendingOrdersExist();
         }
 

--- a/markets/perps-market/contracts/storage/PerpsAccount.sol
+++ b/markets/perps-market/contracts/storage/PerpsAccount.sol
@@ -6,7 +6,6 @@ import {SafeCastI256, SafeCastU256, SafeCastU128} from "@synthetixio/core-contra
 import {SetUtil} from "@synthetixio/core-contracts/contracts/utils/SetUtil.sol";
 import {ISpotMarketSystem} from "../interfaces/external/ISpotMarketSystem.sol";
 import {Position} from "./Position.sol";
-import {AsyncOrder} from "./AsyncOrder.sol";
 import {PerpsMarket} from "./PerpsMarket.sol";
 import {MathUtil} from "../utils/MathUtil.sol";
 import {PerpsPrice} from "./PerpsPrice.sol";
@@ -31,7 +30,6 @@ library PerpsAccount {
     using PerpsMarketConfiguration for PerpsMarketConfiguration.Data;
     using PerpsMarketFactory for PerpsMarketFactory.Data;
     using GlobalPerpsMarketConfiguration for GlobalPerpsMarketConfiguration.Data;
-    using AsyncOrder for AsyncOrder.Data;
     using DecimalMath for int256;
     using DecimalMath for uint256;
 

--- a/markets/perps-market/contracts/storage/PerpsAccount.sol
+++ b/markets/perps-market/contracts/storage/PerpsAccount.sol
@@ -31,6 +31,7 @@ library PerpsAccount {
     using PerpsMarketConfiguration for PerpsMarketConfiguration.Data;
     using PerpsMarketFactory for PerpsMarketFactory.Data;
     using GlobalPerpsMarketConfiguration for GlobalPerpsMarketConfiguration.Data;
+    using AsyncOrder for AsyncOrder.Data;
     using DecimalMath for int256;
     using DecimalMath for uint256;
 
@@ -43,8 +44,6 @@ library PerpsAccount {
         SetUtil.UintSet activeCollateralTypes;
         // @dev set of open position market ids
         SetUtil.UintSet openPositionMarketIds;
-        // @dev a single order per account is allowed we always use index 0 `asyncOrder[0]`. The mapping is used to isolate storage layout from the rest of the struct.
-        mapping(uint128 => AsyncOrder.Data) asyncOrder;
     }
 
     error InsufficientCollateralAvailableForWithdraw(uint available, uint required);
@@ -53,25 +52,12 @@ library PerpsAccount {
 
     error AccountLiquidatable(uint128 accountId);
 
-    error OrderNotValid();
-
     function load(uint128 id) internal pure returns (Data storage account) {
         bytes32 s = keccak256(abi.encode("io.synthetix.perps-market.Account", id));
 
         assembly {
             account.slot := s
         }
-    }
-
-    function getValidOrder(
-        Data storage self,
-        uint marketId
-    ) internal view returns (AsyncOrder.Data storage) {
-        AsyncOrder.Data storage order = self.asyncOrder[0];
-        if (order.marketId != marketId || order.sizeDelta == 0) {
-            revert OrderNotValid();
-        }
-        return order;
     }
 
     function isEligibleForLiquidation(


### PR DESCRIPTION
This PR updates the location of the AsyncOrder instead of adding it to the Account Data struct, it gets loaded from the AsyncOrder library