### PR TITLE
More Audit fixes

### DIFF
--- a/markets/perps-market/cannonfile.test.toml
+++ b/markets/perps-market/cannonfile.test.toml
@@ -85,18 +85,6 @@ factory.PerpsMarketProxy.abiOf = ["PerpsMarketRouter"]
 factory.PerpsMarketProxy.event = "Upgraded"
 factory.PerpsMarketProxy.arg = 0
 
-[invoke.setSynthetix]
-target = ["PerpsMarketProxy"]
-from = "<%= settings.coreProxyOwner %>"
-func = "setSynthetix"
-args = ["<%= imports.synthetix.contracts.CoreProxy.address %>"]
-
-[invoke.setSpotMarket]
-target = ["PerpsMarketProxy"]
-from = "<%= settings.coreProxyOwner %>"
-func = "setSpotMarket"
-args = ["<%= imports.spotMarket.contracts.SpotMarketProxy.address %>"]
-
 [invoke.init_account]
 target = ["PerpsMarketProxy"]
 from = "<%= settings.owner %>"

--- a/markets/perps-market/cannonfile.toml
+++ b/markets/perps-market/cannonfile.toml
@@ -92,18 +92,6 @@ factory.PerpsMarketProxy.abiOf = ["PerpsMarketRouter"]
 factory.PerpsMarketProxy.event = "Upgraded"
 factory.PerpsMarketProxy.arg = 0
 
-[invoke.setSynthetix]
-target = ["PerpsMarketProxy"]
-from = "<%= settings.coreProxyOwner %>"
-func = "setSynthetix"
-args = ["<%= imports.synthetix.contracts.CoreProxy.address %>"]
-
-[invoke.setSpotMarket]
-target = ["PerpsMarketProxy"]
-from = "<%= settings.coreProxyOwner %>"
-func = "setSpotMarket"
-args = ["<%= imports.spotMarket.contracts.SpotMarketProxy.address %>"]
-
 [invoke.init_account]
 target = ["PerpsMarketProxy"]
 from = "<%= settings.owner %>"
@@ -139,7 +127,7 @@ args = ["<%= formatBytes32String('createMarket') %>", "<%= settings.owner %>"]
 [invoke.initializeFactory]
 target = ["PerpsMarketProxy"]
 func = "initializeFactory"
+args = ["<%= imports.synthetix.contracts.CoreProxy.address %>", "<%= imports.spotMarket.contracts.SpotMarketProxy.address %>"]
 from = "<%= settings.owner %>"
 extra.superMarketId.event = "FactoryInitialized"
 extra.superMarketId.arg = 0
-depends = ["invoke.setSynthetix"]

--- a/markets/perps-market/cannonfile.toml
+++ b/markets/perps-market/cannonfile.toml
@@ -127,7 +127,10 @@ args = ["<%= formatBytes32String('createMarket') %>", "<%= settings.owner %>"]
 [invoke.initializeFactory]
 target = ["PerpsMarketProxy"]
 func = "initializeFactory"
-args = ["<%= imports.synthetix.contracts.CoreProxy.address %>", "<%= imports.spotMarket.contracts.SpotMarketProxy.address %>"]
+args = [
+    "<%= imports.synthetix.contracts.CoreProxy.address %>",
+    "<%= imports.spotMarket.contracts.SpotMarketProxy.address %>"
+]
 from = "<%= settings.owner %>"
 extra.superMarketId.event = "FactoryInitialized"
 extra.superMarketId.arg = 0

