### PR TITLE
SIP-343 Add extra fields to existing Market Events to track market debt changes

### DIFF
--- a/protocol/synthetix/contracts/interfaces/IMarketCollateralModule.sol
+++ b/protocol/synthetix/contracts/interfaces/IMarketCollateralModule.sol
@@ -29,13 +29,19 @@ interface IMarketCollateralModule {
      * @param collateralType The address of the collateral that was directly deposited in the market.
      * @param tokenAmount The amount of tokens that were deposited, denominated in the token's native decimal representation.
      * @param sender The address that triggered the deposit.
-     * @param reportedDebt Updated reported debt of the market after depositing
+     * @param creditCapacity Updated credit capacity of the market after depositing collateral.
+     * @param netIssuance Updated net issuance.
+     * @param depositedCollateralValue Updated deposited collateral value of the market.
+     * @param reportedDebt Updated reported debt of the market after depositing collateral.
      */
     event MarketCollateralDeposited(
         uint128 indexed marketId,
         address indexed collateralType,
         uint256 tokenAmount,
         address indexed sender,
+        int128 creditCapacity,
+        int128 netIssuance,
+        uint256 depositedCollateralValue,
         uint256 reportedDebt
     );
 
@@ -45,13 +51,19 @@ interface IMarketCollateralModule {
      * @param collateralType The address of the collateral that was withdrawn from the market.
      * @param tokenAmount The amount of tokens that were withdrawn, denominated in the token's native decimal representation.
      * @param sender The address that triggered the withdrawal.
-     * @param reportedDebt Updated reported debt of the market after withdrawing.
+     * @param creditCapacity Updated credit capacity of the market after withdrawing.
+     * @param netIssuance Updated net issuance.
+     * @param depositedCollateralValue Updated deposited collateral value of the market.
+     * @param reportedDebt Updated reported debt of the market after withdrawing collateral.
      */
     event MarketCollateralWithdrawn(
         uint128 indexed marketId,
         address indexed collateralType,
         uint256 tokenAmount,
         address indexed sender,
+        int128 creditCapacity,
+        int128 netIssuance,
+        uint256 depositedCollateralValue,
         uint256 reportedDebt
     );
 

--- a/protocol/synthetix/contracts/interfaces/IMarketCollateralModule.sol
+++ b/protocol/synthetix/contracts/interfaces/IMarketCollateralModule.sol
@@ -29,12 +29,14 @@ interface IMarketCollateralModule {
      * @param collateralType The address of the collateral that was directly deposited in the market.
      * @param tokenAmount The amount of tokens that were deposited, denominated in the token's native decimal representation.
      * @param sender The address that triggered the deposit.
+     * @param reportedDebt Updated reported debt of the market after depositing
      */
     event MarketCollateralDeposited(
         uint128 indexed marketId,
         address indexed collateralType,
         uint256 tokenAmount,
-        address indexed sender
+        address indexed sender,
+        uint256 reportedDebt
     );
 
     /**
@@ -43,12 +45,14 @@ interface IMarketCollateralModule {
      * @param collateralType The address of the collateral that was withdrawn from the market.
      * @param tokenAmount The amount of tokens that were withdrawn, denominated in the token's native decimal representation.
      * @param sender The address that triggered the withdrawal.
+     * @param reportedDebt Updated reported debt of the market after withdrawing.
      */
     event MarketCollateralWithdrawn(
         uint128 indexed marketId,
         address indexed collateralType,
         uint256 tokenAmount,
-        address indexed sender
+        address indexed sender,
+        uint256 reportedDebt
     );
 
     /**

--- a/protocol/synthetix/contracts/interfaces/IMarketManagerModule.sol
+++ b/protocol/synthetix/contracts/interfaces/IMarketManagerModule.sol
@@ -36,9 +36,10 @@ interface IMarketManagerModule {
      * @param target The address of the account that provided the snxUSD in the deposit.
      * @param amount The amount of snxUSD deposited in the system, denominated with 18 decimals of precision.
      * @param market The address of the external market that is depositing.
-     * @param creditCapacity Updated credit capacity of the market after depositing
-     * @param netIssuance Updated net issuance
-     * @param reportedDebt Updated reported debt of the market after depositing
+     * @param creditCapacity Updated credit capacity of the market after depositing.
+     * @param netIssuance Updated net issuance.
+     * @param depositedCollateralValue Updated deposited collateral value of the market.
+     * @param reportedDebt Updated reported debt of the market after depositing.
      */
     event MarketUsdDeposited(
         uint128 indexed marketId,
@@ -47,6 +48,7 @@ interface IMarketManagerModule {
         address indexed market,
         int128 creditCapacity,
         int128 netIssuance,
+        uint256 depositedCollateralValue,
         uint256 reportedDebt
     );
 
@@ -56,9 +58,10 @@ interface IMarketManagerModule {
      * @param target The address of the account that received the snxUSD in the withdrawal.
      * @param amount The amount of snxUSD withdrawn from the system, denominated with 18 decimals of precision.
      * @param market The address of the external market that is withdrawing.
-     * @param creditCapacity Updated credit capacity of the market after withdrawing
-     * @param netIssuance Updated net issuance
-     * @param reportedDebt Updated reported debt of the market after withdrawal
+     * @param creditCapacity Updated credit capacity of the market after withdrawing.
+     * @param netIssuance Updated net issuance.
+     * @param depositedCollateralValue Updated deposited collateral value of the market.
+     * @param reportedDebt Updated reported debt of the market after withdrawal.
      */
     event MarketUsdWithdrawn(
         uint128 indexed marketId,
@@ -67,6 +70,7 @@ interface IMarketManagerModule {
         address indexed market,
         int128 creditCapacity,
         int128 netIssuance,
+        uint256 depositedCollateralValue,
         uint256 reportedDebt
     );
 

--- a/protocol/synthetix/contracts/interfaces/IMarketManagerModule.sol
+++ b/protocol/synthetix/contracts/interfaces/IMarketManagerModule.sol
@@ -36,12 +36,18 @@ interface IMarketManagerModule {
      * @param target The address of the account that provided the snxUSD in the deposit.
      * @param amount The amount of snxUSD deposited in the system, denominated with 18 decimals of precision.
      * @param market The address of the external market that is depositing.
+     * @param creditCapacity Updated credit capacity of the market after depositing
+     * @param netIssuance Updated net issuance
+     * @param reportedDebt Updated reported debt of the market after depositing
      */
     event MarketUsdDeposited(
         uint128 indexed marketId,
         address indexed target,
         uint256 amount,
-        address indexed market
+        address indexed market,
+        int128 creditCapacity,
+        int128 netIssuance,
+        uint256 reportedDebt
     );
 
     /**
@@ -50,12 +56,18 @@ interface IMarketManagerModule {
      * @param target The address of the account that received the snxUSD in the withdrawal.
      * @param amount The amount of snxUSD withdrawn from the system, denominated with 18 decimals of precision.
      * @param market The address of the external market that is withdrawing.
+     * @param creditCapacity Updated credit capacity of the market after withdrawing
+     * @param netIssuance Updated net issuance
+     * @param reportedDebt Updated reported debt of the market after withdrawal
      */
     event MarketUsdWithdrawn(
         uint128 indexed marketId,
         address indexed target,
         uint256 amount,
-        address indexed market
+        address indexed market,
+        int128 creditCapacity,
+        int128 netIssuance,
+        uint256 reportedDebt
     );
 
     event MarketSystemFeePaid(uint128 indexed marketId, uint256 feeAmount);

--- a/protocol/synthetix/contracts/modules/core/MarketCollateralModule.sol
+++ b/protocol/synthetix/contracts/modules/core/MarketCollateralModule.sol
@@ -65,6 +65,9 @@ contract MarketCollateralModule is IMarketCollateralModule {
             collateralType,
             tokenAmount,
             ERC2771Context._msgSender(),
+            marketData.creditCapacityD18,
+            marketData.netIssuanceD18,
+            marketData.getDepositedCollateralValue(),
             marketData.getReportedDebt()
         );
     }
@@ -119,6 +122,9 @@ contract MarketCollateralModule is IMarketCollateralModule {
             collateralType,
             tokenAmount,
             ERC2771Context._msgSender(),
+            marketData.creditCapacityD18,
+            marketData.netIssuanceD18,
+            marketData.getDepositedCollateralValue(),
             marketData.getReportedDebt()
         );
     }

--- a/protocol/synthetix/contracts/modules/core/MarketCollateralModule.sol
+++ b/protocol/synthetix/contracts/modules/core/MarketCollateralModule.sol
@@ -64,7 +64,8 @@ contract MarketCollateralModule is IMarketCollateralModule {
             marketId,
             collateralType,
             tokenAmount,
-            ERC2771Context._msgSender()
+            ERC2771Context._msgSender(),
+            marketData.getReportedDebt()
         );
     }
 
@@ -117,7 +118,8 @@ contract MarketCollateralModule is IMarketCollateralModule {
             marketId,
             collateralType,
             tokenAmount,
-            ERC2771Context._msgSender()
+            ERC2771Context._msgSender(),
+            marketData.getReportedDebt()
         );
     }
 

--- a/protocol/synthetix/contracts/modules/core/MarketManagerModule.sol
+++ b/protocol/synthetix/contracts/modules/core/MarketManagerModule.sol
@@ -237,6 +237,7 @@ contract MarketManagerModule is IMarketManagerModule {
             ERC2771Context._msgSender(),
             market.creditCapacityD18,
             market.netIssuanceD18,
+            market.getDepositedCollateralValue(),
             market.getReportedDebt()
         );
     }
@@ -285,6 +286,7 @@ contract MarketManagerModule is IMarketManagerModule {
             ERC2771Context._msgSender(),
             marketData.creditCapacityD18,
             marketData.netIssuanceD18,
+            marketData.getDepositedCollateralValue(),
             marketData.getReportedDebt()
         );
     }

--- a/protocol/synthetix/contracts/modules/core/MarketManagerModule.sol
+++ b/protocol/synthetix/contracts/modules/core/MarketManagerModule.sol
@@ -230,7 +230,15 @@ contract MarketManagerModule is IMarketManagerModule {
             emit MarketSystemFeePaid(marketId, feeAmount);
         }
 
-        emit MarketUsdDeposited(marketId, target, amount, ERC2771Context._msgSender());
+        emit MarketUsdDeposited(
+            marketId,
+            target,
+            amount,
+            ERC2771Context._msgSender(),
+            market.creditCapacityD18,
+            market.netIssuanceD18,
+            market.getReportedDebt()
+        );
     }
 
     /**
@@ -270,7 +278,15 @@ contract MarketManagerModule is IMarketManagerModule {
             emit MarketSystemFeePaid(marketId, feeAmount);
         }
 
-        emit MarketUsdWithdrawn(marketId, target, amount, ERC2771Context._msgSender());
+        emit MarketUsdWithdrawn(
+            marketId,
+            target,
+            amount,
+            ERC2771Context._msgSender(),
+            marketData.creditCapacityD18,
+            marketData.netIssuanceD18,
+            marketData.getReportedDebt()
+        );
     }
 
     /**

--- a/protocol/synthetix/test/integration/modules/core/MarketCollateralModule/MarketCollateralModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/MarketCollateralModule/MarketCollateralModule.test.ts
@@ -150,11 +150,12 @@ describe('MarketCollateralModule', function () {
         });
 
         it('emits event', async () => {
+          const reportedDebt = 0;
           await assertEvent(
             tx,
             `MarketCollateralDeposited(${marketId()}, "${collateralAddress()}", ${configuredMaxAmount.toString()}, "${
               MockMarket().address
-            }")`,
+            }", ${reportedDebt})`,
             systems().Core
           );
         });
@@ -267,12 +268,13 @@ describe('MarketCollateralModule', function () {
         });
 
         it('emits event', async () => {
+          const reportedDebt = 0;
           await assertEvent(
             tx,
             `MarketCollateralWithdrawn(${marketId()}, "${collateralAddress()}", ${configuredMaxAmount
               .div(2)
               .div(4)
-              .toString()}, "${MockMarket().address}")`,
+              .toString()}, "${MockMarket().address}", ${reportedDebt})`,
             systems().Core
           );
         });

--- a/protocol/synthetix/test/integration/modules/core/MarketCollateralModule/MarketCollateralModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/MarketCollateralModule/MarketCollateralModule.test.ts
@@ -150,12 +150,28 @@ describe('MarketCollateralModule', function () {
         });
 
         it('emits event', async () => {
+          const tokenAmount = configuredMaxAmount.toString();
+          const sender = MockMarket().address;
+          const creditCapacity = ethers.utils.parseEther('1000');
+          const netIssuance = 0;
+          const depositedCollateralValue = (
+            await systems()
+              .Core.connect(user1)
+              .getMarketCollateralAmount(marketId(), collateralAddress())
+          ).toString();
           const reportedDebt = 0;
           await assertEvent(
             tx,
-            `MarketCollateralDeposited(${marketId()}, "${collateralAddress()}", ${configuredMaxAmount.toString()}, "${
-              MockMarket().address
-            }", ${reportedDebt})`,
+            `MarketCollateralDeposited(${[
+              marketId(),
+              `"${collateralAddress()}"`,
+              tokenAmount,
+              `"${sender}"`,
+              creditCapacity,
+              netIssuance,
+              depositedCollateralValue,
+              reportedDebt,
+            ].join(', ')})`,
             systems().Core
           );
         });
@@ -268,13 +284,28 @@ describe('MarketCollateralModule', function () {
         });
 
         it('emits event', async () => {
+          const tokenAmount = configuredMaxAmount.div(2).div(4).toString();
+          const sender = MockMarket().address;
+          const creditCapacity = ethers.utils.parseEther('1000');
+          const netIssuance = 0;
+          const depositedCollateralValue = (
+            await systems()
+              .Core.connect(user1)
+              .getMarketCollateralAmount(marketId(), collateralAddress())
+          ).toString();
           const reportedDebt = 0;
           await assertEvent(
             tx,
-            `MarketCollateralWithdrawn(${marketId()}, "${collateralAddress()}", ${configuredMaxAmount
-              .div(2)
-              .div(4)
-              .toString()}, "${MockMarket().address}", ${reportedDebt})`,
+            `MarketCollateralWithdrawn(${[
+              marketId(),
+              `"${collateralAddress()}"`,
+              tokenAmount,
+              `"${sender}"`,
+              creditCapacity,
+              netIssuance,
+              depositedCollateralValue,
+              reportedDebt,
+            ].join(', ')})`,
             systems().Core
           );
         });

--- a/protocol/synthetix/test/integration/modules/core/MarketManagerModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/MarketManagerModule.test.ts
@@ -147,6 +147,30 @@ describe('MarketManagerModule', function () {
             0
           );
         });
+
+        it('emits event', async () => {
+          const target = `"${await user1.getAddress()}"`;
+          const amount = bn(1).toString();
+          const market = `"${MockMarket().address}"`;
+          const creditCapacity = bn(1001).toString();
+          const netIssuance = bn(-1).toString();
+          const depositedCollateralValue = bn(0).toString();
+          const reportedDebt = bn(1).toString();
+          await assertEvent(
+            txn,
+            `MarketUsdDeposited(${[
+              marketId(),
+              target,
+              amount,
+              market,
+              creditCapacity,
+              netIssuance,
+              depositedCollateralValue,
+              reportedDebt,
+            ].join(', ')})`,
+            systems().Core
+          );
+        });
       });
 
       describe('when fee is levied', async () => {
@@ -274,6 +298,30 @@ describe('MarketManagerModule', function () {
           assertBn.equal(await systems().USD.balanceOf(await user1.getAddress()), One.div(2));
         });
 
+        it('emits event', async () => {
+          const target = `"${await user1.getAddress()}"`;
+          const amount = bn(0.5).toString();
+          const market = `"${MockMarket().address}"`;
+          const creditCapacity = bn(1000.5).toString();
+          const netIssuance = bn(-0.5).toString();
+          const depositedCollateralValue = bn(0).toString();
+          const reportedDebt = bn(0.5).toString();
+          await assertEvent(
+            txn,
+            `MarketUsdWithdrawn(${[
+              marketId(),
+              target,
+              amount,
+              market,
+              creditCapacity,
+              netIssuance,
+              depositedCollateralValue,
+              reportedDebt,
+            ].join(', ')})`,
+            systems().Core
+          );
+        });
+
         describe('withdraw the rest', async () => {
           before('mint USD to use market', async () => {
             txn = await MockMarket().connect(user1).sellSynth(One.div(2));
@@ -290,6 +338,30 @@ describe('MarketManagerModule', function () {
 
           it('makes USD', async () => {
             assertBn.equal(await systems().USD.balanceOf(await user1.getAddress()), One);
+          });
+
+          it('emits event', async () => {
+            const target = `"${await user1.getAddress()}"`;
+            const amount = bn(0.5).toString();
+            const market = `"${MockMarket().address}"`;
+            const creditCapacity = bn(1000).toString();
+            const netIssuance = bn(0).toString();
+            const depositedCollateralValue = bn(0).toString();
+            const reportedDebt = bn(0).toString();
+            await assertEvent(
+              txn,
+              `MarketUsdWithdrawn(${[
+                marketId(),
+                target,
+                amount,
+                market,
+                creditCapacity,
+                netIssuance,
+                depositedCollateralValue,
+                reportedDebt,
+              ].join(', ')})`,
+              systems().Core
+            );
           });
         });
       });

--- a/protocol/synthetix/test/integration/modules/core/MarketManagerModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/MarketManagerModule.test.ts
@@ -44,7 +44,7 @@ describe('MarketManagerModule', function () {
     verifyUsesFeatureFlag(
       () => systems().Core,
       'registerMarket',
-      () => systems().Core.connect(user2).registerMarket(user1.getAddress())
+      () => systems().Core.connect(user2).registerMarket(MockMarket().address)
     );
 
     it('reverts when trying to register a market that does not support the IMarket interface', async function () {

--- a/protocol/synthetix/test/integration/verifications.ts
+++ b/protocol/synthetix/test/integration/verifications.ts
@@ -9,20 +9,14 @@ export function verifyUsesFeatureFlag(
   txn: () => Promise<unknown>
 ) {
   describe(`when ${flagName} feature disabled`, () => {
-    before('disable feature', async () => {
-      await c().setFeatureFlagDenyAll(ethers.utils.formatBytes32String(flagName), true);
-    });
-
-    after('re-enable feature', async () => {
-      await c().setFeatureFlagDenyAll(ethers.utils.formatBytes32String(flagName), false);
-    });
-
     it('it fails with feature unavailable', async () => {
+      await c().setFeatureFlagDenyAll(ethers.utils.formatBytes32String(flagName), true);
       await assertRevert(
         txn(),
         `FeatureUnavailable("${ethers.utils.formatBytes32String(flagName)}")`,
         c()
       );
+      await c().setFeatureFlagDenyAll(ethers.utils.formatBytes32String(flagName), false);
     });
   });
 }


### PR DESCRIPTION
As a follow up to https://github.com/Synthetixio/synthetix-v3/pull/1849
SIP: https://sips.synthetix.io/sips/sip-343/

- [x] Update events in interface `IMarketCollateralModule`:
  - [x] MarketCollateralDeposited
  - [x] MarketCollateralWithdrawn
- [x] Update events in interface `IMarketManagerModule`:
  - [x] MarketUsdDeposited
  - [x] MarketUsdWithdrawn
- [x] Update emitted events with extra fields `creditCapacity`, `netIssuance`, `depositedCollateralValue` and `reportedDebt` in:
  - [x] MarketCollateralModule.withdrawMarketCollateral
  - [x] MarketCollateralModule.depositMarketCollateral
  - [x] MarketManagerModule.withdrawMarketUsd
  - [x] MarketManagerModule.depositMarketUsd
- [x] Update test cases in `MarketCollateralModule.test.ts`
- [x] Add missing test cases in `MarketManagerModule.test.ts` to check MarketUsdDeposited and MarketUsdWithdrawn events emitted
- [x] Green build :shipit: 
- [x] SIP merged, voted, approved
- [x] Audit