### PR TITLE
Cache only for the current build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,55 +84,6 @@ commands:
           name: "Wait for IPFS daemon to start"
           command: wget --output-document - --retry-connrefused --waitretry=20 --read-timeout=20 --timeout=15 -t 10 --post-data '' "http://localhost:5001/api/v0/version"
 
-  version-contracts:
-    steps:
-      # Find the last update of any contract
-      - run: |
-          git log -1 -- \
-            utils/common-config/hardhat.config.ts \
-            utils/core-modules/contracts \
-            utils/core-modules/cannonfile.test.toml \
-            utils/core-modules/hardhat.config.ts \
-            utils/core-modules/storage.dump.sol \
-            utils/core-contracts/contracts \
-            utils/core-contracts/hardhat.config.ts \
-            protocol/synthetix/contracts \
-            protocol/synthetix/cannonfile.test.toml \
-            protocol/synthetix/cannonfile.toml \
-            protocol/synthetix/hardhat.config.ts \
-            protocol/synthetix/storage.dump.sol \
-            protocol/governance/contracts \
-            protocol/governance/cannonfile.toml \
-            protocol/governance/hardhat.config.ts \
-            protocol/oracle-manager/contracts \
-            protocol/oracle-manager/cannonfile.test.toml \
-            protocol/oracle-manager/cannonfile.toml \
-            protocol/oracle-manager/hardhat.config.ts \
-            protocol/oracle-manager/storage.dump.sol \
-            markets/spot-market/contracts \
-            markets/spot-market/cannonfile.test.toml \
-            markets/spot-market/cannonfile.toml \
-            markets/spot-market/hardhat.config.ts \
-            markets/spot-market/storage.dump.sol \
-            markets/perps-market/contracts \
-            markets/perps-market/cannonfile.test.toml \
-            markets/perps-market/cannonfile.toml \
-            markets/perps-market/hardhat.config.ts \
-            markets/perps-market/storage.dump.sol \
-            markets/legacy-market/contracts \
-            markets/legacy-market/hardhat.config.ts \
-            markets/legacy-market/cannonfile.toml \
-            > /tmp/version--contracts.txt
-      - run: echo "Cannon $(yarn cannon --version)" >> /tmp/version--contracts.txt
-      - run: cat /tmp/version--contracts.txt
-
-  version-testable-contracts:
-    steps:
-      # Currently we only have testable contracts generated for @synthetixio/main
-      # Add more folders to version calc (space separated)
-      - run: git log -1 -- protocol/synthetix/contracts > /tmp/version--testable-contracts.txt
-      - run: cat /tmp/version--testable-contracts.txt
-
   github-pr:
     parameters:
       working_directory:
@@ -199,37 +150,23 @@ jobs:
           keys:
             - hardhat-{{ .Environment.SOLC_VERSION }}
 
-      - version-contracts
-      - restore_cache:
-          keys:
-            - cannon-{{ .Environment.CACHE_VERSION }}-{{ checksum "/tmp/version--contracts.txt" }}
-            - cannon-{{ .Environment.CACHE_VERSION }}-
-
-      - version-testable-contracts
-      - restore_cache:
-          keys:
-            - generated-testable-{{ .Environment.CACHE_VERSION }}-{{ checksum "/tmp/version--testable-contracts.txt" }}
-
       - run:
-          name: "@synthetixio/main: generate-testable"
-          command: |-
-            if test -d "protocol/synthetix/contracts/generated/test" && [ $(ls protocol/synthetix/contracts/generated/test | wc -l) -gt 1  ]; then
-              echo "SKIP, no changes detected"
-            else
-              yarn workspace "@synthetixio/main" run generate-testable
-            fi
+          name: "Generate testable contracts sources"
+          command: yarn workspaces foreach --all --topological-dev --verbose run generate-testable
       - save_cache:
-          key: generated-testable-{{ .Environment.CACHE_VERSION }}-{{ checksum "/tmp/version--testable-contracts.txt" }}
+          key: generated-testable-{{ .Environment.CIRCLE_BUILD_NUM }}
           paths:
             - "protocol/synthetix/contracts/generated"
             # Add more folders here if we generate more
 
