### PR TITLE
add new views

### DIFF
--- a/markets/perps-market/contracts/interfaces/IAsyncOrderModule.sol
+++ b/markets/perps-market/contracts/interfaces/IAsyncOrderModule.sol
@@ -74,4 +74,16 @@ interface IAsyncOrderModule {
         uint128 marketId,
         uint128 accountId
     ) external returns (AsyncOrder.Data memory order);
+
+    /**
+     * @notice Simulates what the order fee would be for the given market with the specified size.
+     * @dev    Note that this does not include the settlement reward fee, which is based on the strategy type used
+     * @param marketId id of the market.
+     * @param sizeDelta size of position.
+     * @return orderFees incurred fees.
+     */
+    function getAsyncOrderFees(
+        uint128 marketId,
+        int128 sizeDelta
+    ) external returns (uint256 orderFees);
 }

--- a/markets/perps-market/contracts/interfaces/IAsyncOrderModule.sol
+++ b/markets/perps-market/contracts/interfaces/IAsyncOrderModule.sol
@@ -85,5 +85,5 @@ interface IAsyncOrderModule {
     function getAsyncOrderFees(
         uint128 marketId,
         int128 sizeDelta
-    ) external returns (uint256 orderFees);
+    ) external view returns (uint256 orderFees);
 }

