### PR TITLE
update yarn config with checksumBehavior=throw

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,4 +1,4 @@
-checksumBehavior: ignore
+checksumBehavior: throw
 
 compressionLevel: mixed
 


### PR DESCRIPTION
This configuration was needed for some legacy dependencies, and is not necessary anymore.