### PR TITLE
`handleSettlementStrategyAdded` independent implementation for base-goerli-competition

### DIFF
--- a/markets/perps-market/subgraph/base-goerli-competition/handleSettlementStrategyAdded.ts
+++ b/markets/perps-market/subgraph/base-goerli-competition/handleSettlementStrategyAdded.ts
@@ -1,0 +1,22 @@
+import { SettlementStrategyAdded } from './generated/PerpsMarketProxy/PerpsMarketProxy';
+import { SettlementStrategy } from './generated/schema';
+
+export function handleSettlementStrategyAdded(event: SettlementStrategyAdded): void {
+  const id = event.params.strategyId.toString() + '-' + event.params.marketId.toString();
+  const strategy = new SettlementStrategy(id);
+
+  strategy.strategyId = event.params.strategyId;
+  strategy.marketId = event.params.marketId;
+
+  strategy.strategyType = event.params.strategy.strategyType;
+  strategy.settlementDelay = event.params.strategy.settlementDelay;
+  strategy.settlementWindowDuration = event.params.strategy.settlementWindowDuration;
+  strategy.priceVerificationContract =
+    event.params.strategy.priceVerificationContract.toHexString();
+  strategy.feedId = event.params.strategy.feedId;
+  strategy.url = event.params.strategy.url;
+  strategy.settlementReward = event.params.strategy.settlementReward;
+  strategy.enabled = !event.params.strategy.disabled;
+
+  strategy.save();
+}

--- a/markets/perps-market/subgraph/base-goerli-competition/index.ts
+++ b/markets/perps-market/subgraph/base-goerli-competition/index.ts
@@ -13,5 +13,5 @@ export * from '../optimism-goerli/handleOrderSettled';
 export * from '../optimism-goerli/handlePositionLiquidated';
 export * from '../optimism-goerli/handlePreviousOrderExpired';
 export * from '../optimism-goerli/handleReferrerShareUpdated';
-export * from '../optimism-goerli/handleSettlementStrategyAdded';
+export * from './handleSettlementStrategyAdded';
 export * from '../optimism-goerli/handleSettlementStrategyEnabled';

--- a/markets/perps-market/subgraph/tests/base-goerli-competition/PerpsMarketProxy.test.ts
+++ b/markets/perps-market/subgraph/tests/base-goerli-competition/PerpsMarketProxy.test.ts
@@ -1,0 +1,15 @@
+import { afterEach, beforeEach, clearStore, describe, logStore, test } from 'matchstick-as';
+
+import handleSettlementStrategyAdded from './handleSettlementStrategyAdded';
+
+describe('PerpsMarketProxy (base-goerli-competition)', () => {
+  beforeEach(() => {
+    clearStore();
+  });
+
+  afterEach(() => {
+    logStore();
+  });
+
+  test('handleSettlementStrategyAdded', handleSettlementStrategyAdded);
+});

--- a/markets/perps-market/subgraph/tests/base-goerli-competition/event-factories/createSettlementStrategyAddedEvent.ts
+++ b/markets/perps-market/subgraph/tests/base-goerli-competition/event-factories/createSettlementStrategyAddedEvent.ts
@@ -1,0 +1,51 @@
+import { BigInt, ethereum, Address, Bytes } from '@graphprotocol/graph-ts';
+import { newTypedMockEvent } from 'matchstick-as';
+import {
+  SettlementStrategyAdded as SettlementStrategyAddedEvent,
+  SettlementStrategyAddedStrategyStruct,
+} from '../../../base-goerli-competition/generated/PerpsMarketProxy/PerpsMarketProxy';
+
+export function createSettlementStrategyAddedEvent(
+  marketId: i32,
+  // strategy struct
+  strategyType: i32,
+  settlementDelay: i64,
+  settlementWindowDuration: i64,
+  priceWindowDuration: i64,
+  priceVerificationContract: string,
+  feedId: string,
+  url: string,
+  settlementReward: i64,
+  disabled: boolean,
+  // end of strategy struct
+  strategyId: i32,
+  timestamp: i64,
+  blockNumber: i64,
+  logIndex: i64
+): SettlementStrategyAddedEvent {
+  const event = newTypedMockEvent<SettlementStrategyAddedEvent>();
+
+  event.parameters = [];
+  event.parameters.push(new ethereum.EventParam('marketId', ethereum.Value.fromI32(marketId)));
+
+  const strategy = changetype<SettlementStrategyAddedStrategyStruct>([
+    ethereum.Value.fromI32(strategyType),
+    ethereum.Value.fromUnsignedBigInt(BigInt.fromI64(settlementDelay)),
+    ethereum.Value.fromUnsignedBigInt(BigInt.fromI64(settlementWindowDuration)),
+    ethereum.Value.fromUnsignedBigInt(BigInt.fromI64(priceWindowDuration)),
+    ethereum.Value.fromAddress(Address.fromString(priceVerificationContract)),
+    ethereum.Value.fromBytes(Bytes.fromHexString(feedId) as Bytes),
+    ethereum.Value.fromString(url),
+    ethereum.Value.fromUnsignedBigInt(BigInt.fromI64(settlementReward)),
+    ethereum.Value.fromBoolean(disabled),
+  ]);
+  event.parameters.push(new ethereum.EventParam('strategy', ethereum.Value.fromTuple(strategy)));
+
+  event.parameters.push(new ethereum.EventParam('strategyId', ethereum.Value.fromI32(strategyId)));
+
+  event.block.timestamp = BigInt.fromI64(timestamp);
+  event.block.number = BigInt.fromI64(blockNumber);
+  event.logIndex = BigInt.fromI64(logIndex);
+
+  return event;
+}

