### PR TITLE
cache cannon builds, remove ipfs dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    env:
-      CANNON_IPFS_URL: "http://127.0.0.1:5001"
-      CANNON_PUBLISH_IPFS_URL: "http://127.0.0.1:5001"
     strategy:
       fail-fast: false
       matrix:
@@ -43,9 +40,11 @@ jobs:
         with:
           node-version: "16.20.1"
           cache: "yarn"
-      - uses: ibnesayeed/setup-ipfs@92d412e0dad36c06ffab50733e9c624896a0964f
+      - name: Cache Cannon packages
+        uses: actions/cache@v3
         with:
-          run_daemon: true
+          path: |
+            ~/.local/share/cannon
 
       - run: yarn install --immutable --immutable-cache
       - run: yarn workspaces foreach --topological-dev --recursive --verbose --from "${{ matrix.workspace }}" run build:ts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Cache Cannon packages
         uses: actions/cache@v3
         with:
+          key: cannon-${{ matrix.workspace }}
           path: |
             ~/.local/share/cannon
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,9 +46,9 @@ jobs:
       - name: Cache Hardhat artifacts
         uses: actions/cache@v3
         with:
-          key: hardhat-${{ matrix.workspace }}-${{ env.GITHUB_REF }}-${{ steps.date.outputs.date }}
+          key: hardhat-${{ matrix.workspace }}-${{ github.head_ref }}-${{ steps.date.outputs.date }}
           restore-keys: |
-            hardhat-${{ matrix.workspace }}-${{ env.GITHUB_REF }}
+            hardhat-${{ matrix.workspace }}-${{ github.head_ref }}
             hardhat-${{ matrix.workspace }}
           path: |
             markets/**/cache
@@ -60,9 +60,9 @@ jobs:
       - name: Cache Cannon packages
         uses: actions/cache@v3
         with:
-          key: cannon-${{ matrix.workspace }}-${{ env.GITHUB_REF }}-${{ steps.date.outputs.date }}
+          key: cannon-${{ matrix.workspace }}-${{ github.head_ref }}-${{ steps.date.outputs.date }}
           restore-keys: |
-            cannon-${{ matrix.workspace }}-${{ env.GITHUB_REF }}
+            cannon-${{ matrix.workspace }}-${{ github.head_ref }}
             cannon-${{ matrix.workspace }}
           path: |
             ~/.local/share/cannon

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,14 @@ jobs:
         with:
           node-version: "16.20.1"
           cache: "yarn"
+      - name: Cache Hardhat artifacts
+        uses: actions/cache@v3
+        with:
+          key: hardhat-${{ matrix.workspace }}
+          path: |
+            protocol/**/cache
+            protocol/**/artifacts
+            protocol/**/test/generated
       - name: Cache Cannon packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,22 +48,24 @@ jobs:
         with:
           key: hardhat-${{ matrix.workspace }}-${{ github.head_ref }}-${{ steps.date.outputs.date }}
           restore-keys: |
-            hardhat-${{ matrix.workspace }}-${{ github.head_ref }}
-            hardhat-${{ matrix.workspace }}
+            hardhat-test-${{ matrix.workspace }}-${{ github.head_ref }}
+            hardhat-test-${{ matrix.workspace }}
           path: |
             markets/**/cache
             markets/**/artifacts
             markets/**/test/generated
+            markets/**/typechain-types
             protocol/**/cache
             protocol/**/artifacts
             protocol/**/test/generated
+            protocol/**/typechain-types
       - name: Cache Cannon packages
         uses: actions/cache@v3
         with:
           key: cannon-${{ matrix.workspace }}-${{ github.head_ref }}-${{ steps.date.outputs.date }}
           restore-keys: |
-            cannon-${{ matrix.workspace }}-${{ github.head_ref }}
-            cannon-${{ matrix.workspace }}
+            cannon-test-${{ matrix.workspace }}-${{ github.head_ref }}
+            cannon-test-${{ matrix.workspace }}
           path: |
             ~/.local/share/cannon
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,9 @@ jobs:
         with:
           key: hardhat-${{ matrix.workspace }}
           path: |
