### PR TITLE
Explicit `latest` or `dev` tag for cannon publish

### DIFF
--- a/markets/perps-market/package.json
+++ b/markets/perps-market/package.json
@@ -14,9 +14,9 @@
     "coverage": "hardhat test",
     "coverage1": "hardhat coverage --network hardhat",
     "compile-contracts": "hardhat compile",
-    "publish-contracts": "yarn build && cannon publish synthetix-perps-market:$(node -p 'require(`./package.json`).version') --chain-id 13370 --quiet --tags $(node -p '/^\\d+\\.\\d+\\.\\d+$/.test(require(`./package.json`).version) ? `latest` : `dev`')",
+    "publish-contracts": "cannon publish synthetix-perps-market:$(node -p 'require(`./package.json`).version') --chain-id 13370 --quiet --tags $(node -p '/^\\d+\\.\\d+\\.\\d+$/.test(require(`./package.json`).version) ? `latest` : `dev`')",
+    "postpack": "yarn build && yarn publish-contracts",
     "size-contracts": "hardhat compile && hardhat size-contracts",
-    "postpack": "yarn publish-contracts",
     "docgen": "hardhat docgen"
   },
   "keywords": [],

--- a/markets/spot-market/package.json
+++ b/markets/spot-market/package.json
@@ -15,9 +15,9 @@
     "coverage": "hardhat test",
     "coverage1": "hardhat coverage --network hardhat",
     "compile-contracts": "hardhat compile",
-    "publish-contracts": "yarn build && cannon publish synthetix-spot-market:$(node -p 'require(`./package.json`).version') --chain-id 13370 --quiet --tags $(node -p '/^\\d+\\.\\d+\\.\\d+$/.test(require(`./package.json`).version) ? `latest` : `dev`')",
+    "publish-contracts": "cannon publish synthetix-spot-market:$(node -p 'require(`./package.json`).version') --chain-id 13370 --quiet --tags $(node -p '/^\\d+\\.\\d+\\.\\d+$/.test(require(`./package.json`).version) ? `latest` : `dev`')",
+    "postpack": "yarn build && yarn publish-contracts",
     "size-contracts": "hardhat compile && hardhat size-contracts",
-    "postpack": "yarn publish-contracts",
     "docgen": "hardhat docgen"
   },
   "keywords": [],

--- a/protocol/oracle-manager/package.json
+++ b/protocol/oracle-manager/package.json
@@ -15,8 +15,8 @@
     "check:storage": "git diff --exit-code storage.dump.sol",
     "compile-contracts": "hardhat compile",
     "size-contracts": "hardhat compile && hardhat size-contracts",
-    "publish-contracts": "yarn build && cannon publish oracle-manager:$(node -p 'require(`./package.json`).version') --chain-id 13370 --quiet --tags $(node -p '/^\\d+\\.\\d+\\.\\d+$/.test(require(`./package.json`).version) ? `latest` : `dev`')",
-    "postpack": "yarn publish-contracts",
+    "publish-contracts": "cannon publish oracle-manager:$(node -p 'require(`./package.json`).version') --chain-id 13370 --quiet --tags $(node -p '/^\\d+\\.\\d+\\.\\d+$/.test(require(`./package.json`).version) ? `latest` : `dev`')",
+    "postpack": "yarn build && yarn publish-contracts",
     "docgen": "hardhat docgen"
   },
   "keywords": [],

--- a/protocol/synthetix/package.json
+++ b/protocol/synthetix/package.json
@@ -16,8 +16,8 @@
     "coverage": "hardhat coverage --network hardhat",
     "compile-contracts": "hardhat compile",
     "size-contracts": "hardhat compile && hardhat size-contracts",
-    "publish-contracts": "yarn build && cannon publish synthetix:$(node -p 'require(`./package.json`).version') --chain-id 13370 --quiet --tags $(node -p '/^\\d+\\.\\d+\\.\\d+$/.test(require(`./package.json`).version) ? `latest` : `dev`')",
-    "postpack": "yarn publish-contracts",
+    "publish-contracts": "cannon publish synthetix:$(node -p 'require(`./package.json`).version') --chain-id 13370 --quiet --tags $(node -p '/^\\d+\\.\\d+\\.\\d+$/.test(require(`./package.json`).version) ? `latest` : `dev`')",
+    "postpack": "yarn build && yarn publish-contracts",
     "docgen": "hardhat docgen"
   },
   "keywords": [],


### PR DESCRIPTION
Because cannon adds `latest` on any publish we end up having all the temporary dev releases marked as `latest` and all the tooling that inspects deployments is broken because of that (latest is expected to point to the latest release)