### PR TITLE
use self-hosted runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       CANNON_IPFS_URL: "http://127.0.0.1:5001"
       CANNON_PUBLISH_IPFS_URL: "http://127.0.0.1:5001"


### PR DESCRIPTION
explore speeding up CI simply by using our own infra