-      - restore_cache:
-          keys:
-            - testable-hardhat-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "/tmp/version--contracts.txt" }}
+      - run:
+          name: "Build testable contracts"
+          command: CANNON_REGISTRY_PRIORITY=local yarn workspaces foreach --all --topological-dev --verbose run build-testable
+
       - run: CANNON_REGISTRY_PRIORITY=local yarn workspaces foreach --all --topological-dev --verbose run build-testable
+
       - save_cache:
-          key: testable-hardhat-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "/tmp/version--contracts.txt" }}
+          key: testable-hardhat-cache-{{ .Environment.CIRCLE_BUILD_NUM }}
           paths:
             - "protocol/synthetix/artifacts"
             - "protocol/synthetix/cache"
@@ -247,7 +184,7 @@ jobs:
       - run: yarn workspaces foreach --all --verbose run check:storage
 
       - save_cache:
-          key: cannon-{{ .Environment.CACHE_VERSION }}-{{ checksum "/tmp/version--contracts.txt" }}
+          key: cannon-{{ .Environment.CIRCLE_BUILD_NUM }}
           paths:
             - "~/.local/share/cannon"
       - save_cache:
@@ -273,19 +210,15 @@ jobs:
           keys:
             - hardhat-{{ .Environment.SOLC_VERSION }}
 
-      - version-contracts
       - restore_cache:
           keys:
-            - cannon-{{ .Environment.CACHE_VERSION }}-{{ checksum "/tmp/version--contracts.txt" }}
-            - cannon-{{ .Environment.CACHE_VERSION }}-
+            - cannon-{{ .Environment.CIRCLE_BUILD_NUM }}
       - restore_cache:
           keys:
-            - testable-hardhat-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "/tmp/version--contracts.txt" }}
-
-      - version-testable-contracts
+            - testable-hardhat-cache-{{ .Environment.CIRCLE_BUILD_NUM }}
       - restore_cache:
           keys:
-            - generated-testable-{{ .Environment.CACHE_VERSION }}-{{ checksum "/tmp/version--testable-contracts.txt" }}
+            - generated-testable-{{ .Environment.CIRCLE_BUILD_NUM }}
 
       - run:
           name: "Compile TS"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ jobs:
           name: "Generate testable contracts sources"
           command: yarn workspaces foreach --all --topological-dev --verbose run generate-testable
       - save_cache:
-          key: generated-testable-{{ .Environment.CIRCLE_BUILD_NUM }}
+          key: generated-testable-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - "protocol/synthetix/contracts/generated"
             # Add more folders here if we generate more
@@ -166,7 +166,7 @@ jobs:
       - run: CANNON_REGISTRY_PRIORITY=local yarn workspaces foreach --all --topological-dev --verbose run build-testable
 
       - save_cache:
-          key: testable-hardhat-cache-{{ .Environment.CIRCLE_BUILD_NUM }}
+          key: testable-hardhat-cache-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - "protocol/synthetix/artifacts"
             - "protocol/synthetix/cache"
@@ -184,7 +184,7 @@ jobs:
       - run: yarn workspaces foreach --all --verbose run check:storage
 
       - save_cache:
-          key: cannon-{{ .Environment.CIRCLE_BUILD_NUM }}
+          key: cannon-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - "~/.local/share/cannon"
       - save_cache:
@@ -212,13 +212,13 @@ jobs:
 
       - restore_cache:
           keys:
-            - cannon-{{ .Environment.CIRCLE_BUILD_NUM }}
+            - cannon-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
           keys:
-            - testable-hardhat-cache-{{ .Environment.CIRCLE_BUILD_NUM }}
+            - testable-hardhat-cache-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
           keys:
-            - generated-testable-{{ .Environment.CIRCLE_BUILD_NUM }}
+            - generated-testable-{{ .Environment.CIRCLE_SHA1 }}
 
       - run:
           name: "Compile TS"


### PR DESCRIPTION
To avoid any potential cross-build caching issues related to contracts, cannon, tests, etc we are now going to cache build artifacts only for current build number. We still have benefits when running parallel test as there is no need to compile/build testable code, as we only do it once. But we will now do it for every new build, so no cross-commit cache contamination