### PR TITLE
Retry failed tests 3 times

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,7 +229,7 @@ jobs:
             for _test in $_tests; do
               echo $_test
             done
-            mocha --timeout 30000 --require hardhat/register --reporter mocha-junit-reporter --reporter-options mochaFile=/tmp/junit/report.xml --exit $_tests
+            mocha --retries 3 --timeout 30000 --require hardhat/register --reporter mocha-junit-reporter --reporter-options mochaFile=/tmp/junit/report.xml --exit $_tests
 
       - store_test_results:
           path: "/tmp/junit"
@@ -263,7 +263,7 @@ jobs:
             for _test in $_tests; do
               echo $_test
             done
-            mocha --timeout 10000 --require ts-node/register --reporter mocha-junit-reporter --reporter-options mochaFile=/tmp/junit/report.xml --exit $_tests
+            mocha --retries 3 --timeout 10000 --require ts-node/register --reporter mocha-junit-reporter --reporter-options mochaFile=/tmp/junit/report.xml --exit $_tests
 
       - store_test_results:
           path: "/tmp/junit"
@@ -304,7 +304,7 @@ jobs:
             for _test in $_tests; do
               echo $_test
             done
-            mocha --timeout 10000 --require hardhat/register --reporter mocha-junit-reporter --reporter-options mochaFile=/tmp/junit/report.xml --exit $_tests
+            mocha --retries 3 --timeout 10000 --require hardhat/register --reporter mocha-junit-reporter --reporter-options mochaFile=/tmp/junit/report.xml --exit $_tests
 
       - store_test_results:
           path: "/tmp/junit"
@@ -346,7 +346,7 @@ jobs:
             for _test in $_tests; do
               echo $_test
             done
-            mocha --timeout 20000 --require hardhat/register --reporter mocha-junit-reporter --reporter-options mochaFile=/tmp/junit/report.xml --exit $_tests
+            mocha --retries 3 --timeout 20000 --require hardhat/register --reporter mocha-junit-reporter --reporter-options mochaFile=/tmp/junit/report.xml --exit $_tests
 
       - store_test_results:
           path: "/tmp/junit"


### PR DESCRIPTION
We bootstrap per test file and not per test because we use `before` and not `beforeEach`, so this might not help.

If it won't - will change bootstrapping to use `beforeEach` instead and avoid state sharing between tests