### PR TITLE
[SIP-PENDING] fixes for reward manager to report correct shares

### DIFF
--- a/protocol/synthetix/contracts/modules/core/RewardsManagerModule.sol
+++ b/protocol/synthetix/contracts/modules/core/RewardsManagerModule.sol
@@ -169,7 +169,12 @@ contract RewardsManagerModule is IRewardsManagerModule {
             revert ParameterError.InvalidParameter("invalid-params", "reward is not found");
         }
 
-        uint256 rewardAmount = vault.updateReward(accountId, poolId, collateralType, rewardId);
+				uint256 totalSharesD18 = vault.currentEpoch().accountsDebtDistribution.totalSharesD18;
+				uint256 actorSharesD18 = vault.currentEpoch().accountsDebtDistribution.getActorShares(
+						accountId.toBytes32()
+				);
+
+        uint256 rewardAmount = vault.updateReward(Vault.PositionSelector(accountId, poolId, collateralType), rewardId, totalSharesD18, actorSharesD18);
 
         RewardDistribution.Data storage reward = vault.rewards[rewardId];
         reward.claimStatus[accountId].pendingSendD18 = 0;

--- a/protocol/synthetix/contracts/modules/core/VaultModule.sol
+++ b/protocol/synthetix/contracts/modules/core/VaultModule.sol
@@ -66,7 +66,10 @@ contract VaultModule is IVaultModule {
         Vault.Data storage vault = Pool.loadExisting(poolId).vaults[collateralType];
 
         // Use account interaction to update its rewards.
-        vault.updateRewards(accountId, poolId, collateralType);
+				uint256 totalSharesD18 = vault.currentEpoch().accountsDebtDistribution.totalSharesD18;
+				uint256 actorSharesD18 = vault.currentEpoch().accountsDebtDistribution.getActorShares(
+						accountId.toBytes32()
+				);
 
         uint256 currentCollateralAmount = vault.currentAccountCollateral(accountId);
 
@@ -151,6 +154,8 @@ contract VaultModule is IVaultModule {
             leverage,
             ERC2771Context._msgSender()
         );
+
+        vault.updateRewards(Vault.PositionSelector(accountId, poolId, collateralType), totalSharesD18, actorSharesD18);
     }
 
     /**

--- a/protocol/synthetix/contracts/storage/Vault.sol
+++ b/protocol/synthetix/contracts/storage/Vault.sol
@@ -67,6 +67,12 @@ library Vault {
         SetUtil.Bytes32Set rewardIds;
     }
 
+		struct PositionSelector {
+        uint128 accountId;
+        uint128 poolId;
+        address collateralType;
+		}
+
     /**
      * @dev Return's the VaultEpoch data for the current epoch.
      */
@@ -112,15 +118,29 @@ library Vault {
         return currentEpoch(self).consolidateAccountDebt(accountId);
     }
 
+		function updateRewards(
+			Data storage self,
+			uint128 accountId,
+			uint128 poolId,
+			address collateralType
+		) internal returns (uint256[] memory rewards, address[] memory distributors) {
+				uint256 totalSharesD18 = currentEpoch(self).accountsDebtDistribution.totalSharesD18;
+				uint256 actorSharesD18 = currentEpoch(self).accountsDebtDistribution.getActorShares(
+						accountId.toBytes32()
+				);
+
+				return updateRewards(self, PositionSelector(accountId, poolId, collateralType), totalSharesD18, actorSharesD18);
+		}
+
     /**
      * @dev Traverses available rewards for this vault, and updates an accounts
      * claim on them according to the amount of debt shares they have.
      */
     function updateRewards(
         Data storage self,
-        uint128 accountId,
-        uint128 poolId,
-        address collateralType
+				PositionSelector memory pos,
+				uint256 totalSharesD18,
+				uint256 actorSharesD18
     ) internal returns (uint256[] memory rewards, address[] memory distributors) {
         rewards = new uint256[](self.rewardIds.length());
         distributors = new address[](self.rewardIds.length());
@@ -136,10 +156,10 @@ library Vault {
             distributors[i] = address(dist.distributor);
             rewards[i] = updateReward(
                 self,
-                accountId,
-                poolId,
-                collateralType,
-                self.rewardIds.valueAt(i + 1)
+								pos,
+                self.rewardIds.valueAt(i + 1),
+								totalSharesD18,
+								actorSharesD18
             );
         }
     }
@@ -150,33 +170,28 @@ library Vault {
      */
     function updateReward(
         Data storage self,
-        uint128 accountId,
-        uint128 poolId,
-        address collateralType,
-        bytes32 rewardId
+				PositionSelector memory pos,
+        bytes32 rewardId,
+				uint256 totalSharesD18,
+				uint256 actorSharesD18
     ) internal returns (uint256) {
-        uint256 totalSharesD18 = currentEpoch(self).accountsDebtDistribution.totalSharesD18;
-        uint256 actorSharesD18 = currentEpoch(self).accountsDebtDistribution.getActorShares(
-            accountId.toBytes32()
-        );
-
         RewardDistribution.Data storage dist = self.rewards[rewardId];
 
         if (address(dist.distributor) == address(0)) {
             revert RewardDistributorNotFound();
         }
 
-        dist.distributor.onPositionUpdated(accountId, poolId, collateralType, actorSharesD18);
+        dist.distributor.onPositionUpdated(pos.accountId, pos.poolId, pos.collateralType, actorSharesD18);
 
         dist.rewardPerShareD18 += dist.updateEntry(totalSharesD18).toUint().to128();
 
-        dist.claimStatus[accountId].pendingSendD18 += actorSharesD18
-            .mulDecimal(dist.rewardPerShareD18 - dist.claimStatus[accountId].lastRewardPerShareD18)
+        dist.claimStatus[pos.accountId].pendingSendD18 += actorSharesD18
+            .mulDecimal(dist.rewardPerShareD18 - dist.claimStatus[pos.accountId].lastRewardPerShareD18)
             .to128();
 
-        dist.claimStatus[accountId].lastRewardPerShareD18 = dist.rewardPerShareD18;
+        dist.claimStatus[pos.accountId].lastRewardPerShareD18 = dist.rewardPerShareD18;
 
-        return dist.claimStatus[accountId].pendingSendD18;
+        return dist.claimStatus[pos.accountId].pendingSendD18;
     }
 
     /**


### PR DESCRIPTION
basically this whole change is to move rewards manager position updated hook to occur after the position changes have occured. the data sent to the distributor is still the data from when the distribution was prior to update, but now we send the message after the change has occured so its possible for the rewards distributor to query for the new value. This is required for SnapshotRewardsDistributor.

it slightly improves gas. but it modestly increases complexity as well.