### PR TITLE
v3 CI fix hardhat not loading solc on Node18

### DIFF
--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.16.0"
+          node-version: "18.15.0"
           cache: "yarn"
 
       # The following steps are for checking the validity of the yarn.lock edits.

--- a/.github/workflows/docgen.yml
+++ b/.github/workflows/docgen.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.16.0"
+          node-version: "18.15.0"
           cache: "yarn"
       - run: yarn --version
       - run: yarn install --immutable --immutable-cache

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.16.0"
+          node-version: "18.15.0"
           cache: "yarn"
       - run: yarn --version
       - run: yarn install --immutable --immutable-cache

--- a/.github/workflows/simulate-release.yml
+++ b/.github/workflows/simulate-release.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.16.0"
+          node-version: "18.15.0"
           cache: "yarn"
       - uses: ibnesayeed/setup-ipfs@92d412e0dad36c06ffab50733e9c624896a0964f
         with:

--- a/.github/workflows/test-with-coverage.yml
+++ b/.github/workflows/test-with-coverage.yml
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "16.20.1"
+          node-version: "18.15.0"
           cache: "yarn"
       - uses: ibnesayeed/setup-ipfs@92d412e0dad36c06ffab50733e9c624896a0964f
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "16.20.1"
+          node-version: "18.15.0"
           cache: "yarn"
       - uses: ibnesayeed/setup-ipfs@92d412e0dad36c06ffab50733e9c624896a0964f
         with:

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "markets/**"
   ],
   "engines": {
-    "node": "^18.16.0"
+    "node": "^18.15.0"
   },
   "packageManager": "yarn@3.6.0"
 }


### PR DESCRIPTION
Update Node version to avoid hardhat silently bail with success


For context:
Hardhat randomly just silently quitting with exit code 0 when downloading solc compiler
It was an issue with NodeJS in *some* versions and looks like 18.16.0 is one of the affected versions (see https://github.com/NomicFoundation/hardhat/issues/3877)
Using fresher (or older version of node solves it).

on `18.17.1` couple of the core-utils tests are failing, so sticking to `18.15.0` for now.