### PR TITLE
New liquidation params

### DIFF
--- a/markets/perps-market/contracts/interfaces/IMarketConfigurationModule.sol
+++ b/markets/perps-market/contracts/interfaces/IMarketConfigurationModule.sol
@@ -62,6 +62,7 @@ interface IMarketConfigurationModule {
         uint128 indexed marketId,
         uint256 initialMarginRatioD18,
         uint256 maintenanceMarginRatioD18,
+        uint256 minimumInitialMarginRatioD18,
         uint256 liquidationRewardRatioD18,
         uint256 maxLiquidationLimitAccumulationMultiplier,
         uint256 maxSecondsInLiquidationWindow,
@@ -132,7 +133,8 @@ interface IMarketConfigurationModule {
      * @notice Set liquidation parameters for a market with this function.
      * @param marketId id of the market to set liquidation parameters.
      * @param initialMarginRatioD18 the initial margin ratio (as decimal with 18 digits precision).
-     * @param maintenanceMarginRatioD18 the maintenance margin ratio (as decimal with 18 digits precision).
+     * @param minimumInitialMarginRatioD18 the minimum initial margin ratio (as decimal with 18 digits precision).
+     * @param maintenanceMarginScalarD18 the maintenance margin scalar relative to the initial margin ratio (as decimal with 18 digits precision).
      * @param liquidationRewardRatioD18 the liquidation reward ratio (as decimal with 18 digits precision).
      * @param maxLiquidationLimitAccumulationMultiplier the max liquidation limit accumulation multiplier.
      * @param maxSecondsInLiquidationWindow the max seconds in liquidation window (used together with the acc multiplier to get max liquidation per window).
@@ -141,7 +143,8 @@ interface IMarketConfigurationModule {
     function setLiquidationParameters(
         uint128 marketId,
         uint256 initialMarginRatioD18,
-        uint256 maintenanceMarginRatioD18,
+        uint256 minimumInitialMarginRatioD18,
+        uint256 maintenanceMarginScalarD18,
         uint256 liquidationRewardRatioD18,
         uint256 maxLiquidationLimitAccumulationMultiplier,
         uint256 maxSecondsInLiquidationWindow,
@@ -190,10 +193,12 @@ interface IMarketConfigurationModule {
      * @notice Gets liquidation parameters details of a market.
      * @param marketId id of the market.
      * @return initialMarginRatioD18 the initial margin ratio (as decimal with 18 digits precision).
-     * @return maintenanceMarginRatioD18 the maintenance margin ratio (as decimal with 18 digits precision).
+     * @return minimumInitialMarginRatioD18 the minimum initial margin ratio (as decimal with 18 digits precision).
+     * @return maintenanceMarginScalarD18 the maintenance margin scalar relative to the initial margin ratio (as decimal with 18 digits precision).
      * @return liquidationRewardRatioD18 the liquidation reward ratio (as decimal with 18 digits precision).
      * @return maxLiquidationLimitAccumulationMultiplier the max liquidation limit accumulation multiplier.
      * @return maxSecondsInLiquidationWindow the max seconds in liquidation window (used together with the acc multiplier to get max liquidation per window).
+     * @return minimumPositionMargin the minimum position margin.
      */
     function getLiquidationParameters(
         uint128 marketId
@@ -202,10 +207,12 @@ interface IMarketConfigurationModule {
         view
         returns (
             uint256 initialMarginRatioD18,
-            uint256 maintenanceMarginRatioD18,
+            uint256 minimumInitialMarginRatioD18,
+            uint256 maintenanceMarginScalarD18,
             uint256 liquidationRewardRatioD18,
             uint256 maxLiquidationLimitAccumulationMultiplier,
-            uint256 maxSecondsInLiquidationWindow
+            uint256 maxSecondsInLiquidationWindow,
+            uint256 minimumPositionMargin
         );
 
     /**

--- a/markets/perps-market/contracts/modules/MarketConfigurationModule.sol
+++ b/markets/perps-market/contracts/modules/MarketConfigurationModule.sol
@@ -108,7 +108,8 @@ contract MarketConfigurationModule is IMarketConfigurationModule {
     function setLiquidationParameters(
         uint128 marketId,
         uint256 initialMarginRatioD18,
-        uint256 maintenanceMarginRatioD18,
+        uint256 minimumInitialMarginRatioD18,
+        uint256 maintenanceMarginScalarD18,
         uint256 liquidationRewardRatioD18,
         uint256 maxLiquidationLimitAccumulationMultiplier,
         uint256 maxSecondsInLiquidationWindow,
@@ -118,7 +119,8 @@ contract MarketConfigurationModule is IMarketConfigurationModule {
         PerpsMarketConfiguration.Data storage config = PerpsMarketConfiguration.load(marketId);
 
         config.initialMarginRatioD18 = initialMarginRatioD18;
-        config.maintenanceMarginRatioD18 = maintenanceMarginRatioD18;
+        config.maintenanceMarginScalarD18 = maintenanceMarginScalarD18;
+        config.minimumInitialMarginRatioD18 = minimumInitialMarginRatioD18;
         config.liquidationRewardRatioD18 = liquidationRewardRatioD18;
         config
             .maxLiquidationLimitAccumulationMultiplier = maxLiquidationLimitAccumulationMultiplier;
@@ -128,7 +130,8 @@ contract MarketConfigurationModule is IMarketConfigurationModule {
         emit LiquidationParametersSet(
             marketId,
             initialMarginRatioD18,
-            maintenanceMarginRatioD18,
+            maintenanceMarginScalarD18,
+            minimumInitialMarginRatioD18,
             liquidationRewardRatioD18,
             maxLiquidationLimitAccumulationMultiplier,
             maxSecondsInLiquidationWindow,
@@ -167,20 +170,24 @@ contract MarketConfigurationModule is IMarketConfigurationModule {
         override
         returns (
             uint256 initialMarginRatioD18,
-            uint256 maintenanceMarginRatioD18,
+            uint256 minimumInitialMarginRatioD18,
+            uint256 maintenanceMarginScalarD18,
             uint256 liquidationRewardRatioD18,
             uint256 maxLiquidationLimitAccumulationMultiplier,
-            uint256 maxSecondsInLiquidationWindow
+            uint256 maxSecondsInLiquidationWindow,
+            uint256 minimumPositionMargin
         )
     {
         PerpsMarketConfiguration.Data storage config = PerpsMarketConfiguration.load(marketId);
 
         initialMarginRatioD18 = config.initialMarginRatioD18;
-        maintenanceMarginRatioD18 = config.maintenanceMarginRatioD18;
+        minimumInitialMarginRatioD18 = config.minimumInitialMarginRatioD18;
+        maintenanceMarginScalarD18 = config.maintenanceMarginScalarD18;
         liquidationRewardRatioD18 = config.liquidationRewardRatioD18;
         maxLiquidationLimitAccumulationMultiplier = config
             .maxLiquidationLimitAccumulationMultiplier;
         maxSecondsInLiquidationWindow = config.maxSecondsInLiquidationWindow;
+        minimumPositionMargin = config.minimumPositionMargin;
     }
 
     /**

--- a/markets/perps-market/contracts/modules/PerpsAccountModule.sol
+++ b/markets/perps-market/contracts/modules/PerpsAccountModule.sol
@@ -118,9 +118,9 @@ contract PerpsAccountModule is IPerpsAccountModule {
     ) external view override returns (int256 withdrawableMargin) {
         PerpsAccount.Data storage account = PerpsAccount.load(accountId);
         int256 availableMargin = account.getAvailableMargin();
-        (uint256 initialMaintenanceMargin, ) = account.getAccountRequiredMargins();
+        (uint256 initialRequiredMargin, ) = account.getAccountRequiredMargins();
 
-        withdrawableMargin = availableMargin - initialMaintenanceMargin.toInt();
+        withdrawableMargin = availableMargin - initialRequiredMargin.toInt();
     }
 
     /**

--- a/markets/perps-market/contracts/storage/PerpsAccount.sol
+++ b/markets/perps-market/contracts/storage/PerpsAccount.sol
@@ -139,7 +139,7 @@ library PerpsAccount {
         (
             bool isEligible,
             int256 availableMargin,
-            uint256 initialMaintenanceMargin,
+            uint256 initialRequiredMargin,
 
         ) = isEligibleForLiquidation(self);
 
@@ -148,7 +148,7 @@ library PerpsAccount {
         }
 
         // availableMargin can be assumed to be positive since we check for isEligible for liquidation prior
-        availableWithdrawableCollateralUsd = availableMargin.toUint() - initialMaintenanceMargin;
+        availableWithdrawableCollateralUsd = availableMargin.toUint() - initialRequiredMargin;
 
         if (amountToWithdraw > availableWithdrawableCollateralUsd) {
             revert InsufficientCollateralAvailableForWithdraw(

--- a/markets/perps-market/contracts/storage/PerpsMarketConfiguration.sol
+++ b/markets/perps-market/contracts/storage/PerpsMarketConfiguration.sol
@@ -28,11 +28,14 @@ library PerpsMarketConfiguration {
          */
         uint256 initialMarginRatioD18;
         /**
-         * @dev the maintenance margin requirements for this market when opening a position
+         * @dev This scalar is applied to the calculated initial margin ratio
          * @dev this generally will be lower than initial margin but is used to determine when to liquidate a position
          * @dev this fraction is multiplied by the impact of the position on the skew (position size / skewScale)
          */
-        uint256 maintenanceMarginRatioD18;
+        uint256 maintenanceMarginScalarD18;
+        /**
+         * @dev This ratio is multiplied by the market's notional size (size * currentPrice) to determine how much credit is required for the market to be sufficiently backed by the LPs
+         */
         uint256 lockedOiRatioD18;
         /**
          * @dev This multiplier is applied to the max liquidation value when calculating max liquidation for a given market
@@ -51,6 +54,10 @@ library PerpsMarketConfiguration {
          * @dev minimum position value in USD, this is a constant value added to position margin requirements (initial/maintenance)
          */
         uint256 minimumPositionMargin;
+        /**
+         * @dev This value gets applied to the initial margin ratio to ensure there's a cap on the max leverage regardless of position size
+         */
+        uint256 minimumInitialMarginRatioD18;
     }
 
     function load(uint128 marketId) internal pure returns (Data storage store) {
@@ -95,8 +102,10 @@ library PerpsMarketConfiguration {
         uint256 sizeAbs = MathUtil.abs(size.to256());
         uint256 impactOnSkew = self.skewScale == 0 ? 0 : sizeAbs.divDecimal(self.skewScale);
 
-        initialMarginRatio = impactOnSkew.mulDecimal(self.initialMarginRatioD18);
-        maintenanceMarginRatio = impactOnSkew.mulDecimal(self.maintenanceMarginRatioD18);
+        initialMarginRatio =
+            impactOnSkew.mulDecimal(self.initialMarginRatioD18) +
+            self.minimumInitialMarginRatioD18;
+        maintenanceMarginRatio = initialMarginRatio.mulDecimal(self.maintenanceMarginScalarD18);
 
         uint256 notional = sizeAbs.mulDecimal(price);
         initialMargin = notional.mulDecimal(initialMarginRatio) + self.minimumPositionMargin;

--- a/markets/perps-market/test/integration/Account/Margins.test.ts
+++ b/markets/perps-market/test/integration/Account/Margins.test.ts
@@ -15,7 +15,8 @@ describe('Account margins test', () => {
       fundingParams: { skewScale: bn(100), maxFundingVelocity: bn(0) },
       liquidationParams: {
         initialMarginFraction: bn(2),
-        maintenanceMarginFraction: bn(1),
+        minimumInitialMarginRatio: bn(0.01),
+        maintenanceMarginScalar: bn(0.5),
         maxLiquidationLimitAccumulationMultiplier: bn(1),
         liquidationRewardRatio: bn(0.05),
         maxSecondsInLiquidationWindow: bn(10),
@@ -33,7 +34,8 @@ describe('Account margins test', () => {
       fundingParams: { skewScale: bn(1000), maxFundingVelocity: bn(0) },
       liquidationParams: {
         initialMarginFraction: bn(2),
-        maintenanceMarginFraction: bn(1),
+        minimumInitialMarginRatio: bn(0.01),
+        maintenanceMarginScalar: bn(0.5),
         maxLiquidationLimitAccumulationMultiplier: bn(1),
         liquidationRewardRatio: bn(0.05),
         maxSecondsInLiquidationWindow: bn(10),
@@ -117,12 +119,15 @@ describe('Account margins test', () => {
       const notionalBtcValue = wei(2).mul(wei(30_000));
       const notionalEthValue = wei(20).mul(wei(2000));
 
-      btcInitialMargin = notionalBtcValue.mul(wei(2).div(wei(btcSkewScale)).mul(wei(2)));
-      ethInitialMargin = notionalEthValue.mul(wei(20).div(wei(ethSkewScale)).mul(wei(2)));
+      const btcInitialMarginRatio = wei(2).div(wei(btcSkewScale)).mul(wei(2)).add(wei(0.01));
+      const ethInitialMarginRatio = wei(20).div(wei(ethSkewScale)).mul(wei(2)).add(wei(0.01));
+
+      btcInitialMargin = notionalBtcValue.mul(btcInitialMarginRatio);
+      ethInitialMargin = notionalEthValue.mul(ethInitialMarginRatio);
 
       // maintenance margin ratio == 1
-      btcMaintenanceMargin = notionalBtcValue.mul(wei(2).div(wei(btcSkewScale)));
-      ethMaintenanceMargin = notionalEthValue.mul(wei(20).div(wei(ethSkewScale)));
+      btcMaintenanceMargin = btcInitialMargin.mul(wei(0.5));
+      ethMaintenanceMargin = ethInitialMargin.mul(wei(0.5));
 
       // in above config: 1000 + 500
       minimumPositionMargin = wei(1500);

--- a/markets/perps-market/test/integration/Account/ModifyCollateral.withdraw.test.ts
+++ b/markets/perps-market/test/integration/Account/ModifyCollateral.withdraw.test.ts
@@ -121,7 +121,8 @@ describe('ModifyCollateral Withdraw', () => {
         fundingParams: { skewScale: bn(100), maxFundingVelocity: bn(0) },
         liquidationParams: {
           initialMarginFraction: bn(2),
-          maintenanceMarginFraction: bn(1),
+          minimumInitialMarginRatio: bn(0.01),
+          maintenanceMarginScalar: bn(0.5),
           maxLiquidationLimitAccumulationMultiplier: bn(1),
           liquidationRewardRatio: bn(0.05),
           maxSecondsInLiquidationWindow: bn(10),
@@ -139,7 +140,8 @@ describe('ModifyCollateral Withdraw', () => {
         fundingParams: { skewScale: bn(1000), maxFundingVelocity: bn(0) },
         liquidationParams: {
           initialMarginFraction: bn(2),
-          maintenanceMarginFraction: bn(1),
+          minimumInitialMarginRatio: bn(0.01),
+          maintenanceMarginScalar: bn(0.5),
           maxLiquidationLimitAccumulationMultiplier: bn(1),
           liquidationRewardRatio: bn(0.05),
           maxSecondsInLiquidationWindow: bn(10),
@@ -290,7 +292,7 @@ describe('ModifyCollateral Withdraw', () => {
           systems()
             .PerpsMarket.connect(trader1())
             .modifyCollateral(trader1AccountId, sUSDSynthId, bn(-18000)),
-          `InsufficientCollateralAvailableForWithdraw("${bn(15000)}", "${bn(18000)}")`
+          `InsufficientCollateralAvailableForWithdraw("${bn(14000)}", "${bn(18000)}")`
         );
       });
 

--- a/markets/perps-market/test/integration/Liquidation/Liquidation.margin.test.ts
+++ b/markets/perps-market/test/integration/Liquidation/Liquidation.margin.test.ts
@@ -14,7 +14,8 @@ describe('Liquidation - margin', async () => {
       fundingParams: { skewScale: bn(100), maxFundingVelocity: bn(0) },
       liquidationParams: {
         initialMarginFraction: bn(2),
-        maintenanceMarginFraction: bn(1),
+        minimumInitialMarginRatio: bn(0.01),
+        maintenanceMarginScalar: bn(0.5),
         maxLiquidationLimitAccumulationMultiplier: bn(1),
         liquidationRewardRatio: bn(0.05),
         maxSecondsInLiquidationWindow: bn(10),
@@ -32,7 +33,8 @@ describe('Liquidation - margin', async () => {
       fundingParams: { skewScale: bn(1000), maxFundingVelocity: bn(0) },
       liquidationParams: {
         initialMarginFraction: bn(2),
-        maintenanceMarginFraction: bn(1),
+        minimumInitialMarginRatio: bn(0.01),
+        maintenanceMarginScalar: bn(0.5),
         maxLiquidationLimitAccumulationMultiplier: bn(1),
         liquidationRewardRatio: bn(0.05),
         maxSecondsInLiquidationWindow: bn(10),
@@ -50,7 +52,8 @@ describe('Liquidation - margin', async () => {
       fundingParams: { skewScale: bn(100_000), maxFundingVelocity: bn(0) },
       liquidationParams: {
         initialMarginFraction: bn(2),
-        maintenanceMarginFraction: bn(1),
+        minimumInitialMarginRatio: bn(0.01),
+        maintenanceMarginScalar: bn(0.5),
         maxLiquidationLimitAccumulationMultiplier: bn(1),
         liquidationRewardRatio: bn(0.05),
         maxSecondsInLiquidationWindow: bn(10),
@@ -68,7 +71,8 @@ describe('Liquidation - margin', async () => {
       fundingParams: { skewScale: bn(100_000), maxFundingVelocity: bn(0) },
       liquidationParams: {
         initialMarginFraction: bn(1.5),
-        maintenanceMarginFraction: bn(0.75),
+        minimumInitialMarginRatio: bn(0.035),
+        maintenanceMarginScalar: bn(0.5),
         maxLiquidationLimitAccumulationMultiplier: bn(1),
         liquidationRewardRatio: bn(0.05),
         maxSecondsInLiquidationWindow: bn(10),
@@ -86,7 +90,8 @@ describe('Liquidation - margin', async () => {
       fundingParams: { skewScale: bn(100_000), maxFundingVelocity: bn(0) },
       liquidationParams: {
         initialMarginFraction: bn(1.5),
-        maintenanceMarginFraction: bn(0.75),
+        minimumInitialMarginRatio: bn(0.035),
+        maintenanceMarginScalar: bn(0.5),
         maxLiquidationLimitAccumulationMultiplier: bn(1),
         liquidationRewardRatio: bn(0.05),
         maxSecondsInLiquidationWindow: bn(10),
@@ -271,7 +276,8 @@ describe('Liquidation - margin', async () => {
     before('set minimumPositionMargin for OP to 50', async () => {
       const opMarketId = perpsMarkets()[4].marketId();
       const initialMarginFraction = bn(1.5);
-      const maintenanceMarginFraction = bn(0.75);
+      const maintenanceMarginScalar = bn(0.035);
+      const minimumInitialMarginRatio = bn(0.5);
       const maxLiquidationLimitAccumulationMultiplier = bn(1);
       const liquidationRewardRatio = bn(0.05);
       const maxSecondsInLiquidationWindow = bn(10);
@@ -281,7 +287,8 @@ describe('Liquidation - margin', async () => {
         .setLiquidationParameters(
           opMarketId,
           initialMarginFraction,
-          maintenanceMarginFraction,
+          maintenanceMarginScalar,
+          minimumInitialMarginRatio,
           maxLiquidationLimitAccumulationMultiplier,
           liquidationRewardRatio,
           maxSecondsInLiquidationWindow,
@@ -307,7 +314,7 @@ describe('Liquidation - margin', async () => {
   describe('price change - eligible for liquidation', () => {
     [
       bn(31000), // btc
-      bn(1775), // eth
+      bn(1820), // eth
       bn(3), // link
       bn(1), // arb
       bn(1), // op, the only one that has a price change
@@ -319,7 +326,7 @@ describe('Liquidation - margin', async () => {
 
     [
       bn(-1150), // btc
-      bn(-4900), // eth
+      bn(-4000), // eth
       bn(-4100), // link
       bn(-5250), // arb
       bn(-5250), // op
@@ -334,7 +341,7 @@ describe('Liquidation - margin', async () => {
     });
 
     it('has correct available margin', async () => {
-      assertBn.equal(await systems().PerpsMarket.getAvailableMargin(2), bn(-650));
+      assertBn.equal(await systems().PerpsMarket.getAvailableMargin(2), bn(250));
     });
 
     it('reverts when trying to withdraw', async () => {

--- a/markets/perps-market/test/integration/Liquidation/Liquidation.maxLiquidationAmount.test.ts
+++ b/markets/perps-market/test/integration/Liquidation/Liquidation.maxLiquidationAmount.test.ts
@@ -20,7 +20,8 @@ describe('Liquidation - max liquidatable amount', async () => {
         fundingParams: { skewScale: bn(1000), maxFundingVelocity: bn(0) },
         liquidationParams: {
           initialMarginFraction: bn(3),
-          maintenanceMarginFraction: bn(2),
+          minimumInitialMarginRatio: bn(0),
+          maintenanceMarginScalar: bn(0.5),
           maxLiquidationLimitAccumulationMultiplier: bn(1),
           liquidationRewardRatio: bn(0.05),
           maxSecondsInLiquidationWindow: ethers.BigNumber.from(10),

--- a/markets/perps-market/test/integration/Liquidation/Liquidation.multi-collateral.test.ts
+++ b/markets/perps-market/test/integration/Liquidation/Liquidation.multi-collateral.test.ts
@@ -17,7 +17,8 @@ describe('Liquidation - multi collateral', async () => {
       fundingParams: { skewScale: bn(100), maxFundingVelocity: bn(0) },
       liquidationParams: {
         initialMarginFraction: bn(2),
-        maintenanceMarginFraction: bn(1),
+        minimumInitialMarginRatio: bn(0.01),
+        maintenanceMarginScalar: bn(0.5),
         maxLiquidationLimitAccumulationMultiplier: bn(1),
         liquidationRewardRatio: bn(0.01),
         maxSecondsInLiquidationWindow: bn(10),
@@ -35,7 +36,8 @@ describe('Liquidation - multi collateral', async () => {
       fundingParams: { skewScale: bn(1000), maxFundingVelocity: bn(0) },
       liquidationParams: {
         initialMarginFraction: bn(2),
-        maintenanceMarginFraction: bn(1),
+        minimumInitialMarginRatio: bn(0.01),
+        maintenanceMarginScalar: bn(0.5),
         maxLiquidationLimitAccumulationMultiplier: bn(1),
         liquidationRewardRatio: bn(0.02),
         maxSecondsInLiquidationWindow: bn(10),
@@ -53,7 +55,8 @@ describe('Liquidation - multi collateral', async () => {
       fundingParams: { skewScale: bn(100_000), maxFundingVelocity: bn(0) },
       liquidationParams: {
         initialMarginFraction: bn(2),
-        maintenanceMarginFraction: bn(1),
+        minimumInitialMarginRatio: bn(0.01),
+        maintenanceMarginScalar: bn(0.5),
         maxLiquidationLimitAccumulationMultiplier: bn(1),
         liquidationRewardRatio: bn(0.05),
         maxSecondsInLiquidationWindow: bn(10),

--- a/markets/perps-market/test/integration/Market/MarketConfiguration.test.ts
+++ b/markets/perps-market/test/integration/Market/MarketConfiguration.test.ts
@@ -29,7 +29,8 @@ describe('MarketConfiguration', async () => {
     maxFundingVelocity: bn(0.3),
     skewScale: bn(1),
     initialMarginFraction: bn(2),
-    maintenanceMarginFraction: bn(10),
+    minimumInitialMarginRatio: bn(0.01),
+    maintenanceMarginScalar: bn(0.5),
     lockedOiPercentRatioD18: bn(15),
     maxLiquidationLimitAccumulationMultiplier: bn(5),
     minimumPositionMargin: bn(50),
@@ -148,13 +149,14 @@ describe('MarketConfiguration', async () => {
         .setLiquidationParameters(
           marketId,
           fixture.initialMarginFraction,
-          fixture.maintenanceMarginFraction,
+          fixture.minimumInitialMarginRatio,
+          fixture.maintenanceMarginScalar,
           fixture.liquidationRewardRatioD18,
           fixture.maxLiquidationLimitAccumulationMultiplier,
           fixture.maxSecondsInLiquidationWindow,
           fixture.minimumPositionMargin
         ),
-      `LiquidationParametersSet(${marketId.toString()}, ${fixture.initialMarginFraction.toString()}, ${fixture.maintenanceMarginFraction.toString()}, ${fixture.liquidationRewardRatioD18.toString()}, ${fixture.maxLiquidationLimitAccumulationMultiplier.toString()}, ${fixture.maxSecondsInLiquidationWindow.toString()}, ${fixture.minimumPositionMargin.toString()})`,
+      `LiquidationParametersSet(${marketId.toString()}, ${fixture.initialMarginFraction.toString()}, ${fixture.maintenanceMarginScalar.toString()}, ${fixture.minimumInitialMarginRatio.toString()}, ${fixture.liquidationRewardRatioD18.toString()}, ${fixture.maxLiquidationLimitAccumulationMultiplier.toString()}, ${fixture.maxSecondsInLiquidationWindow.toString()}, ${fixture.minimumPositionMargin.toString()})`,
 
       systems().PerpsMarket
     );
@@ -207,7 +209,8 @@ describe('MarketConfiguration', async () => {
         .setLiquidationParameters(
           marketId,
           fixture.initialMarginFraction,
-          fixture.maintenanceMarginFraction,
+          fixture.minimumInitialMarginRatio,
+          fixture.maintenanceMarginScalar,
           fixture.liquidationRewardRatioD18,
           fixture.maxLiquidationLimitAccumulationMultiplier,
           fixture.maxSecondsInLiquidationWindow,
@@ -269,13 +272,15 @@ describe('MarketConfiguration', async () => {
   it('get liquidationParameters', async () => {
     const [
       initialMarginFraction,
-      maintenanceMarginFraction,
+      minimumInitialMarginRatio,
+      maintenanceMarginScalar,
       liquidationRewardRatioD18,
       maxLiquidationLimitAccumulationMultiplier,
       maxSecondsInLiquidationWindow,
     ] = await systems().PerpsMarket.getLiquidationParameters(marketId);
     assertBn.equal(initialMarginFraction, fixture.initialMarginFraction);
-    assertBn.equal(maintenanceMarginFraction, fixture.maintenanceMarginFraction);
+    assertBn.equal(minimumInitialMarginRatio, fixture.minimumInitialMarginRatio);
+    assertBn.equal(maintenanceMarginScalar, fixture.maintenanceMarginScalar);
     assertBn.equal(liquidationRewardRatioD18, fixture.liquidationRewardRatioD18);
     assertBn.equal(
       maxLiquidationLimitAccumulationMultiplier,

--- a/markets/perps-market/test/integration/Market/MarketDebt.withFunding.test.ts
+++ b/markets/perps-market/test/integration/Market/MarketDebt.withFunding.test.ts
@@ -34,7 +34,8 @@ describe('Market Debt - with funding', () => {
           fundingParams: { skewScale: _SKEW_SCALE, maxFundingVelocity: _MAX_FUNDING_VELOCITY },
           liquidationParams: {
             initialMarginFraction: bn(3),
-            maintenanceMarginFraction: bn(2),
+            minimumInitialMarginRatio: bn(0.01),
+            maintenanceMarginScalar: bn(0.5),
             maxLiquidationLimitAccumulationMultiplier: bn(1),
             liquidationRewardRatio: bn(0.05),
             maxSecondsInLiquidationWindow: ethers.BigNumber.from(10),

--- a/markets/perps-market/test/integration/bootstrap/bootstrapPerpsMarkets.ts
+++ b/markets/perps-market/test/integration/bootstrap/bootstrapPerpsMarkets.ts
@@ -29,7 +29,8 @@ export type PerpsMarketData = Array<{
   };
   liquidationParams?: {
     initialMarginFraction: ethers.BigNumber;
-    maintenanceMarginFraction: ethers.BigNumber;
+    minimumInitialMarginRatio: ethers.BigNumber;
+    maintenanceMarginScalar: ethers.BigNumber;
     maxLiquidationLimitAccumulationMultiplier: ethers.BigNumber;
     liquidationRewardRatio: ethers.BigNumber;
     maxSecondsInLiquidationWindow: ethers.BigNumber;
@@ -145,7 +146,8 @@ export const bootstrapPerpsMarkets = (
           await contracts.PerpsMarket.connect(r.owner()).setLiquidationParameters(
             marketId,
             liquidationParams.initialMarginFraction,
-            liquidationParams.maintenanceMarginFraction,
+            liquidationParams.minimumInitialMarginRatio,
+            liquidationParams.maintenanceMarginScalar,
             liquidationParams.liquidationRewardRatio,
             liquidationParams.maxLiquidationLimitAccumulationMultiplier,
             liquidationParams.maxSecondsInLiquidationWindow,


### PR DESCRIPTION
- removed `maintenanceMarginRatio`
- added `minimumInitialRatio` -> this ratio is added to the computed initial ratio based on the configured `initialMarginRatio`
- added `maintenaceMarginScalar` -> this scalar is multiplied by initial margin ratio to get the maintenance margin ratio