+            markets/**/cache
+            markets/**/artifacts
+            markets/**/test/generated
             protocol/**/cache
             protocol/**/artifacts
             protocol/**/test/generated

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,10 +40,16 @@ jobs:
         with:
           node-version: "16.20.1"
           cache: "yarn"
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
       - name: Cache Hardhat artifacts
         uses: actions/cache@v3
         with:
-          key: hardhat-${{ matrix.workspace }}
+          key: hardhat-${{ matrix.workspace }}-${{ env.GITHUB_REF }}-${{ steps.date.outputs.date }}
+          restore-keys: |
+            hardhat-${{ matrix.workspace }}-${{ env.GITHUB_REF }}
+            hardhat-${{ matrix.workspace }}
           path: |
             markets/**/cache
             markets/**/artifacts
@@ -54,7 +60,10 @@ jobs:
       - name: Cache Cannon packages
         uses: actions/cache@v3
         with:
-          key: cannon-${{ matrix.workspace }}
+          key: cannon-${{ matrix.workspace }}-${{ env.GITHUB_REF }}-${{ steps.date.outputs.date }}
+          restore-keys: |
+            cannon-${{ matrix.workspace }}-${{ env.GITHUB_REF }}
+            cannon-${{ matrix.workspace }}
           path: |
             ~/.local/share/cannon
 

--- a/markets/perps-market/contracts/modules/AsyncOrderModule.sol
+++ b/markets/perps-market/contracts/modules/AsyncOrderModule.sol
@@ -15,8 +15,6 @@ import {GlobalPerpsMarket} from "../storage/GlobalPerpsMarket.sol";
 import {PerpsMarketConfiguration} from "../storage/PerpsMarketConfiguration.sol";
 import {SettlementStrategy} from "../storage/SettlementStrategy.sol";
 
-import "hardhat/console.sol";
-
 /**
  * @title Module for committing async orders.
  * @dev See IAsyncOrderModule.
@@ -41,8 +39,6 @@ contract AsyncOrderModule is IAsyncOrderModule {
     function commitOrder(
         AsyncOrder.OrderCommitmentRequest memory commitment
     ) external override returns (AsyncOrder.Data memory retOrder, uint fees) {
-				console.log('IM A DUMMY CHANGE');
-				console.log('and another one');
         PerpsMarket.loadValid(commitment.marketId);
 
         // Check if commitment.accountId is valid

--- a/markets/perps-market/contracts/modules/AsyncOrderModule.sol
+++ b/markets/perps-market/contracts/modules/AsyncOrderModule.sol
@@ -15,6 +15,8 @@ import {GlobalPerpsMarket} from "../storage/GlobalPerpsMarket.sol";
 import {PerpsMarketConfiguration} from "../storage/PerpsMarketConfiguration.sol";
 import {SettlementStrategy} from "../storage/SettlementStrategy.sol";
 
+import "hardhat/console.sol";
+
 /**
  * @title Module for committing async orders.
  * @dev See IAsyncOrderModule.
@@ -39,6 +41,7 @@ contract AsyncOrderModule is IAsyncOrderModule {
     function commitOrder(
         AsyncOrder.OrderCommitmentRequest memory commitment
     ) external override returns (AsyncOrder.Data memory retOrder, uint fees) {
+				console.log('IM A DUMMY CHANGE');
         PerpsMarket.loadValid(commitment.marketId);
 
         // Check if commitment.accountId is valid

--- a/markets/perps-market/contracts/modules/AsyncOrderModule.sol
+++ b/markets/perps-market/contracts/modules/AsyncOrderModule.sol
@@ -42,6 +42,7 @@ contract AsyncOrderModule is IAsyncOrderModule {
         AsyncOrder.OrderCommitmentRequest memory commitment
     ) external override returns (AsyncOrder.Data memory retOrder, uint fees) {
 				console.log('IM A DUMMY CHANGE');
+				console.log('and another one');
         PerpsMarket.loadValid(commitment.marketId);
 
         // Check if commitment.accountId is valid


### PR DESCRIPTION
using `actions/cache` action, cache cannon package data and hardhat artifacts cache.

reduces build time of tests by about 3 minutes.