### PR TITLE
Add council upgrade proposal

### DIFF
--- a/protocol/governance/cannonfile.test.toml
+++ b/protocol/governance/cannonfile.test.toml
@@ -27,7 +27,7 @@ artifact = "contracts/generated/test/TestableElectionStorage.sol:TestableElectio
 # Core Router + Testable modules
 [router.TestRouter]
 contracts = [
-  # Extend Core Router
+  # Extend Original Core Router
   "CoreRouter",
   # Testable storage contracts
   "TestableCouncilStorage",
@@ -37,7 +37,6 @@ contracts = [
 ]
 depends = [
   "router.CoreRouter",
-  # Testable storage contracts
   "contract.TestableCouncilStorage",
   "contract.TestableDebtShareStorage",
   "contract.TestableElectionSettingsStorage",

--- a/protocol/governance/cannonfile.toml
+++ b/protocol/governance/cannonfile.toml
@@ -37,7 +37,7 @@ defaultValue = "90" # days
 defaultValue = "3" # days
 
 [contract.InitialModuleBundle]
-artifact = "InitialModuleBundle"
+artifact = "contracts/modules/core/InitialModuleBundle.sol:InitialModuleBundle"
 create2 = true
 
 [contract.InitialProxy]
@@ -51,30 +51,38 @@ depends = ["contract.InitialModuleBundle"]
 [contract.AssociatedSystemsModule]
 artifact = "contracts/modules/core/AssociatedSystemsModule.sol:AssociatedSystemsModule"
 
-[contract.ElectionModule]
-artifact = "ElectionModule"
-
 [contract.ElectionInspectorModule]
-artifact = "ElectionInspectorModule"
+artifact = "contracts/modules/core/ElectionInspectorModule.sol:ElectionInspectorModule"
+
+[contract.ElectionModule]
+artifact = "contracts/modules/core/ElectionModule.sol:ElectionModule"
+
+[contract.OwnerModule]
+artifact = "contracts/modules/core/OwnerModule.sol:OwnerModule"
+
+[contract.UpgradeProposalModule]
+artifact = "contracts/modules/core/UpgradeProposalModule.sol:UpgradeProposalModule"
 
 [contract.CouncilTokenModule]
-artifact = "CouncilTokenModule"
+artifact = "contracts/modules/council-nft/CouncilTokenModule.sol:CouncilTokenModule"
 
 [contract.DebtShareMock]
-artifact = "DebtShareMock"
+artifact = "contracts/mocks/DebtShareMock.sol:DebtShareMock"
 
 [router.CoreRouter]
 contracts = [
   "AssociatedSystemsModule",
-  "ElectionModule",
   "ElectionInspectorModule",
-  "InitialModuleBundle",
+  "ElectionModule",
+  "OwnerModule",
+  "UpgradeProposalModule",
 ]
 depends = [
   "contract.AssociatedSystemsModule",
-  "contract.ElectionModule",
   "contract.ElectionInspectorModule",
-  "contract.InitialModuleBundle",
+  "contract.ElectionModule",
+  "contract.OwnerModule",
+  "contract.UpgradeProposalModule",
 ]
 
 [invoke.upgrade_core_proxy]

--- a/protocol/governance/contracts/modules/core/BaseElectionModule.sol
+++ b/protocol/governance/contracts/modules/core/BaseElectionModule.sol
@@ -7,6 +7,7 @@ import "@synthetixio/core-contracts/contracts/initializable/InitializableMixin.s
 import "@synthetixio/core-contracts/contracts/utils/SafeCast.sol";
 import "@synthetixio/core-contracts/contracts/ownership/OwnableStorage.sol";
 import "@synthetixio/main/contracts/storage/CrossChain.sol";
+import "@synthetixio/core-contracts/contracts/proxy/ProxyStorage.sol";
 import "../../interfaces/IElectionModule.sol";
 import "../../submodules/election/ElectionSettingsManager.sol";
 import "../../submodules/election/ElectionSchedule.sol";
@@ -21,7 +22,8 @@ contract BaseElectionModule is
     ElectionCredentials,
     ElectionVotes,
     ElectionTally,
-    InitializableMixin
+    InitializableMixin,
+    ProxyStorage
 {
     using SetUtil for SetUtil.AddressSet;
     using Council for Council.Data;
@@ -82,8 +84,12 @@ contract BaseElectionModule is
             epochEndDate - epochStartDate, // epochDuration
             votingPeriodStartDate - nominationPeriodStartDate, // nominationPeriodDuration
             epochEndDate - votingPeriodStartDate, // votingPeriodDuration
-            maxDateAdjustmentTolerance // maxDateAdjustmentTolerance
+            maxDateAdjustmentTolerance
         );
+
+        // Set current implementation (see UpgradeProposalModule)
+        settings.proposedImplementation = _proxyStore().implementation;
+
         _copyMissingSettings(settings, store.getNextElectionSettings());
 
         Epoch.Data storage firstEpoch = store.getCurrentElection().epoch;

--- a/protocol/governance/contracts/modules/core/InitialModuleBundle.sol
+++ b/protocol/governance/contracts/modules/core/InitialModuleBundle.sol
@@ -4,10 +4,6 @@ pragma solidity >=0.8.11 <0.9.0;
 import "@synthetixio/core-modules/contracts/modules/OwnerModule.sol";
 import "@synthetixio/core-modules/contracts/modules/UpgradeModule.sol";
 
-// The below contract is only used during initialization as a kernel for the first release which the system can be upgraded onto.
-// Subsequent upgrades will not need this module bundle
-// In the future on live networks, we may want to find some way to hardcode the owner address here to prevent grieving
-
 // solhint-disable-next-line no-empty-blocks
 contract InitialModuleBundle is OwnerModule, UpgradeModule {
 

--- a/protocol/governance/contracts/modules/core/OwnerModule.sol
+++ b/protocol/governance/contracts/modules/core/OwnerModule.sol
@@ -1,0 +1,9 @@
+//SPDX-License-Identifier: MIT
+pragma solidity >=0.8.11 <0.9.0;
+
+import {OwnerModule as BaseOwnerModule} from "@synthetixio/core-modules/contracts/modules/OwnerModule.sol";
+
+// solhint-disable-next-line no-empty-blocks
+contract OwnerModule is BaseOwnerModule {
+
+}

--- a/protocol/governance/contracts/modules/core/UpgradeProposalModule.sol
+++ b/protocol/governance/contracts/modules/core/UpgradeProposalModule.sol
@@ -1,0 +1,78 @@
+//SPDX-License-Identifier: MIT
+pragma solidity >=0.8.11 <0.9.0;
+
+import "@synthetixio/core-contracts/contracts/errors/AddressError.sol";
+import "@synthetixio/core-contracts/contracts/utils/AddressUtil.sol";
+import "@synthetixio/core-contracts/contracts/errors/ChangeError.sol";
+import "@synthetixio/core-contracts/contracts/proxy/UUPSImplementation.sol";
+import "@synthetixio/core-contracts/contracts/ownership/OwnableStorage.sol";
+import "../../storage/Council.sol";
+
+contract UpgradeProposalModule is UUPSImplementation {
+    using Council for Council.Data;
+
+    function upgradeTo(address candidateImplementation) public override {
+        OwnableStorage.onlyOwner();
+        ProxyStore storage store = _proxyStore();
+
+        if (store.simulatingUpgrade == true) {
+            _upgradeTo(candidateImplementation);
+        } else {
+            _proposeUpgrade(candidateImplementation);
+        }
+    }
+
+    function _proposeUpgrade(address newImplementation) internal {
+        _validateImplementation(newImplementation);
+
+        ElectionSettings.Data storage settings = Council.load().getNextElectionSettings();
+        settings.proposedImplementation = newImplementation;
+        emit Upgraded(address(this), newImplementation);
+    }
+
+    function _validateImplementation(address candidateImplementation) internal {
+        if (candidateImplementation == address(0)) {
+            revert AddressError.ZeroAddress();
+        }
+
+        if (!AddressUtil.isContract(candidateImplementation)) {
+            revert AddressError.NotAContract(candidateImplementation);
+        }
+
+        ProxyStore storage store = _proxyStore();
+
+        if (candidateImplementation == store.implementation) {
+            revert ChangeError.NoChange();
+        }
+
+        if (_implementationIsSterile(candidateImplementation)) {
+            revert ImplementationIsSterile(candidateImplementation);
+        }
+    }
+
+    function getProposedImplementation() external view returns (address) {
+        return Council.load().getNextElectionSettings().proposedImplementation;
+    }
+
+    function acceptUpgradeProposal() public {
+        OwnableStorage.onlyOwner();
+        ElectionSettings.Data storage settings = Council.load().getCurrentElectionSettings();
+        _upgradeTo(settings.proposedImplementation);
+    }
+
+    function declineUpgradeProposal() public {
+        OwnableStorage.onlyOwner();
+        ElectionSettings.Data storage prevSettings = Council.load().getPreviousElectionSettings();
+        ElectionSettings.Data storage currSettings = Council.load().getCurrentElectionSettings();
+
+        address currentImplementation = this.getImplementation();
+
+        if (currentImplementation != prevSettings.proposedImplementation) {
+            _upgradeTo(prevSettings.proposedImplementation);
+        }
+
+        // Clean implementation proposal value, in the case the next Council needs
+        // to also decline it, they will use this value instead of the currently declined one.
+        currSettings.proposedImplementation = prevSettings.proposedImplementation;
+    }
+}

--- a/protocol/governance/contracts/storage/ElectionSettings.sol
+++ b/protocol/governance/contracts/storage/ElectionSettings.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.0;
 
 library ElectionSettings {
     struct Data {
+        // Implementation proposed by previous Council to which can be upgraded to (see UpgradeProposalModule)
+        address proposedImplementation;
         // Number of council members in the current epoch
         uint8 epochSeatCount;
         // Minimum active council members. If too many are dismissed an emergency election is triggered

--- a/protocol/governance/contracts/submodules/election/ElectionSettingsManager.sol
+++ b/protocol/governance/contracts/submodules/election/ElectionSettingsManager.sol
@@ -65,6 +65,9 @@ contract ElectionSettingsManager is ElectionBase {
         ElectionSettings.Data storage from,
         ElectionSettings.Data storage to
     ) internal {
+        if (to.proposedImplementation == address(0)) {
+            to.proposedImplementation = from.proposedImplementation;
+        }
         if (to.epochSeatCount == 0) {
             to.epochSeatCount = from.epochSeatCount;
         }

--- a/protocol/governance/storage.dump.sol
+++ b/protocol/governance/storage.dump.sol
@@ -263,6 +263,7 @@ library Election {
 // @custom:artifact contracts/storage/ElectionSettings.sol:ElectionSettings
 library ElectionSettings {
     struct Data {
+        address proposedImplementation;
         uint8 epochSeatCount;
         uint8 minimumActiveMembers;
         uint64 epochDuration;

--- a/protocol/governance/test/contracts/UpgradeProposalModule.test.ts
+++ b/protocol/governance/test/contracts/UpgradeProposalModule.test.ts
@@ -1,0 +1,53 @@
+import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
+import { ethers } from 'ethers';
+import hre from 'hardhat';
+import { bootstrap } from '../bootstrap';
+import { InitialModuleBundle } from '../generated/typechain';
+
+describe('UpgradeProposalModule', function () {
+  const { c, getSigners, snapshotCheckpoint } = bootstrap();
+
+  let owner: ethers.Signer;
+  let user: ethers.Signer;
+
+  before('identify signers', function () {
+    [owner, user] = getSigners();
+  });
+
+  describe('#upgradeTo', function () {
+    it('reverts when called by not the owner', async function () {
+      await assertRevert(
+        c.CoreProxy.connect(user).upgradeTo(ethers.constants.AddressZero),
+        'Unauthorized'
+      );
+    });
+
+    it('reverts when using Zero Address', async function () {
+      await assertRevert(c.CoreProxy.upgradeTo(ethers.constants.AddressZero), 'ZeroAddress');
+    });
+
+    it('reverts when using something that is not a contract', async function () {
+      await assertRevert(c.CoreProxy.upgradeTo(await user.getAddress()), 'NotAContract');
+    });
+
+    it('reverts when proposing same implementation', async function () {
+      const current = await c.CoreProxy.getImplementation();
+      await assertRevert(c.CoreProxy.upgradeTo(current), 'NoChange');
+    });
+  });
+
+  // describe('#simulateUpgradeTo', function () {
+  //   let NewImplementation: InitialModuleBundle;
+
+  //   snapshotCheckpoint();
+
+  //   before('create new implementation', async function () {
+  //     const factory = await hre.ethers.getContractFactory('InitialModuleBundle', owner);
+  //     NewImplementation = await factory.deploy();
+  //   });
+
+  //   it('reverts', async function () {
+  //     await c.CoreProxy.simulateUpgradeTo(NewImplementation.address);
+  //   });
+  // });
+});


### PR DESCRIPTION
This PR adds a new module `UpgradeProposalModule` which replaces the original `UpgradeModule`, adding the custom functionality where the upgrades can only be proposed to the next Council, which then can be accepted or declined.