### PR TITLE
Make sure we fail build when tests fail

### DIFF
--- a/.github/workflows/check-packages.yml
+++ b/.github/workflows/check-packages.yml
@@ -1,6 +1,10 @@
 name: "Validate yarn.lock and cache"
 
-on: [pull_request]
+on:
+  pull_request: {}
+  push:
+    branches:
+      - "main"
 
 jobs:
   check:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,11 @@
 name: Lint
-on: [push]
+
+on:
+  pull_request: {}
+  push:
+    branches:
+      - "main"
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/simulate-release.yml
+++ b/.github/workflows/simulate-release.yml
@@ -15,6 +15,7 @@ jobs:
       CANNON_IPFS_URL: "http://127.0.0.1:5001"
       CANNON_PUBLISH_IPFS_URL: "http://127.0.0.1:5001"
     strategy:
+      fail-fast: false
       matrix:
         network: [goerli, optimistic-goerli]
         project: [protocol/oracle-manager, protocol/synthetix]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    continue-on-error: true
     env:
       CANNON_IPFS_URL: "http://127.0.0.1:5001"
       CANNON_PUBLISH_IPFS_URL: "http://127.0.0.1:5001"
     strategy:
+      fail-fast: false
       matrix:
         package:
           [


### PR DESCRIPTION
But do not fail-fast and run all tests without cancelling them!

Instead of `continue-on-error: true` we should be using `strategy -> fail-fast: false` for matrix builds.