### PR TITLE
Withdraw different collateral fix

### DIFF
--- a/markets/perps-market/contracts/modules/PerpsAccountModule.sol
+++ b/markets/perps-market/contracts/modules/PerpsAccountModule.sol
@@ -62,7 +62,7 @@ contract PerpsAccountModule is IPerpsAccountModule {
         } else {
             uint256 amountAbs = MathUtil.abs(amountDelta);
             // removing collateral
-            account.validateWithdrawableAmount(amountAbs);
+            account.validateWithdrawableAmount(synthMarketId, amountAbs);
             _withdrawMargin(perpsMarketFactory, perpsMarketId, synthMarketId, amountAbs);
         }
 

--- a/markets/perps-market/contracts/modules/PerpsAccountModule.sol
+++ b/markets/perps-market/contracts/modules/PerpsAccountModule.sol
@@ -62,7 +62,11 @@ contract PerpsAccountModule is IPerpsAccountModule {
         } else {
             uint256 amountAbs = MathUtil.abs(amountDelta);
             // removing collateral
-            account.validateWithdrawableAmount(synthMarketId, amountAbs);
+            account.validateWithdrawableAmount(
+                synthMarketId,
+                amountAbs,
+                perpsMarketFactory.spotMarket
+            );
             _withdrawMargin(perpsMarketFactory, perpsMarketId, synthMarketId, amountAbs);
         }
 

--- a/markets/perps-market/contracts/storage/PerpsAccount.sol
+++ b/markets/perps-market/contracts/storage/PerpsAccount.sol
@@ -45,7 +45,10 @@ library PerpsAccount {
         SetUtil.UintSet openPositionMarketIds;
     }
 
-    error InsufficientCollateralAvailableForWithdraw(uint available, uint required);
+    error InsufficientCollateralAvailableForWithdraw(
+        uint availableUsdDenominated,
+        uint requiredUsdDenominated
+    );
 
     error InsufficientSynthCollateral(
         uint128 synthMarketId,
@@ -205,7 +208,7 @@ library PerpsAccount {
         if (amountToWithdrawUsd > availableWithdrawableCollateralUsd) {
             revert InsufficientCollateralAvailableForWithdraw(
                 availableWithdrawableCollateralUsd,
-                amountToWithdraw
+                amountToWithdrawUsd
             );
         }
     }

--- a/markets/perps-market/contracts/storage/PerpsAccount.sol
+++ b/markets/perps-market/contracts/storage/PerpsAccount.sol
@@ -204,7 +204,13 @@ library PerpsAccount {
         // availableMargin can be assumed to be positive since we check for isEligible for liquidation prior
         availableWithdrawableCollateralUsd = availableMargin.toUint() - requiredMargin;
 
-        (uint amountToWithdrawUsd, ) = spotMarket.quoteSellExactIn(synthMarketId, amountToWithdraw);
+        uint amountToWithdrawUsd;
+        if (synthMarketId == SNX_USD_MARKET_ID) {
+            amountToWithdrawUsd = amountToWithdraw;
+        } else {
+            (amountToWithdrawUsd, ) = spotMarket.quoteSellExactIn(synthMarketId, amountToWithdraw);
+        }
+
         if (amountToWithdrawUsd > availableWithdrawableCollateralUsd) {
             revert InsufficientCollateralAvailableForWithdraw(
                 availableWithdrawableCollateralUsd,

--- a/markets/perps-market/test/integration/Account/ModifyCollateral.withdraw.test.ts
+++ b/markets/perps-market/test/integration/Account/ModifyCollateral.withdraw.test.ts
@@ -68,14 +68,14 @@ describe('ModifyCollateral Withdraw', () => {
     before('trader2 deposits snxUSD as collateral', async () => {
       await systems()
         .PerpsMarket.connect(trader2())
-        .modifyCollateral(accountIds[1], 0, depositAmount.toBN());
+        .modifyCollateral(accountIds[1], sUSDSynthId, depositAmount.toBN());
     });
     it('reverts when trader1 tries to withdraw snxUSD', async () => {
       await assertRevert(
         systems()
           .PerpsMarket.connect(trader1())
-          .modifyCollateral(accountIds[0], 0, withdrawAmount.mul(-1).toBN()),
-        `InsufficientSynthCollateral("0", "0", "${withdrawAmount.toBN()}")`
+          .modifyCollateral(accountIds[0], sUSDSynthId, withdrawAmount.mul(-1).toBN()),
+        `InsufficientSynthCollateral("${sUSDSynthId}", "0", "${withdrawAmount.toBN()}")`
       );
     });
     it('reverts when trader2 tries to withdraw snxBTC', async () => {

--- a/markets/perps-market/test/integration/Account/ModifyCollateral.withdraw.test.ts
+++ b/markets/perps-market/test/integration/Account/ModifyCollateral.withdraw.test.ts
@@ -39,8 +39,6 @@ describe('ModifyCollateral Withdraw', () => {
   const restoreToSetup = snapshotCheckpoint(provider);
 
   describe('withdraw without open position modifyCollateral() from another account', async () => {
-    let spotBalanceBefore: ethers.BigNumber;
-
     before(restoreToSetup);
 
     before('owner sets limits to max', async () => {
@@ -53,13 +51,6 @@ describe('ModifyCollateral Withdraw', () => {
       await systems()
         .SpotMarket.connect(trader1())
         .buy(synthBTCMarketId, marginAmount.toBN(), oneBTC.toBN(), ethers.constants.AddressZero);
-    });
-
-    before('record balances', async () => {
-      spotBalanceBefore = await synthMarkets()[0]
-        .synth()
-        .connect(trader1())
-        .balanceOf(await trader1().getAddress());
     });
 
     before('trader1 approves the perps market', async () => {
@@ -96,6 +87,7 @@ describe('ModifyCollateral Withdraw', () => {
       );
     });
   });
+
   describe('withdraw without open position modifyCollateral()', async () => {
     let spotBalanceBefore: ethers.BigNumber;
     let modifyCollateralWithdrawTxn: ethers.providers.TransactionResponse;


### PR DESCRIPTION
Issue: if an account wants to withdraw collateral that is available in the system but not on the account it reverts with overflow. 
Fix: Add an explicit revert

Hidden issue: when withdrawing collateral, use the snxUSD value to check against limits, not the nominal value