--- a/markets/perps-market/subgraph/tests/base-goerli-competition/handleSettlementStrategyAdded.ts
+++ b/markets/perps-market/subgraph/tests/base-goerli-competition/handleSettlementStrategyAdded.ts
@@ -1,0 +1,66 @@
+import { assert, log } from 'matchstick-as';
+import { handleSettlementStrategyAdded } from '../../base-goerli-competition';
+import { createSettlementStrategyAddedEvent } from './event-factories/createSettlementStrategyAddedEvent';
+
+export default function test(): void {
+  assert.entityCount('SettlementStrategy', 0);
+
+  log.info('Should create a new record for the SettlementStrategy', []);
+
+  const marketId = 1;
+  const strategyType = 1;
+  const settlementDelay = 10_000;
+  const settlementWindowDuration = 10_000;
+  const priceWindowDuration = 10_000;
+  const priceVerificationContract = '0x4200000000000000000000000000000000000000';
+  const feedId = '0x6900000000000000000000000000000000000000';
+  const url = 'https://example.com';
+  const settlementReward = 10_000;
+  const disabled = false;
+  const strategyId = 1;
+  const timestamp = 10_000;
+  const blockNumber = 10;
+  const logIndex = 1;
+
+  handleSettlementStrategyAdded(
+    createSettlementStrategyAddedEvent(
+      marketId,
+      strategyType,
+      settlementDelay,
+      settlementWindowDuration,
+      priceWindowDuration,
+      priceVerificationContract,
+      feedId,
+      url,
+      settlementReward,
+      disabled,
+      strategyId,
+      timestamp,
+      blockNumber,
+      logIndex
+    )
+  );
+
+  assert.entityCount('SettlementStrategy', 1);
+  assert.fieldEquals('SettlementStrategy', '1-1', 'id', '1-1');
+  assert.fieldEquals('SettlementStrategy', '1-1', 'strategyId', '1');
+  assert.fieldEquals('SettlementStrategy', '1-1', 'marketId', '1');
+  assert.fieldEquals('SettlementStrategy', '1-1', 'strategyType', strategyType.toString());
+  assert.fieldEquals('SettlementStrategy', '1-1', 'settlementDelay', settlementDelay.toString());
+  assert.fieldEquals(
+    'SettlementStrategy',
+    '1-1',
+    'settlementWindowDuration',
+    settlementWindowDuration.toString()
+  );
+  assert.fieldEquals(
+    'SettlementStrategy',
+    '1-1',
+    'priceVerificationContract',
+    priceVerificationContract.toString()
+  );
+  assert.fieldEquals('SettlementStrategy', '1-1', 'feedId', feedId.toString());
+  assert.fieldEquals('SettlementStrategy', '1-1', 'url', url);
+  assert.fieldEquals('SettlementStrategy', '1-1', 'settlementReward', settlementReward.toString());
+  assert.fieldEquals('SettlementStrategy', '1-1', 'enabled', (!disabled).toString());
+}


### PR DESCRIPTION
As the ABI has incompatible changes we need to have independent implementation for a base-goerli-competition subgraph

1. Add `base-goerli-competition/handleSettlementStrategyAdded.ts`
2. Reference new implementation instead of `optimism-goerli/handleSettlementStrategyAdded`
3. Create independent test for new delpoyment `tests/base-goerli-competition/PerpsMarketProxy.test.ts`


Sync error is no more. We are good now.

<img width="850" alt="image" src="https://github.com/Synthetixio/synthetix-v3/assets/28145325/8106cc06-6de8-4e67-a132-1e6e01156734">