--- a/markets/perps-market/contracts/interfaces/IAsyncOrderModule.sol
+++ b/markets/perps-market/contracts/interfaces/IAsyncOrderModule.sol
@@ -82,7 +82,7 @@ interface IAsyncOrderModule {
      * @param sizeDelta size of position.
      * @return orderFees incurred fees.
      */
-    function getAsyncOrderFees(
+    function computeOrderFees(
         uint128 marketId,
         int128 sizeDelta
     ) external view returns (uint256 orderFees);

--- a/markets/perps-market/contracts/interfaces/IPerpsAccountModule.sol
+++ b/markets/perps-market/contracts/interfaces/IPerpsAccountModule.sol
@@ -1,12 +1,10 @@
 //SPDX-License-Identifier: MIT
 pragma solidity >=0.8.11 <0.9.0;
 
-import {AsyncOrder} from "../storage/AsyncOrder.sol";
-
 /**
  * @title Account module
  */
-interface IAccountModule {
+interface IPerpsAccountModule {
     /**
      * @notice Gets fired when an account colateral is modified.
      * @param accountId Id of the account.
@@ -77,5 +75,24 @@ interface IAccountModule {
      * @param accountId Id of the account.
      * @return availableMargin available margin of the position.
      */
-    function getAvailableMargin(uint128 accountId) external view returns (int);
+    function getAvailableMargin(uint128 accountId) external view returns (int256 availableMargin);
+
+    /**
+     * @notice Gets the exact withdrawable amount a trader has available from this account while holding the account's current positions.
+     * @param accountId Id of the account.
+     * @return withdrawableMargin available margin to withdraw.
+     */
+    function getWithdrawableMargin(
+        uint128 accountId
+    ) external view returns (int256 withdrawableMargin);
+
+    /**
+     * @notice Gets the initial/maintenance margins across all positions that an account has open.
+     * @param accountId Id of the account.
+     * @return requiredInitialMargin initial margin req (used when withdrawing collateral).
+     * @return requiredMaintenanceMargin maintenance margin req (used to determine liquidation threshold).
+     */
+    function getRequiredMargins(
+        uint128 accountId
+    ) external view returns (uint256 requiredInitialMargin, uint256 requiredMaintenanceMargin);
 }

--- a/markets/perps-market/contracts/interfaces/IPerpsMarketModule.sol
+++ b/markets/perps-market/contracts/interfaces/IPerpsMarketModule.sol
@@ -32,7 +32,7 @@ interface IPerpsMarketModule {
 
     function indexPrice(uint128 marketId) external view returns (uint);
 
-    function fillPrice(uint128 marketId, int orderSize, uint price) external returns (uint);
+    function fillPrice(uint128 marketId, int128 orderSize, uint price) external returns (uint);
 
     /**
      * @dev Given a marketId return a market's summary details in one call.

--- a/markets/perps-market/contracts/modules/AsyncOrderModule.sol
+++ b/markets/perps-market/contracts/modules/AsyncOrderModule.sol
@@ -126,7 +126,7 @@ contract AsyncOrderModule is IAsyncOrderModule {
     function getAsyncOrderFees(
         uint128 marketId,
         int128 sizeDelta
-    ) external override returns (uint256 orderFees) {
+    ) external view override returns (uint256 orderFees) {
         PerpsMarket.Data storage perpsMarket = PerpsMarket.load(marketId);
         int256 skew = perpsMarket.skew;
         PerpsMarketConfiguration.Data storage marketConfig = PerpsMarketConfiguration.load(

--- a/markets/perps-market/contracts/modules/AsyncOrderModule.sol
+++ b/markets/perps-market/contracts/modules/AsyncOrderModule.sol
@@ -123,7 +123,7 @@ contract AsyncOrderModule is IAsyncOrderModule {
     /**
      * @inheritdoc IAsyncOrderModule
      */
-    function getAsyncOrderFees(
+    function computeOrderFees(
         uint128 marketId,
         int128 sizeDelta
     ) external view override returns (uint256 orderFees) {

--- a/markets/perps-market/contracts/modules/AsyncOrderModule.sol
+++ b/markets/perps-market/contracts/modules/AsyncOrderModule.sol
@@ -6,7 +6,6 @@ import {DecimalMath} from "@synthetixio/core-contracts/contracts/utils/DecimalMa
 import {Account} from "@synthetixio/main/contracts/storage/Account.sol";
 import {AccountRBAC} from "@synthetixio/main/contracts/storage/AccountRBAC.sol";
 import {IPythVerifier} from "../interfaces/external/IPythVerifier.sol";
-import {IAccountModule} from "../interfaces/IAccountModule.sol";
 import {IAsyncOrderModule} from "../interfaces/IAsyncOrderModule.sol";
 import {PerpsAccount, SNX_USD_MARKET_ID} from "../storage/PerpsAccount.sol";
 import {MathUtil} from "../utils/MathUtil.sol";
@@ -119,5 +118,32 @@ contract AsyncOrderModule is IAsyncOrderModule {
         order.reset();
 
         emit OrderCanceled(marketId, accountId, order.settlementTime, order.acceptablePrice);
+    }
+
+    /**
+     * @inheritdoc IAsyncOrderModule
+     */
+    function getAsyncOrderFees(
+        uint128 marketId,
+        int128 sizeDelta
+    ) external override returns (uint256 orderFees) {
+        PerpsMarket.Data storage perpsMarket = PerpsMarket.load(marketId);
+        int256 skew = perpsMarket.skew;
+        PerpsMarketConfiguration.Data storage marketConfig = PerpsMarketConfiguration.load(
+            marketId
+        );
+        uint256 fillPrice = AsyncOrder.calculateFillPrice(
+            skew,
+            marketConfig.skewScale,
+            sizeDelta,
+            PerpsPrice.getCurrentPrice(marketId)
+        );
+
+        orderFees = AsyncOrder.calculateOrderFee(
+            sizeDelta,
+            fillPrice,
+            skew,
+            marketConfig.orderFees
+        );
     }
 }

--- a/markets/perps-market/contracts/modules/LiquidationModule.sol
+++ b/markets/perps-market/contracts/modules/LiquidationModule.sol
@@ -30,7 +30,7 @@ contract LiquidationModule is ILiquidationModule, IMarketEvents {
             .liquidatableAccounts;
         PerpsAccount.Data storage account = PerpsAccount.load(accountId);
         if (!liquidatableAccounts.contains(accountId)) {
-            (bool isEligible, , ) = account.isEligibleForLiquidation();
+            (bool isEligible, , , ) = account.isEligibleForLiquidation();
 
             if (isEligible) {
                 account.flagForLiquidation();

--- a/markets/perps-market/contracts/modules/PerpsAccountModule.sol
+++ b/markets/perps-market/contracts/modules/PerpsAccountModule.sol
@@ -5,7 +5,7 @@ import {Account} from "@synthetixio/main/contracts/storage/Account.sol";
 import {AccountRBAC} from "@synthetixio/main/contracts/storage/AccountRBAC.sol";
 import {ITokenModule} from "@synthetixio/core-modules/contracts/interfaces/ITokenModule.sol";
 import {PerpsMarketFactory} from "../storage/PerpsMarketFactory.sol";
-import {IAccountModule} from "../interfaces/IAccountModule.sol";
+import {IPerpsAccountModule} from "../interfaces/IPerpsAccountModule.sol";
 import {PerpsAccount} from "../storage/PerpsAccount.sol";
 import {Position} from "../storage/Position.sol";
 import {AsyncOrder} from "../storage/AsyncOrder.sol";
@@ -17,9 +17,9 @@ import {SafeCastU256, SafeCastI256} from "@synthetixio/core-contracts/contracts/
 
 /**
  * @title Module to manage accounts
- * @dev See IAccountModule.
+ * @dev See IPerpsAccountModule.
  */
-contract PerpsAccountModule is IAccountModule {
+contract PerpsAccountModule is IPerpsAccountModule {
     using PerpsAccount for PerpsAccount.Data;
     using Position for Position.Data;
     using AsyncOrder for AsyncOrder.Data;
@@ -29,7 +29,7 @@ contract PerpsAccountModule is IAccountModule {
     using PerpsMarketFactory for PerpsMarketFactory.Data;
 
     /**
-     * @inheritdoc IAccountModule
+     * @inheritdoc IPerpsAccountModule
      */
     function modifyCollateral(
         uint128 accountId,
@@ -71,21 +71,21 @@ contract PerpsAccountModule is IAccountModule {
     }
 
     /**
-     * @inheritdoc IAccountModule
+     * @inheritdoc IPerpsAccountModule
      */
     function totalCollateralValue(uint128 accountId) external view override returns (uint) {
         return PerpsAccount.load(accountId).getTotalCollateralValue();
     }
 
     /**
-     * @inheritdoc IAccountModule
+     * @inheritdoc IPerpsAccountModule
      */
     function totalAccountOpenInterest(uint128 accountId) external view override returns (uint) {
         return PerpsAccount.load(accountId).getTotalNotionalOpenInterest();
     }
 
     /**
-     * @inheritdoc IAccountModule
+     * @inheritdoc IPerpsAccountModule
      */
     function getOpenPosition(
         uint128 accountId,
@@ -102,14 +102,45 @@ contract PerpsAccountModule is IAccountModule {
     }
 
     /**
-     * @inheritdoc IAccountModule
+     * @inheritdoc IPerpsAccountModule
      */
-    function getAvailableMargin(uint128 accountId) external view override returns (int) {
-        return PerpsAccount.load(accountId).getAvailableMargin();
+    function getAvailableMargin(
+        uint128 accountId
+    ) external view override returns (int256 availableMargin) {
+        availableMargin = PerpsAccount.load(accountId).getAvailableMargin();
     }
 
     /**
-     * @inheritdoc IAccountModule
+     * @inheritdoc IPerpsAccountModule
+     */
+    function getWithdrawableMargin(
+        uint128 accountId
+    ) external view override returns (int256 withdrawableMargin) {
+        PerpsAccount.Data storage account = PerpsAccount.load(accountId);
+        int256 availableMargin = account.getAvailableMargin();
+        (uint256 initialMaintenanceMargin, ) = account.getAccountRequiredMargins();
+
+        withdrawableMargin = availableMargin - initialMaintenanceMargin.toInt();
+    }
+
+    /**
+     * @inheritdoc IPerpsAccountModule
+     */
+    function getRequiredMargins(
+        uint128 accountId
+    )
+        external
+        view
+        override
+        returns (uint256 requiredInitialMargin, uint256 requiredMaintenanceMargin)
+    {
+        (requiredInitialMargin, requiredMaintenanceMargin) = PerpsAccount
+            .load(accountId)
+            .getAccountRequiredMargins();
+    }
+
+    /**
+     * @inheritdoc IPerpsAccountModule
      */
     function getCollateralAmount(
         uint128 accountId,

--- a/markets/perps-market/contracts/modules/PerpsMarketModule.sol
+++ b/markets/perps-market/contracts/modules/PerpsMarketModule.sol
@@ -45,7 +45,7 @@ contract PerpsMarketModule is IPerpsMarketModule {
 
     function fillPrice(
         uint128 marketId,
-        int orderSize,
+        int128 orderSize,
         uint price
     ) external view override returns (uint) {
         return

--- a/markets/perps-market/contracts/storage/AsyncOrder.sol
+++ b/markets/perps-market/contracts/storage/AsyncOrder.sol
@@ -295,7 +295,7 @@ library AsyncOrder {
         PerpsAccount.Data storage account = PerpsAccount.load(order.accountId);
 
         bool isEligible;
-        (isEligible, runtime.currentAvailableMargin, runtime.requiredMaintenanceMargin) = account
+        (isEligible, runtime.currentAvailableMargin, , runtime.requiredMaintenanceMargin) = account
             .isEligibleForLiquidation();
 
         if (isEligible) {
@@ -431,10 +431,10 @@ library AsyncOrder {
      * @notice Calculates the fill price for an order.
      */
     function calculateFillPrice(
-        int skew,
-        uint skewScale,
-        int size,
-        uint price
+        int256 skew,
+        uint256 skewScale,
+        int128 size,
+        uint256 price
     ) internal pure returns (uint) {
         // How is the p/d-adjusted price calculated using an example:
         //

--- a/markets/perps-market/contracts/storage/PerpsAccount.sol
+++ b/markets/perps-market/contracts/storage/PerpsAccount.sol
@@ -215,11 +215,13 @@ library PerpsAccount {
     }
 
     /**
-     * @notice  This function returns the minimum margin an account requires to stay above liquidation threshold
+     * @notice  This function returns the required margins for an account
+     * @dev The initial required margin is used to determine withdrawal amount and when opening positions
+     * @dev The maintenance margin is used to determine when to liquidate a position
      */
     function getAccountRequiredMargins(
         Data storage self
-    ) internal view returns (uint accountMaintenanceMargin, uint initialMaintenanceMargin) {
+    ) internal view returns (uint initialMargin, uint maintenanceMargin) {
         // use separate accounting for liquidation rewards so we can compare against global min/max liquidation reward values
         uint256 accumulatedLiquidationRewards;
         for (uint i = 1; i <= self.openPositionMarketIds.length(); i++) {
@@ -240,8 +242,8 @@ library PerpsAccount {
                 );
 
             accumulatedLiquidationRewards += liquidationMargin;
-            accountMaintenanceMargin += positionMaintenanceMargin;
-            initialMaintenanceMargin += positionInitialMargin;
+            maintenanceMargin += positionMaintenanceMargin;
+            initialMargin += positionInitialMargin;
         }
 
         // if account was liquidated, we account for liquidation reward that would be paid out to the liquidation keeper in required margin
@@ -250,8 +252,8 @@ library PerpsAccount {
         );
 
         return (
-            initialMaintenanceMargin + possibleLiquidationReward,
-            accountMaintenanceMargin + possibleLiquidationReward
+            initialMargin + possibleLiquidationReward,
+            maintenanceMargin + possibleLiquidationReward
         );
     }
 

--- a/markets/perps-market/contracts/storage/PerpsMarketConfiguration.sol
+++ b/markets/perps-market/contracts/storage/PerpsMarketConfiguration.sol
@@ -48,7 +48,7 @@ library PerpsMarketConfiguration {
          */
         uint256 liquidationRewardRatioD18;
         /**
-         * @dev minimum position value in USD, this is used when we calculate maintenance margin
+         * @dev minimum position value in USD, this is a constant value added to position margin requirements (initial/maintenance)
          */
         uint256 minimumPositionMargin;
     }
@@ -99,8 +99,10 @@ library PerpsMarketConfiguration {
         maintenanceMarginRatio = impactOnSkew.mulDecimal(self.maintenanceMarginRatioD18);
 
         uint256 notional = sizeAbs.mulDecimal(price);
-        initialMargin = notional.mulDecimal(initialMarginRatio);
-        maintenanceMargin = notional.mulDecimal(maintenanceMarginRatio);
+        initialMargin = notional.mulDecimal(initialMarginRatio) + self.minimumPositionMargin;
+        maintenanceMargin =
+            notional.mulDecimal(maintenanceMarginRatio) +
+            self.minimumPositionMargin;
 
         liquidationMargin = calculateLiquidationReward(self, notional);
     }

--- a/markets/perps-market/test/integration/Account/Margins.test.ts
+++ b/markets/perps-market/test/integration/Account/Margins.test.ts
@@ -1,0 +1,104 @@
+import { ethers } from 'ethers';
+import { bn, bootstrapMarkets } from '../bootstrap';
+import assertBn from '@synthetixio/core-utils/src/utils/assertions/assert-bignumber';
+import assertEvent from '@synthetixio/core-utils/utils/assertions/assert-event';
+import { PerpsMarketProxy } from '../../generated/typechain';
+import { openPosition } from '../helpers';
+
+describe.only('Account margins test', () => {
+  const accountId = 4;
+  const { systems, provider, trader1, perpsMarkets } = bootstrapMarkets({
+    synthMarkets: [],
+    perpsMarkets: [
+      {
+        requestedMarketId: 25,
+        name: 'Bitcoin',
+        token: 'BTC',
+        price: bn(30_000),
+        fundingParams: { skewScale: bn(100), maxFundingVelocity: bn(0) },
+        liquidationParams: {
+          initialMarginFraction: bn(2),
+          maintenanceMarginFraction: bn(1),
+          maxLiquidationLimitAccumulationMultiplier: bn(1),
+          liquidationRewardRatio: bn(0.05),
+          maxSecondsInLiquidationWindow: bn(10),
+          minimumPositionMargin: bn(1000),
+        },
+        settlementStrategy: {
+          settlementReward: bn(0),
+        },
+      },
+      {
+        requestedMarketId: 26,
+        name: 'Ether',
+        token: 'ETH',
+        price: bn(2000),
+        fundingParams: { skewScale: bn(1000), maxFundingVelocity: bn(0) },
+        liquidationParams: {
+          initialMarginFraction: bn(2),
+          maintenanceMarginFraction: bn(1),
+          maxLiquidationLimitAccumulationMultiplier: bn(1),
+          liquidationRewardRatio: bn(0.05),
+          maxSecondsInLiquidationWindow: bn(10),
+          minimumPositionMargin: bn(500),
+        },
+        settlementStrategy: {
+          settlementReward: bn(0),
+        },
+      },
+    ],
+    traderAccountIds: [accountId, 5],
+  });
+
+  // add $100k
+  before('add some snx collateral to margin', async () => {
+    await systems().PerpsMarket.connect(trader1()).modifyCollateral(accountId, 0, bn(100_000));
+  });
+
+  describe('before open positions', () => {
+    it('has correct available margin', async () => {
+      assertBn.equal(await systems().PerpsMarket.getAvailableMargin(accountId), bn(100_000));
+    });
+
+    it('has correct withdrawable margin', async () => {
+      assertBn.equal(await systems().PerpsMarket.getWithdrawableMargin(accountId), bn(100_000));
+    });
+
+    it('has correct initial and maintenance margin', async () => {
+      const [initialMargin, maintenanceMargin] = await systems().PerpsMarket.getRequiredMargins(
+        accountId
+      );
+      assertBn.equal(initialMargin, 0);
+      assertBn.equal(maintenanceMargin, 0);
+    });
+  });
+
+  describe('after open positions', () => {
+    before('open 2 positions', async () => {
+      await openPosition({
+        systems,
+        provider,
+        trader: trader1(),
+        accountId: 2,
+        keeper: trader1(),
+        marketId: perpsMarkets()[0].marketId(),
+        sizeDelta: bn(-2),
+        settlementStrategyId: perpsMarkets()[0].strategyId(),
+        price: bn(30_000),
+      });
+      await openPosition({
+        systems,
+        provider,
+        trader: trader1(),
+        accountId: 2,
+        keeper: trader1(),
+        marketId: perpsMarkets()[1].marketId(),
+        sizeDelta: bn(20),
+        settlementStrategyId: perpsMarkets()[1].strategyId(),
+        price: bn(2_000),
+      });
+    });
+
+    it('has correct available margin', async () => {});
+  });
+});

--- a/markets/perps-market/test/integration/Account/ModifyCollateral.withdraw.test.ts
+++ b/markets/perps-market/test/integration/Account/ModifyCollateral.withdraw.test.ts
@@ -9,7 +9,7 @@ import { wei } from '@synthetixio/wei';
 import { OpenPositionData, openPosition } from '../helpers';
 
 const sUSDSynthId = 0;
-describe('ModifyCollateral Withdraw', () => {
+describe.only('ModifyCollateral Withdraw', () => {
   const accountIds = [10, 20];
   const oneBTC = wei(1);
   const marginAmount = wei(10_000);
@@ -93,22 +93,12 @@ describe('ModifyCollateral Withdraw', () => {
     });
 
     it('properly reflects core system collateral balance', async () => {
-      // const perpsBalanceAfter = await synthMarkets()[0]
-      //   .synth()
-      //   .connect(trader1())
-      //   .balanceOf(systems().PerpsMarket.address);
-
       const btcCollateralValue = await systems().Core.getMarketCollateralAmount(
         superMarketId(),
         synthMarkets()[0].synthAddress()
       );
 
       assertBn.equal(btcCollateralValue, depositAmount.sub(withdrawAmount).toBN());
-
-      // assertBn.equal(
-      //   perpsBalanceAfter,
-      //   wei(perpsBalanceBefore).add(depositAmount).sub(withdrawAmount).toBN()
-      // );
     });
 
     it('emits correct event with the expected values', async () => {
@@ -259,10 +249,15 @@ describe('ModifyCollateral Withdraw', () => {
         );
       });
     });
-    describe('allow withdraw when its less than "collateral available for withdraw', () => {
+    describe('allow withdraw when its less than collateral available for withdraw', () => {
       const restore = snapshotCheckpoint(provider);
 
       before('withdraw allowed amount', async () => {
+        const [initialMarginReq] = await systems()
+          .PerpsMarket.connect(trader1())
+          .getRequiredMargins(trader1AccountId);
+        // available margin = collateral value + pnl = $19000
+
         await systems()
           .PerpsMarket.connect(trader1())
           .modifyCollateral(trader1AccountId, sUSDSynthId, bn(-17000));

--- a/markets/perps-market/test/integration/Orders/OffchainAsyncOrder.fees.test.ts
+++ b/markets/perps-market/test/integration/Orders/OffchainAsyncOrder.fees.test.ts
@@ -1,5 +1,5 @@
 import { ethers } from 'ethers';
-import { DEFAULT_SETTLEMENT_STRATEGY, bn, bootstrapMarkets, decimalMul } from '../bootstrap';
+import { DEFAULT_SETTLEMENT_STRATEGY, bn, bootstrapMarkets } from '../bootstrap';
 import { fastForwardTo } from '@synthetixio/core-utils/utils/hardhat/rpc';
 import { snapshotCheckpoint } from '@synthetixio/core-utils/utils/mocha/snapshot';
 import { SynthMarkets } from '@synthetixio/spot-market/test/common';
@@ -15,7 +15,7 @@ import assertBn from '@synthetixio/core-utils/utils/assertions/assert-bignumber'
 import { getTxTime } from '@synthetixio/core-utils/src/utils/hardhat/rpc';
 import Wei, { wei } from '@synthetixio/wei';
 
-describe.only('Offchain Async Order test - fees', () => {
+describe('Offchain Async Order test - fees', () => {
   const orderFees = {
     makerFee: wei(0.0003), // 3bps
     takerFee: wei(0.0008), // 8bps

--- a/markets/perps-market/test/integration/Orders/OffchainAsyncOrder.fees.test.ts
+++ b/markets/perps-market/test/integration/Orders/OffchainAsyncOrder.fees.test.ts
@@ -155,7 +155,7 @@ describe('Offchain Async Order test - fees', () => {
 
         it('returns proper fees on getOrderFees', async () => {
           assertBn.equal(
-            await systems().PerpsMarket.getAsyncOrderFees(ethMarketId, sizeDelta),
+            await systems().PerpsMarket.computeOrderFees(ethMarketId, sizeDelta),
             feesPaidOnSettle.perpsMarketFee
           );
         });

--- a/markets/perps-market/test/integration/bootstrap/bootstrap.ts
+++ b/markets/perps-market/test/integration/bootstrap/bootstrap.ts
@@ -157,5 +157,3 @@ export function bootstrapMarkets(data: BootstrapArgs) {
 
 export const bn = (n: number) => wei(n).toBN();
 export const toNum = (n: ethers.BigNumber) => Number(ethers.utils.formatEther(n));
-export const decimalMul = (a: ethers.BigNumber, b: ethers.BigNumber) => a.mul(b).div(bn(1));
-export const decimalDiv = (a: ethers.BigNumber, b: ethers.BigNumber) => a.mul(bn(1)).div(b);

--- a/markets/perps-market/test/integration/helpers/computeFees.ts
+++ b/markets/perps-market/test/integration/helpers/computeFees.ts
@@ -1,5 +1,5 @@
 import { ethers } from 'ethers';
-import { DEFAULT_SETTLEMENT_STRATEGY, bn } from '../bootstrap';
+import { DEFAULT_SETTLEMENT_STRATEGY } from '../bootstrap';
 import Wei, { wei } from '@synthetixio/wei';
 
 type OrderFees = {

--- a/markets/perps-market/test/integration/helpers/computeFees.ts
+++ b/markets/perps-market/test/integration/helpers/computeFees.ts
@@ -1,0 +1,49 @@
+import { ethers } from 'ethers';
+import { DEFAULT_SETTLEMENT_STRATEGY, bn } from '../bootstrap';
+import Wei, { wei } from '@synthetixio/wei';
+
+type OrderFees = {
+  makerFee: Wei;
+  takerFee: Wei;
+};
+
+export type Fees = {
+  totalFees: ethers.BigNumber;
+  keeperFee: ethers.BigNumber;
+  perpsMarketFee: ethers.BigNumber;
+};
+
+export const computeFees: (
+  sizeBefore: Wei,
+  sizeDelta: Wei,
+  price: Wei,
+  orderFees: OrderFees
+) => Fees = (sizeBefore, sizeDelta, price, orderFees) => {
+  let makerSize = wei(0),
+    takerSize = wei(0);
+
+  if (sizeDelta.eq(0)) {
+    // no change in fees
+  } else if (sizeBefore.eq(0) || sizeBefore.mul(sizeDelta).gt(0)) {
+    // same side. taker
+    takerSize = sizeDelta.abs();
+  } else {
+    makerSize = sizeBefore.abs() > sizeDelta.abs() ? sizeDelta.abs() : sizeBefore.abs();
+    takerSize = sizeBefore.abs() < sizeDelta.abs() ? sizeDelta.abs().sub(sizeBefore.abs()) : wei(0);
+  }
+
+  const notionalTaker = wei(takerSize).mul(wei(price));
+  const notionalMaker = wei(makerSize).mul(price);
+
+  const perpsMarketFee = notionalMaker
+    .mul(orderFees.makerFee)
+    .add(notionalTaker.mul(orderFees.takerFee));
+
+  const keeperFee = DEFAULT_SETTLEMENT_STRATEGY.settlementReward;
+
+  return {
+    totalFees: perpsMarketFee.add(keeperFee).toBN(),
+    perpsMarketFee: perpsMarketFee.toBN(),
+    keeperFee,
+  };
+};

--- a/markets/perps-market/test/integration/helpers/index.ts
+++ b/markets/perps-market/test/integration/helpers/index.ts
@@ -1,3 +1,5 @@
 export * from './settleHelper';
 export * from './collateralHelper';
 export * from './openPosition';
+export * from './fillPrice';
+export * from './computeFees';


### PR DESCRIPTION
- Adds three new views: `computeOrderFees`, `getWithdrawableMargin`, `getRequiredMargins`.
- Uses initial margin instead of maintenance margin for withdrawable margin calc.
- Tests (and a small `computeFees` types change)