### PR TITLE
Remove possibility of gov nft transfers

### DIFF
--- a/protocol/governance/contracts/modules/council-nft/CouncilTokenModule.sol
+++ b/protocol/governance/contracts/modules/council-nft/CouncilTokenModule.sol
@@ -11,6 +11,10 @@ import {ICouncilTokenModule} from "../../interfaces/ICouncilTokenModule.sol";
  */
 // solhint-disable-next-line no-empty-blocks
 contract CouncilTokenModule is ICouncilTokenModule, NftModule {
+    error NotImplemented();
 
+    function _transfer(address, address, uint256) internal pure override {
+        revert NotImplemented();
+    }
 }
 /* solhint-enable no-empty-blocks */

--- a/protocol/governance/test/bootstrap.ts
+++ b/protocol/governance/test/bootstrap.ts
@@ -6,6 +6,7 @@ import type { CoreProxy, CouncilToken, SnapshotRecordMock } from './generated/ty
 interface Contracts {
   CoreProxy: CoreProxy;
   CouncilToken: CouncilToken;
+  CouncilTokenRouter: CouncilToken;
   SnapshotRecordMock: SnapshotRecordMock;
 }
 
@@ -28,6 +29,7 @@ export function bootstrap() {
     Object.assign(contracts, {
       CoreProxy: getContract('CoreProxy'),
       CouncilToken: getContract('CouncilToken'),
+      CouncilTokenRouter: getContract('CouncilTokenRouter'),
       SnapshotRecordMock: getContract('SnapshotRecordMock'),
     });
   });
@@ -39,11 +41,11 @@ export function bootstrap() {
     getContract,
     snapshotCheckpoint,
 
-    async deployNewProxy() {
+    async deployNewProxy(implementation?: string) {
       const [owner] = getSigners();
       const factory = await hre.ethers.getContractFactory('Proxy', owner);
       const NewProxy = await factory.deploy(
-        await c.CoreProxy.getImplementation(),
+        implementation || (await c.CoreProxy.getImplementation()),
         await owner.getAddress()
       );
       return c.CoreProxy.attach(NewProxy.address);

--- a/protocol/governance/test/contracts/CouncilTokenModule.test.ts
+++ b/protocol/governance/test/contracts/CouncilTokenModule.test.ts
@@ -1,0 +1,44 @@
+import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
+import { ethers } from 'ethers';
+import { bootstrap } from '../bootstrap';
+import { CouncilTokenModule } from '../generated/typechain/CouncilTokenModule';
+
+describe('CouncilTokenModule', function () {
+  const { c, getSigners, deployNewProxy } = bootstrap();
+
+  let user1: ethers.Signer;
+  let user2: ethers.Signer;
+  let CouncilToken: CouncilTokenModule;
+
+  before('identify signers', async function () {
+    [, user1, user2] = getSigners();
+  });
+
+  before('deploy new council token router', async function () {
+    // create a new Proxy with our implementation of the CouncilToken so we can test it isolated
+    CouncilToken = await deployNewProxy(c.CouncilTokenRouter.address);
+  });
+
+  it('can mint council nfts', async function () {
+    await CouncilToken.mint(await user1.getAddress(), 1);
+    await CouncilToken.mint(await user2.getAddress(), 2);
+  });
+
+  it('can burn council nfts', async function () {
+    await CouncilToken.burn(1);
+    await CouncilToken.burn(2);
+  });
+
+  it('reverts when trying to transfer', async function () {
+    await CouncilToken.mint(await user1.getAddress(), 3);
+
+    await assertRevert(
+      CouncilToken.connect(user1).transferFrom(
+        await user1.getAddress(),
+        await user2.getAddress(),
+        3
+      ),
+      'NotImplemented()'
+    );
+  });
+});


### PR DESCRIPTION
Do not allow Governance NFT holders to transfer them. They should only be burned or minted by the system.