--- a/markets/perps-market/contracts/interfaces/IGlobalPerpsMarketModule.sol
+++ b/markets/perps-market/contracts/interfaces/IGlobalPerpsMarketModule.sol
@@ -59,11 +59,6 @@ interface IGlobalPerpsMarketModule {
     error InvalidReferrerShareRatio(uint256 shareRatioD18);
 
     /**
-     * @notice Thrown when a referrer address is invalid (0x)
-     */
-    error InvalidReferrerAddress(address referrer);
-
-    /**
      * @notice Thrown when a minLiquidationRewardUsd is greater than maxLiquidationRewardUsd
      */
     error InvalidLiquidationRewardGuards(

--- a/markets/perps-market/contracts/interfaces/IGlobalPerpsMarketModule.sol
+++ b/markets/perps-market/contracts/interfaces/IGlobalPerpsMarketModule.sol
@@ -59,14 +59,6 @@ interface IGlobalPerpsMarketModule {
     error InvalidReferrerShareRatio(uint256 shareRatioD18);
 
     /**
-     * @notice Thrown when a minLiquidationRewardUsd is greater than maxLiquidationRewardUsd
-     */
-    error InvalidLiquidationRewardGuards(
-        uint256 minLiquidationRewardUsd,
-        uint256 maxLiquidationRewardUsd
-    );
-
-    /**
      * @notice Sets the max collateral amount for a specific synth market.
      * @param synthMarketId Synth market id, 0 for snxUSD.
      * @param collateralAmount Max collateral amount to set for the synth market id.

--- a/markets/perps-market/contracts/interfaces/IGlobalPerpsMarketModule.sol
+++ b/markets/perps-market/contracts/interfaces/IGlobalPerpsMarketModule.sol
@@ -59,6 +59,19 @@ interface IGlobalPerpsMarketModule {
     error InvalidReferrerShareRatio(uint256 shareRatioD18);
 
     /**
+     * @notice Thrown when a referrer address is invalid (0x)
+     */
+    error InvalidReferrerAddress(address referrer);
+
+    /**
+     * @notice Thrown when a minLiquidationRewardUsd is greater than maxLiquidationRewardUsd
+     */
+    error InvalidLiquidationRewardGuards(
+        uint256 minLiquidationRewardUsd,
+        uint256 maxLiquidationRewardUsd
+    );
+
+    /**
      * @notice Sets the max collateral amount for a specific synth market.
      * @param synthMarketId Synth market id, 0 for snxUSD.
      * @param collateralAmount Max collateral amount to set for the synth market id.

--- a/markets/perps-market/contracts/interfaces/ILiquidationModule.sol
+++ b/markets/perps-market/contracts/interfaces/ILiquidationModule.sol
@@ -46,7 +46,7 @@ interface ILiquidationModule {
      * @param maxNumberOfAccounts max number of accounts to liquidate.
      * @return liquidationReward total reward sent to liquidator.
      */
-    function liquidateFlaggedAccounts(
+    function liquidateFlagged(
         uint256 maxNumberOfAccounts
     ) external returns (uint256 liquidationReward);
 

--- a/markets/perps-market/contracts/interfaces/ILiquidationModule.sol
+++ b/markets/perps-market/contracts/interfaces/ILiquidationModule.sol
@@ -42,10 +42,29 @@ interface ILiquidationModule {
     function liquidate(uint128 accountId) external returns (uint256 liquidationReward);
 
     /**
-     * @notice Liquidates all flagged accounts.
+     * @notice Liquidates up to maxNumberOfAccounts flagged accounts.
+     * @param maxNumberOfAccounts max number of accounts to liquidate.
      * @return liquidationReward total reward sent to liquidator.
      */
-    function liquidateFlagged() external returns (uint256 liquidationReward);
+    function liquidateFlaggedAccounts(
+        uint256 maxNumberOfAccounts
+    ) external returns (uint256 liquidationReward);
+
+    /**
+     * @notice Liquidates the listed flagged accounts.
+     * @dev if any of the accounts is not flagged for liquidation it will be skipped.
+     * @param accountIds list of account ids to liquidate.
+     * @return liquidationReward total reward sent to liquidator.
+     */
+    function liquidateFlaggedAccounts(
+        uint128[] calldata accountIds
+    ) external returns (uint256 liquidationReward);
+
+    /**
+     * @notice Returns the list of flagged accounts.
+     * @return accountIds list of flagged accounts.
+     */
+    function flaggedAccounts() external view returns (uint256[] memory accountIds);
 
     /**
      * @notice Returns if an account is eligible for liquidation.

--- a/markets/perps-market/contracts/interfaces/IMarketConfigurationModule.sol
+++ b/markets/perps-market/contracts/interfaces/IMarketConfigurationModule.sol
@@ -100,6 +100,11 @@ interface IMarketConfigurationModule {
     event SettlementStrategyEnabled(uint128 indexed marketId, uint256 strategyId, bool enabled);
 
     /**
+     * @notice Thrown when the settlement window duration is set to zero
+     */
+    error InvalidSettlementWindowDuration(uint256 duration);
+
+    /**
      * @notice Add a new settlement strategy with this function.
      * @param marketId id of the market to add the settlement strategy.
      * @param strategy strategy details (see SettlementStrategy.Data struct).

--- a/markets/perps-market/contracts/interfaces/IPerpsMarketFactoryModule.sol
+++ b/markets/perps-market/contracts/interfaces/IPerpsMarketFactoryModule.sol
@@ -35,6 +35,12 @@ interface IPerpsMarketFactoryModule is IMarket {
     ) external returns (uint128);
 
     /**
+     * @notice Sets the perps market name.
+     * @param marketName the new perps market name.
+     */
+    function setPerpsMarketName(string memory marketName) external;
+
+    /**
      * @notice Creates a new market.
      * @param requestedMarketId id of the market to create.
      * @param marketName name of the market to create.

--- a/markets/perps-market/contracts/interfaces/IPerpsMarketFactoryModule.sol
+++ b/markets/perps-market/contracts/interfaces/IPerpsMarketFactoryModule.sol
@@ -28,19 +28,11 @@ interface IPerpsMarketFactoryModule is IMarket {
      * @dev this function should be called only once.
      * @return globalPerpsMarketId Id of the global perps market id.
      */
-    function initializeFactory() external returns (uint128);
-
-    /**
-     * @notice Sets the synthetix system.
-     * @param synthetix address of the main synthetix proxy.
-     */
-    function setSynthetix(ISynthetixSystem synthetix) external;
-
-    /**
-     * @notice Sets the spot market system.
-     * @param spotMarket address of the spot market proxy.
-     */
-    function setSpotMarket(ISpotMarketSystem spotMarket) external;
+    function initializeFactory(
+        ISynthetixSystem synthetix,
+        ISpotMarketSystem spotMarket,
+        string memory marketName
+    ) external returns (uint128);
 
     /**
      * @notice Creates a new market.

--- a/markets/perps-market/contracts/modules/GlobalPerpsMarketModule.sol
+++ b/markets/perps-market/contracts/modules/GlobalPerpsMarketModule.sol
@@ -9,6 +9,7 @@ import {GlobalPerpsMarketConfiguration} from "../storage/GlobalPerpsMarketConfig
 import {GlobalPerpsMarket} from "../storage/GlobalPerpsMarket.sol";
 import {IGlobalPerpsMarketModule} from "../interfaces/IGlobalPerpsMarketModule.sol";
 import {OwnableStorage} from "@synthetixio/core-contracts/contracts/ownership/OwnableStorage.sol";
+import "@synthetixio/core-contracts/contracts/errors/AddressError.sol";
 
 /**
  * @title Module for global Perps Market settings.
@@ -141,7 +142,7 @@ contract GlobalPerpsMarketModule is IGlobalPerpsMarketModule {
         }
 
         if (referrer == address(0)) {
-            revert InvalidReferrerAddress(referrer);
+            revert AddressError.ZeroAddress();
         }
 
         GlobalPerpsMarketConfiguration.load().referrerShare[referrer] = shareRatioD18;

--- a/markets/perps-market/contracts/modules/GlobalPerpsMarketModule.sol
+++ b/markets/perps-market/contracts/modules/GlobalPerpsMarketModule.sol
@@ -69,6 +69,10 @@ contract GlobalPerpsMarketModule is IGlobalPerpsMarketModule {
         uint256 maxLiquidationRewardUsd
     ) external override {
         OwnableStorage.onlyOwner();
+        if (minLiquidationRewardUsd > maxLiquidationRewardUsd) {
+            revert InvalidLiquidationRewardGuards(minLiquidationRewardUsd, maxLiquidationRewardUsd);
+        }
+
         GlobalPerpsMarketConfiguration.Data storage store = GlobalPerpsMarketConfiguration.load();
         store.minLiquidationRewardUsd = minLiquidationRewardUsd;
         store.maxLiquidationRewardUsd = maxLiquidationRewardUsd;
@@ -134,6 +138,10 @@ contract GlobalPerpsMarketModule is IGlobalPerpsMarketModule {
 
         if (shareRatioD18 > DecimalMath.UNIT) {
             revert InvalidReferrerShareRatio(shareRatioD18);
+        }
+
+        if (referrer == address(0)) {
+            revert InvalidReferrerAddress(referrer);
         }
 
         GlobalPerpsMarketConfiguration.load().referrerShare[referrer] = shareRatioD18;

--- a/markets/perps-market/contracts/modules/GlobalPerpsMarketModule.sol
+++ b/markets/perps-market/contracts/modules/GlobalPerpsMarketModule.sol
@@ -10,6 +10,7 @@ import {GlobalPerpsMarket} from "../storage/GlobalPerpsMarket.sol";
 import {IGlobalPerpsMarketModule} from "../interfaces/IGlobalPerpsMarketModule.sol";
 import {OwnableStorage} from "@synthetixio/core-contracts/contracts/ownership/OwnableStorage.sol";
 import "@synthetixio/core-contracts/contracts/errors/AddressError.sol";
+import "@synthetixio/core-contracts/contracts/errors/ParameterError.sol";
 
 /**
  * @title Module for global Perps Market settings.
@@ -71,7 +72,7 @@ contract GlobalPerpsMarketModule is IGlobalPerpsMarketModule {
     ) external override {
         OwnableStorage.onlyOwner();
         if (minLiquidationRewardUsd > maxLiquidationRewardUsd) {
-            revert InvalidLiquidationRewardGuards(minLiquidationRewardUsd, maxLiquidationRewardUsd);
+            revert ParameterError.InvalidParameter("min/maxLiquidationRewardUSD", "min > max");
         }
 
         GlobalPerpsMarketConfiguration.Data storage store = GlobalPerpsMarketConfiguration.load();

--- a/markets/perps-market/contracts/modules/LiquidationModule.sol
+++ b/markets/perps-market/contracts/modules/LiquidationModule.sol
@@ -55,7 +55,7 @@ contract LiquidationModule is ILiquidationModule, IMarketEvents {
     /**
      * @inheritdoc ILiquidationModule
      */
-    function liquidateFlaggedAccounts(
+    function liquidateFlagged(
         uint256 maxNumberOfAccounts
     ) external override returns (uint256 liquidationReward) {
         uint256[] memory liquidatableAccounts = GlobalPerpsMarket

--- a/markets/perps-market/contracts/modules/LiquidationModule.sol
+++ b/markets/perps-market/contracts/modules/LiquidationModule.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.11 <0.9.0;
 
 import {DecimalMath} from "@synthetixio/core-contracts/contracts/utils/DecimalMath.sol";
+import {MathUtil} from "../utils/MathUtil.sol";
 import {SafeCastU256} from "@synthetixio/core-contracts/contracts/utils/SafeCast.sol";
 import {SetUtil} from "@synthetixio/core-contracts/contracts/utils/SetUtil.sol";
 import {ILiquidationModule} from "../interfaces/ILiquidationModule.sol";
@@ -63,9 +64,10 @@ contract LiquidationModule is ILiquidationModule, IMarketEvents {
             .liquidatableAccounts
             .values();
 
-        uint numberOfAccountsToLiquidate = maxNumberOfAccounts > liquidatableAccounts.length
-            ? liquidatableAccounts.length
-            : maxNumberOfAccounts;
+        uint numberOfAccountsToLiquidate = MathUtil.min(
+            maxNumberOfAccounts,
+            liquidatableAccounts.length
+        );
 
         for (uint i = 0; i < numberOfAccountsToLiquidate; i++) {
             uint128 accountId = liquidatableAccounts[i].to128();

--- a/markets/perps-market/contracts/modules/MarketConfigurationModule.sol
+++ b/markets/perps-market/contracts/modules/MarketConfigurationModule.sol
@@ -24,6 +24,10 @@ contract MarketConfigurationModule is IMarketConfigurationModule {
     ) external override returns (uint256 strategyId) {
         OwnableStorage.onlyOwner();
 
+        if (strategy.settlementWindowDuration == 0) {
+            revert InvalidSettlementWindowDuration(strategy.settlementWindowDuration);
+        }
+
         strategy.settlementDelay = strategy.settlementDelay == 0 ? 1 : strategy.settlementDelay;
 
         PerpsMarketConfiguration.Data storage config = PerpsMarketConfiguration.load(marketId);

--- a/markets/perps-market/contracts/modules/PerpsMarketFactoryModule.sol
+++ b/markets/perps-market/contracts/modules/PerpsMarketFactoryModule.sol
@@ -53,12 +53,7 @@ contract PerpsMarketFactoryModule is IPerpsMarketFactoryModule {
 
         uint128 perpsMarketId;
         if (factory.perpsMarketId == 0) {
-            setSynthetix(synthetix);
-            setSpotMarket(spotMarket);
-            factory.name = marketName;
-
-            perpsMarketId = synthetix.registerMarket(address(this));
-            factory.perpsMarketId = perpsMarketId;
+            perpsMarketId = factory.initialize(synthetix, spotMarket, marketName);
         } else {
             perpsMarketId = factory.perpsMarketId;
         }
@@ -68,17 +63,12 @@ contract PerpsMarketFactoryModule is IPerpsMarketFactoryModule {
         return perpsMarketId;
     }
 
-    function setSynthetix(ISynthetixSystem synthetix) internal {
-        PerpsMarketFactory.Data storage store = PerpsMarketFactory.load();
-
-        store.synthetix = synthetix;
-        (address usdTokenAddress, ) = synthetix.getAssociatedSystem("USDToken");
-        store.usdToken = ITokenModule(usdTokenAddress);
-        store.oracle = synthetix.getOracleManager();
-    }
-
-    function setSpotMarket(ISpotMarketSystem spotMarket) internal {
-        PerpsMarketFactory.load().spotMarket = spotMarket;
+    /**
+     * @inheritdoc IPerpsMarketFactoryModule
+     */
+    function setPerpsMarketName(string memory marketName) external override {
+        OwnableStorage.onlyOwner();
+        PerpsMarketFactory.load().name = marketName;
     }
 
     /**

--- a/markets/perps-market/contracts/storage/AsyncOrder.sol
+++ b/markets/perps-market/contracts/storage/AsyncOrder.sol
@@ -214,7 +214,7 @@ library AsyncOrder {
             revert SettlementWindowNotOpen(block.timestamp, self.settlementTime);
         }
 
-        if (expired(self, settlementStrategy)) {
+        if (block.timestamp > settlementExpiration) {
             revert SettlementWindowExpired(
                 block.timestamp,
                 self.settlementTime,

--- a/markets/perps-market/contracts/storage/PerpsMarketFactory.sol
+++ b/markets/perps-market/contracts/storage/PerpsMarketFactory.sol
@@ -50,6 +50,25 @@ library PerpsMarketFactory {
         }
     }
 
+    function initialize(
+        Data storage self,
+        ISynthetixSystem synthetix,
+        ISpotMarketSystem spotMarket,
+        string memory name
+    ) internal returns (uint128 perpsMarketId) {
+        onlyIfNotInitialized(self); // redundant check, but kept here in case this internal is called somewhere else
+
+        (address usdTokenAddress, ) = synthetix.getAssociatedSystem("USDToken");
+        perpsMarketId = synthetix.registerMarket(address(this));
+
+        self.spotMarket = spotMarket;
+        self.synthetix = synthetix;
+        self.name = name;
+        self.usdToken = ITokenModule(usdTokenAddress);
+        self.oracle = synthetix.getOracleManager();
+        self.perpsMarketId = perpsMarketId;
+    }
+
     function depositMarketCollateral(
         Data storage self,
         ITokenModule collateral,

--- a/markets/perps-market/contracts/storage/PerpsMarketFactory.sol
+++ b/markets/perps-market/contracts/storage/PerpsMarketFactory.sol
@@ -28,8 +28,7 @@ library PerpsMarketFactory {
         ISynthetixSystem synthetix;
         ISpotMarketSystem spotMarket;
         uint128 perpsMarketId;
-        address owner;
-        address nominatedOwner;
+        string name;
     }
 
     function onlyIfInitialized(Data storage self) internal view {

--- a/markets/perps-market/storage.dump.sol
+++ b/markets/perps-market/storage.dump.sol
@@ -671,8 +671,7 @@ library PerpsMarketFactory {
         address synthetix;
         address spotMarket;
         uint128 perpsMarketId;
-        address owner;
-        address nominatedOwner;
+        string name;
     }
     function load() internal pure returns (Data storage perpsMarketFactory) {
         bytes32 s = _SLOT_PERPS_MARKET_FACTORY;

--- a/markets/perps-market/test/integration/Market/CreateMarket.test.ts
+++ b/markets/perps-market/test/integration/Market/CreateMarket.test.ts
@@ -11,7 +11,7 @@ describe('Create Market test', () => {
     token = 'snxETH',
     price = bn(1000);
 
-  const { systems, signers, owner, restore, trader1 } = bootstrapMarkets({
+  const { systems, signers, owner, restore, trader1, superMarketId } = bootstrapMarkets({
     synthMarkets: [],
     perpsMarkets: [], // don't create a market in bootstrap
     traderAccountIds: [2, 3],
@@ -250,6 +250,31 @@ describe('Create Market test', () => {
 
       it('can get market minimum credit', async () => {
         assertBn.equal(await systems().PerpsMarket.minimumCredit(marketId), bn(0));
+      });
+    });
+  });
+
+  describe('factory setup', async () => {
+    before(restore);
+
+    describe('attempt to do it with non-owner', () => {
+      it('reverts setting market name', async () => {
+        await assertRevert(
+          systems().PerpsMarket.connect(randomAccount).setPerpsMarketName('NewSuperMarket'),
+          'Unauthorized'
+        );
+      });
+    });
+
+    describe('from owner', () => {
+      before('set a new market name', async () => {
+        await systems().PerpsMarket.connect(owner()).setPerpsMarketName('NewSuperMarket');
+      });
+      it('market name was updated', async () => {
+        assert.equal(
+          await systems().PerpsMarket.name(superMarketId()),
+          'NewSuperMarket Perps Market'
+        );
       });
     });
   });

--- a/markets/perps-market/test/integration/Market/CreateMarket.test.ts
+++ b/markets/perps-market/test/integration/Market/CreateMarket.test.ts
@@ -222,34 +222,4 @@ describe('Create Market test', () => {
       });
     });
   });
-
-  describe('factory setup', async () => {
-    before(restore);
-
-    describe('attempt to do it with non-owner', () => {
-      it('reverts setting synthetix', async () => {
-        await assertRevert(
-          systems().PerpsMarket.connect(randomAccount).setSynthetix(ethers.constants.AddressZero),
-          'Unauthorized'
-        );
-      });
-
-      it('reverts setting spot market', async () => {
-        await assertRevert(
-          systems().PerpsMarket.connect(randomAccount).setSpotMarket(ethers.constants.AddressZero),
-          'Unauthorized'
-        );
-      });
-    });
-
-    describe('from owner', () => {
-      it('can set synthetix', async () => {
-        await systems().PerpsMarket.connect(owner()).setSynthetix(systems().Core.address);
-      });
-
-      it('can set spot market', async () => {
-        await systems().PerpsMarket.connect(owner()).setSpotMarket(systems().SpotMarket.address);
-      });
-    });
-  });
 });

--- a/markets/perps-market/test/integration/Market/CreateMarket.test.ts
+++ b/markets/perps-market/test/integration/Market/CreateMarket.test.ts
@@ -64,6 +64,38 @@ describe('Create Market test', () => {
     });
   });
 
+  describe('market initialization with invalid parameters', async () => {
+    before(restore);
+    const marketId = BigNumber.from(25);
+    let oracleNodeId: string;
+
+    before('create perps market', async () => {
+      await systems().PerpsMarket.connect(owner()).createMarket(marketId, name, token);
+    });
+
+    describe('attempt to add a settlement strategy with 0 secs window duration', () => {
+      it('reverts', async () => {
+        await assertRevert(
+          systems()
+            .PerpsMarket.connect(owner())
+            .addSettlementStrategy(marketId, {
+              strategyType: 0,
+              settlementDelay: 5,
+              settlementWindowDuration: 0,
+              priceWindowDuration: 120,
+              priceVerificationContract: ethers.constants.AddressZero,
+              feedId: ethers.constants.HashZero,
+              url: '',
+              disabled: false,
+              settlementReward: bn(5),
+              priceDeviationTolerance: bn(0.01),
+            }),
+          'InvalidSettlementWindowDuration("0")'
+        );
+      });
+    });
+  });
+
   describe('market operation and configuration', async () => {
     before(restore);
 

--- a/markets/perps-market/test/integration/Market/CreateMarket.test.ts
+++ b/markets/perps-market/test/integration/Market/CreateMarket.test.ts
@@ -67,7 +67,6 @@ describe('Create Market test', () => {
   describe('market initialization with invalid parameters', async () => {
     before(restore);
     const marketId = BigNumber.from(25);
-    let oracleNodeId: string;
 
     before('create perps market', async () => {
       await systems().PerpsMarket.connect(owner()).createMarket(marketId, name, token);

--- a/markets/perps-market/test/integration/Markets/GlobalPerpsMarket.test.ts
+++ b/markets/perps-market/test/integration/Markets/GlobalPerpsMarket.test.ts
@@ -2,9 +2,10 @@ import { BigNumber } from 'ethers';
 import { bn, bootstrapMarkets } from '../bootstrap';
 import assertBn from '@synthetixio/core-utils/src/utils/assertions/assert-bignumber';
 import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
+import assert from 'assert';
 
-describe('GlobalPerpsMarket', () => {
-  const { systems, perpsMarkets, trader1 } = bootstrapMarkets({
+describe.only('GlobalPerpsMarket', () => {
+  const { systems, perpsMarkets, trader1, superMarketId } = bootstrapMarkets({
     synthMarkets: [{ name: 'Ether', token: 'snxETH', buyPrice: bn(1000), sellPrice: bn(1000) }],
     perpsMarkets: [
       { requestedMarketId: 25, name: 'Ether', token: 'snxETH', price: bn(1000) },
@@ -21,6 +22,11 @@ describe('GlobalPerpsMarket', () => {
       await systems().PerpsMarket.setLiquidationRewardGuards(100, 500);
     }
   );
+
+  it('returns the supermarket name', async () => {
+    assert.equal(await systems().PerpsMarket.name(superMarketId()), 'SuperMarket Perps Market');
+    assert.equal(await systems().PerpsMarket.name(0), '');
+  });
 
   it('returns maxCollateralAmounts for synth market id', async () => {
     assertBn.equal(

--- a/markets/perps-market/test/integration/Markets/GlobalPerpsMarket.test.ts
+++ b/markets/perps-market/test/integration/Markets/GlobalPerpsMarket.test.ts
@@ -4,7 +4,7 @@ import assertBn from '@synthetixio/core-utils/src/utils/assertions/assert-bignum
 import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
 import assert from 'assert';
 
-describe.only('GlobalPerpsMarket', () => {
+describe('GlobalPerpsMarket', () => {
   const { systems, perpsMarkets, trader1, superMarketId } = bootstrapMarkets({
     synthMarkets: [{ name: 'Ether', token: 'snxETH', buyPrice: bn(1000), sellPrice: bn(1000) }],
     perpsMarkets: [

--- a/markets/perps-market/test/integration/Markets/GlobalPerpsMarket.test.ts
+++ b/markets/perps-market/test/integration/Markets/GlobalPerpsMarket.test.ts
@@ -68,7 +68,7 @@ describe('GlobalPerpsMarket', () => {
   it('transaction should fail if min and max are inverted', async () => {
     await assertRevert(
       systems().PerpsMarket.connect(owner()).setLiquidationRewardGuards(500, 100),
-      'InvalidLiquidationRewardGuards("500", "100")'
+      'InvalidParameter("min/maxLiquidationRewardUSD", "min > max")'
     );
   });
 

--- a/markets/perps-market/test/integration/Markets/GlobalPerpsMarket.test.ts
+++ b/markets/perps-market/test/integration/Markets/GlobalPerpsMarket.test.ts
@@ -5,7 +5,7 @@ import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert
 import assert from 'assert';
 
 describe('GlobalPerpsMarket', () => {
-  const { systems, perpsMarkets, trader1, superMarketId } = bootstrapMarkets({
+  const { systems, perpsMarkets, trader1, superMarketId, owner } = bootstrapMarkets({
     synthMarkets: [{ name: 'Ether', token: 'snxETH', buyPrice: bn(1000), sellPrice: bn(1000) }],
     perpsMarkets: [
       { requestedMarketId: 25, name: 'Ether', token: 'snxETH', price: bn(1000) },
@@ -62,6 +62,13 @@ describe('GlobalPerpsMarket', () => {
     await assertRevert(
       systems().PerpsMarket.connect(trader1()).setSynthDeductionPriority([1, 2]),
       `Unauthorized("${await trader1().getAddress()}")`
+    );
+  });
+
+  it('transaction should fail if min and max are inverted', async () => {
+    await assertRevert(
+      systems().PerpsMarket.connect(owner()).setLiquidationRewardGuards(500, 100),
+      'InvalidLiquidationRewardGuards("500", "100")'
     );
   });
 

--- a/markets/perps-market/test/integration/Orders/OffchainAsyncOrder.referrer.test.ts
+++ b/markets/perps-market/test/integration/Orders/OffchainAsyncOrder.referrer.test.ts
@@ -342,6 +342,15 @@ describe('OffchainAsyncOrder - feeCollector - referrer', () => {
   });
 
   describe('update referrer share failures', () => {
+    it('reverts when referrer address is 0x', async () => {
+      await assertRevert(
+        systems()
+          .PerpsMarket.connect(owner())
+          .updateReferrerShare(ethers.constants.AddressZero, bn(0.1)),
+        'ZeroAddress'
+      );
+    });
+
     it('reverts when set above 100%', async () => {
       await assertRevert(
         systems()

--- a/markets/perps-market/test/integration/bootstrap/bootstrapPerpsMarkets.ts
+++ b/markets/perps-market/test/integration/bootstrap/bootstrapPerpsMarkets.ts
@@ -81,9 +81,16 @@ export const bootstrapPerpsMarkets = (
   });
 
   before('create super market', async () => {
-    superMarketId = await contracts.PerpsMarket.callStatic.initializeFactory();
-    await contracts.PerpsMarket.initializeFactory();
-
+    superMarketId = await contracts.PerpsMarket.callStatic.initializeFactory(
+      contracts.Core.address,
+      contracts.SpotMarket.address,
+      'SuperMarket'
+    );
+    await contracts.PerpsMarket.initializeFactory(
+      contracts.Core.address,
+      contracts.SpotMarket.address,
+      'SuperMarket'
+    );
     await contracts.Core.connect(r.owner()).setPoolConfiguration(r.poolId, [
       {
         marketId: superMarketId,


### PR DESCRIPTION
- [x] [5.4.1 liquidateFlagged() could run out of gas](https://gist.github.com/iosiro-security/3be89b4425d6e33ef7e025a6c1e25231#541-liquidateflagged-could-run-out-of-gas)
- [x] [5.4.2 Perps super market cannot re-register to a new core deployment](https://gist.github.com/iosiro-security/3be89b4425d6e33ef7e025a6c1e25231#542-perps-super-market-cannot-re-register-to-a-new-core-deployment)
- [x] [5.4.3 Changing the spot market does not ensure all balances on the old market are settled](https://gist.github.com/iosiro-security/3be89b4425d6e33ef7e025a6c1e25231#543-changing-the-spot-market-does-not-ensure-all-balances-on-the-old-market-are-settled)
- [x] [5.4.4 Setting some configuration values should ensure the value is not logically incoherent with its purpose](https://gist.github.com/iosiro-security/3be89b4425d6e33ef7e025a6c1e25231#544-setting-some-configuration-values-should-ensure-the-value-is-not-logically-incoherent-with-its-purpose)
- [x] [Gas optimisations](https://gist.github.com/iosiro-security/3be89b4425d6e33ef7e025a6c1e25231#gas-optimisations)
- [x] [Unused Variables](https://gist.github.com/iosiro-security/3be89b4425d6e33ef7e025a6c1e25231#unused-variables)
- [x] Use `PerpsMarketFactoryModule.name()`
- [x] Rename `marketId` to `synthMarketId` in `PerpsAccount.deductFromAccount()` to improve readability.
- [x] fix tests