### PR TITLE
Fix Infura URL for optimism mainnet

### DIFF
--- a/utils/common-config/hardhat.config.ts
+++ b/utils/common-config/hardhat.config.ts
@@ -59,7 +59,7 @@ const config = {
     ['optimistic-mainnet']: {
       url:
         process.env.NETWORK_ENDPOINT ||
-        `https://optimism.infura.io/v3/${process.env.INFURA_API_KEY}`,
+        `https://optimism-mainnet.infura.io/v3/${process.env.INFURA_API_KEY}`,
       accounts: process.env.DEPLOYER_PRIVATE_KEY ? [process.env.DEPLOYER_PRIVATE_KEY] : [],
       chainId: 10,
     },


### PR DESCRIPTION
Discovered when simulating releases.

It was not working before either. but because we were grepping for InitialProxy even failures were green tick.

<img width="1070" alt="image" src="https://github.com/Synthetixio/synthetix-v3/assets/28145325/0f4503c4-a7d6-43df-99e0-e5163c868489">
