### PR TITLE
Price impact on available margin on order validation

### DIFF
--- a/markets/perps-market/contracts/storage/AsyncOrder.sol
+++ b/markets/perps-market/contracts/storage/AsyncOrder.sol
@@ -333,12 +333,18 @@ library AsyncOrder {
             KeeperCosts.load().getSettlementKeeperCosts(runtime.accountId) +
             strategy.settlementReward;
 
+        oldPosition = PerpsMarket.accountPosition(runtime.marketId, runtime.accountId);
+        runtime.newPositionSize = oldPosition.size + runtime.sizeDelta;
+
+        // only account for negative pnl
+        runtime.currentAvailableMargin += MathUtil.min(
+            calculateStartingPnl(runtime.fillPrice, orderPrice, runtime.newPositionSize),
+            0
+        );
+
         if (runtime.currentAvailableMargin < runtime.orderFees.toInt()) {
             revert InsufficientMargin(runtime.currentAvailableMargin, runtime.orderFees);
         }
-
-        oldPosition = PerpsMarket.accountPosition(runtime.marketId, runtime.accountId);
-        runtime.newPositionSize = oldPosition.size + runtime.sizeDelta;
 
         PerpsMarket.validatePositionSize(
             perpsMarketData,
@@ -515,6 +521,17 @@ library AsyncOrder {
         uint maxNumberOfWindows;
         uint numberOfWindows;
         uint256 requiredRewardMargin;
+    }
+
+    /**
+     * @notice Initial pnl of a position after it's opened due to p/d fill price delta.
+     */
+    function calculateStartingPnl(
+        uint fillPrice,
+        uint marketPrice,
+        int128 size
+    ) internal pure returns (int256) {
+        return size.mulDecimal(marketPrice.toInt() - fillPrice.toInt());
     }
 
     /**

--- a/markets/perps-market/contracts/storage/PerpsAccount.sol
+++ b/markets/perps-market/contracts/storage/PerpsAccount.sol
@@ -60,7 +60,7 @@ library PerpsAccount {
         uint withdrawAmount
     );
 
-    error InsufficientMarginError(uint leftover);
+    error InsufficientAccountMargin(uint leftover);
 
     error AccountLiquidatable(uint128 accountId);
 
@@ -502,7 +502,7 @@ library PerpsAccount {
         }
 
         if (leftoverAmount > 0) {
-            revert InsufficientMarginError(leftoverAmount);
+            revert InsufficientAccountMargin(leftoverAmount);
         }
     }
 

--- a/markets/perps-market/test/integration/Liquidation/Liquidation.maxLiquidationAmount.macro.test.ts
+++ b/markets/perps-market/test/integration/Liquidation/Liquidation.maxLiquidationAmount.macro.test.ts
@@ -17,9 +17,9 @@ describe('Liquidation - max liquidatable amount with multiple continuing liquida
           makerFee: bn(0.007),
           takerFee: bn(0.003),
         },
-        fundingParams: { skewScale: bn(10000), maxFundingVelocity: bn(0) },
+        fundingParams: { skewScale: bn(1000), maxFundingVelocity: bn(0) },
         liquidationParams: {
-          initialMarginFraction: bn(3),
+          initialMarginFraction: bn(1),
           minimumInitialMarginRatio: bn(0),
           maintenanceMarginScalar: bn(0.66),
           maxLiquidationLimitAccumulationMultiplier: bn(1),
@@ -192,7 +192,7 @@ describe('Liquidation - max liquidatable amount with multiple continuing liquida
         settlementStrategyId: perpsMarket.strategyId(),
         price: bn(10),
       });
-      const tx = await perpsMarket.aggregator().mockSetCurrentPrice(bn(0.05));
+      const tx = await perpsMarket.aggregator().mockSetCurrentPrice(bn(1));
       timeSetupCompletes = await getTxTime(provider(), tx);
     });
 
@@ -216,8 +216,6 @@ describe('Liquidation - max liquidatable amount with multiple continuing liquida
 
   describe('liquidate second trader', () => {
     before('call liquidate', async () => {
-      console.log(await systems().PerpsMarket.getRequiredMargins(3));
-      console.log(await systems().PerpsMarket.getAvailableMargin(3));
       await systems().PerpsMarket.connect(keeper()).liquidate(3);
     });
 

--- a/markets/perps-market/test/integration/Liquidation/Liquidation.maxLiquidationAmount.macro.test.ts
+++ b/markets/perps-market/test/integration/Liquidation/Liquidation.maxLiquidationAmount.macro.test.ts
@@ -17,7 +17,7 @@ describe('Liquidation - max liquidatable amount with multiple continuing liquida
           makerFee: bn(0.007),
           takerFee: bn(0.003),
         },
-        fundingParams: { skewScale: bn(1000), maxFundingVelocity: bn(0) },
+        fundingParams: { skewScale: bn(10000), maxFundingVelocity: bn(0) },
         liquidationParams: {
           initialMarginFraction: bn(3),
           minimumInitialMarginRatio: bn(0),
@@ -192,7 +192,7 @@ describe('Liquidation - max liquidatable amount with multiple continuing liquida
         settlementStrategyId: perpsMarket.strategyId(),
         price: bn(10),
       });
-      const tx = await perpsMarket.aggregator().mockSetCurrentPrice(bn(1));
+      const tx = await perpsMarket.aggregator().mockSetCurrentPrice(bn(0.05));
       timeSetupCompletes = await getTxTime(provider(), tx);
     });
 
@@ -216,6 +216,8 @@ describe('Liquidation - max liquidatable amount with multiple continuing liquida
 
   describe('liquidate second trader', () => {
     before('call liquidate', async () => {
+      console.log(await systems().PerpsMarket.getRequiredMargins(3));
+      console.log(await systems().PerpsMarket.getAvailableMargin(3));
       await systems().PerpsMarket.connect(keeper()).liquidate(3);
     });
 

--- a/markets/perps-market/test/integration/Market/MarketDebt.withFunding.test.ts
+++ b/markets/perps-market/test/integration/Market/MarketDebt.withFunding.test.ts
@@ -61,15 +61,15 @@ describe('Market Debt - with funding', () => {
   });
 
   before('add collateral to margin', async () => {
-    await systems().PerpsMarket.connect(trader1()).modifyCollateral(2, 0, bn(12_000));
-    await systems().PerpsMarket.connect(trader2()).modifyCollateral(3, 0, bn(12_000));
+    await systems().PerpsMarket.connect(trader1()).modifyCollateral(2, 0, bn(12_500));
+    await systems().PerpsMarket.connect(trader2()).modifyCollateral(3, 0, bn(12_500));
     await systems().PerpsMarket.connect(trader3()).modifyCollateral(4, 0, bn(100_000));
   });
 
   describe('with no positions', () => {
     it('should report total collateral value as debt', async () => {
       const debt = await systems().PerpsMarket.reportedDebt(superMarketId());
-      assertBn.equal(debt, bn(124_000));
+      assertBn.equal(debt, bn(125_000));
     });
   });
 

--- a/markets/perps-market/test/integration/Orders/OffchainAsyncOrder.settle.test.ts
+++ b/markets/perps-market/test/integration/Orders/OffchainAsyncOrder.settle.test.ts
@@ -8,7 +8,7 @@ import assertBn from '@synthetixio/core-utils/utils/assertions/assert-bignumber'
 import assertEvent from '@synthetixio/core-utils/utils/assertions/assert-event';
 import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
 import { getTxTime } from '@synthetixio/core-utils/src/utils/hardhat/rpc';
-import { calculateFillPrice } from '../helpers/fillPrice';
+import { calculateFillPrice, calculatePricePnl } from '../helpers/fillPrice';
 import { wei } from '@synthetixio/wei';
 import { calcCurrentFundingVelocity } from '../helpers/funding-calcs';
 
@@ -333,7 +333,11 @@ describe('Settle Offchain Async Order test', () => {
             return;
           }
 
-          const availableCollateral = testCase.name === 'only snxBTC' ? bn(0.1) : bn(2.1);
+          const currentSkew = await systems().PerpsMarket.skew(ethMarketId);
+          const startingPnl = calculatePricePnl(wei(currentSkew), wei(100_000), wei(1), wei(1000));
+          const availableCollateral = (testCase.name === 'only snxBTC' ? wei(0.1) : wei(2.1)).add(
+            startingPnl
+          );
 
           const validPythPriceData = await systems().MockPyth.createPriceFeedUpdateData(
             DEFAULT_SETTLEMENT_STRATEGY.feedId,
@@ -349,7 +353,7 @@ describe('Settle Offchain Async Order test', () => {
             systems()
               .PerpsMarket.connect(keeper())
               .settlePythOrder(validPythPriceData, extraData, { value: updateFee }),
-            `InsufficientMargin("${availableCollateral.toString()}", "${bn(5).toString()}")`
+            `InsufficientMargin("${availableCollateral.bn}", "${bn(5).toString()}")`
           );
         });
       });

--- a/markets/perps-market/test/integration/Orders/Order.marginValidation.capped.test.ts
+++ b/markets/perps-market/test/integration/Orders/Order.marginValidation.capped.test.ts
@@ -6,9 +6,13 @@ import {
   openPosition,
   requiredMargins,
   getRequiredLiquidationRewardMargin,
+  expectedStartingPnl,
 } from '../helpers';
 import { wei } from '@synthetixio/wei';
 import { ethers } from 'ethers';
+
+const BTC_MARKET_PRICE = wei(10_000);
+const ETH_MARKET_PRICE = wei(2000);
 
 describe('Orders - capped margin validation', () => {
   const liqParams = {
@@ -45,7 +49,7 @@ describe('Orders - capped margin validation', () => {
         requestedMarketId: 50,
         name: 'Bitcoin',
         token: 'BTC',
-        price: bn(10_000),
+        price: BTC_MARKET_PRICE.toBN(),
         fundingParams: { skewScale: bn(1000), maxFundingVelocity: bn(0) },
         liquidationParams: {
           initialMarginFraction: liqParams.btc.imRatio.toBN(),
@@ -64,7 +68,7 @@ describe('Orders - capped margin validation', () => {
         requestedMarketId: 51,
         name: 'Ether',
         token: 'ETH',
-        price: bn(2000),
+        price: ETH_MARKET_PRICE.toBN(),
         fundingParams: { skewScale: bn(10_000), maxFundingVelocity: bn(0) },
         liquidationParams: {
           initialMarginFraction: liqParams.eth.imRatio.toBN(),
@@ -94,6 +98,7 @@ describe('Orders - capped margin validation', () => {
     });
 
     it('reverts if not enough margin', async () => {
+      const fillPrice = calculateFillPrice(wei(0), wei(10_000), wei(3), ETH_MARKET_PRICE);
       const { initialMargin, liquidationMargin } = requiredMargins(
         {
           initialMarginRatio: liqParams.eth.imRatio,
@@ -102,7 +107,7 @@ describe('Orders - capped margin validation', () => {
           liquidationRewardRatio: liqParams.eth.liqRatio,
         },
         wei(3),
-        calculateFillPrice(wei(0), wei(10_000), wei(3), wei(2000)),
+        fillPrice,
         wei(10_000)
       );
 
@@ -120,6 +125,10 @@ describe('Orders - capped margin validation', () => {
         totalRequiredMargin.toBN()
       );
 
+      const availableMargin = wei(100).add(
+        expectedStartingPnl(ETH_MARKET_PRICE, fillPrice, wei(3))
+      );
+
       await assertRevert(
         systems()
           .PerpsMarket.connect(trader1())
@@ -132,7 +141,10 @@ describe('Orders - capped margin validation', () => {
             referrer: ethers.constants.AddressZero,
             trackingCode: ethers.constants.HashZero,
           }),
-        `InsufficientMargin("${bn(100)}", "${totalRequiredMargin.toString(18, true)}")`
+        `InsufficientMargin("${availableMargin.toBN()}", "${totalRequiredMargin.toString(
+          18,
+          true
+        )}")`
       );
     });
   });
@@ -185,6 +197,7 @@ describe('Orders - capped margin validation', () => {
         wei(10_000)
       );
 
+      const fillPrice = calculateFillPrice(wei(0), wei(1000), wei(5), BTC_MARKET_PRICE);
       const { initialMargin: btcInitialMargin, liquidationMargin: btcLiqMargin } = requiredMargins(
         {
           initialMarginRatio: liqParams.btc.imRatio,
@@ -193,7 +206,7 @@ describe('Orders - capped margin validation', () => {
           liquidationRewardRatio: liqParams.btc.liqRatio,
         },
         wei(5),
-        calculateFillPrice(wei(0), wei(1000), wei(5), wei(10_000)),
+        fillPrice,
         wei(1000)
       );
 
@@ -216,6 +229,11 @@ describe('Orders - capped margin validation', () => {
         totalRequiredMargin.toBN()
       );
 
+      const currentAvailableMargin = await systems().PerpsMarket.getAvailableMargin(2);
+      const availableMargin = wei(currentAvailableMargin).add(
+        expectedStartingPnl(BTC_MARKET_PRICE, fillPrice, wei(5))
+      );
+
       await assertRevert(
         systems()
           .PerpsMarket.connect(trader1())
@@ -228,9 +246,10 @@ describe('Orders - capped margin validation', () => {
             referrer: ethers.constants.AddressZero,
             trackingCode: ethers.constants.HashZero,
           }),
-        `InsufficientMargin("${await systems().PerpsMarket.getAvailableMargin(
-          2
-        )}", "${totalRequiredMargin.toString(18, true)}")`
+        `InsufficientMargin("${availableMargin.toBN()}", "${totalRequiredMargin.toString(
+          18,
+          true
+        )}")`
       );
     });
   });
@@ -280,6 +299,7 @@ describe('Orders - capped margin validation', () => {
         wei(10_000)
       );
 
+      const fillPrice = calculateFillPrice(wei(5), wei(1000), wei(5), BTC_MARKET_PRICE);
       const { initialMargin: btcInitialMargin, liquidationMargin: btcLiqMargin } = requiredMargins(
         {
           initialMarginRatio: liqParams.btc.imRatio,
@@ -288,7 +308,7 @@ describe('Orders - capped margin validation', () => {
           liquidationRewardRatio: liqParams.btc.liqRatio,
         },
         wei(10),
-        calculateFillPrice(wei(5), wei(1000), wei(5), wei(10_000)),
+        fillPrice,
         wei(1000)
       );
 
@@ -311,6 +331,11 @@ describe('Orders - capped margin validation', () => {
         totalRequiredMargin.toBN()
       );
 
+      const currentAvailableMargin = await systems().PerpsMarket.getAvailableMargin(2);
+      const availableMargin = wei(currentAvailableMargin).add(
+        expectedStartingPnl(BTC_MARKET_PRICE, fillPrice, wei(10))
+      );
+
       await assertRevert(
         systems()
           .PerpsMarket.connect(trader1())
@@ -323,9 +348,10 @@ describe('Orders - capped margin validation', () => {
             referrer: ethers.constants.AddressZero,
             trackingCode: ethers.constants.HashZero,
           }),
-        `InsufficientMargin("${await systems().PerpsMarket.getAvailableMargin(
-          2
-        )}", "${totalRequiredMargin.toString(18, true)}")`
+        `InsufficientMargin("${availableMargin.toBN()}", "${totalRequiredMargin.toString(
+          18,
+          true
+        )}")`
       );
     });
   });

--- a/markets/perps-market/test/integration/Orders/Order.marginValidation.test.ts
+++ b/markets/perps-market/test/integration/Orders/Order.marginValidation.test.ts
@@ -6,11 +6,15 @@ import {
   openPosition,
   requiredMargins,
   getRequiredLiquidationRewardMargin,
+  expectedStartingPnl,
 } from '../helpers';
 import { wei } from '@synthetixio/wei';
 import { ethers } from 'ethers';
 
 const MIN_LIQUIDATION_REWARD = wei(100);
+const BTC_MARKET_PRICE = wei(10_000);
+const ETH_MARKET_PRICE = wei(2000);
+
 describe('Orders - margin validation', () => {
   const liqParams = {
     btc: {
@@ -46,7 +50,7 @@ describe('Orders - margin validation', () => {
         requestedMarketId: 50,
         name: 'Bitcoin',
         token: 'BTC',
-        price: bn(10_000),
+        price: BTC_MARKET_PRICE.toBN(),
         fundingParams: { skewScale: bn(1000), maxFundingVelocity: bn(0) },
         liquidationParams: {
           initialMarginFraction: liqParams.btc.imRatio.toBN(),
@@ -65,7 +69,7 @@ describe('Orders - margin validation', () => {
         requestedMarketId: 51,
         name: 'Ether',
         token: 'ETH',
-        price: bn(2000),
+        price: ETH_MARKET_PRICE.toBN(),
         fundingParams: { skewScale: bn(10_000), maxFundingVelocity: bn(0) },
         liquidationParams: {
           initialMarginFraction: liqParams.eth.imRatio.toBN(),
@@ -95,6 +99,7 @@ describe('Orders - margin validation', () => {
     });
 
     it('reverts if not enough margin', async () => {
+      const fillPrice = calculateFillPrice(wei(0), wei(10_000), wei(3), wei(2000));
       const { initialMargin, liquidationMargin } = requiredMargins(
         {
           initialMarginRatio: liqParams.eth.imRatio,
@@ -103,7 +108,7 @@ describe('Orders - margin validation', () => {
           liquidationRewardRatio: liqParams.eth.liqRatio,
         },
         wei(3),
-        calculateFillPrice(wei(0), wei(10_000), wei(3), wei(2000)),
+        fillPrice,
         wei(10_000)
       );
 
@@ -121,6 +126,10 @@ describe('Orders - margin validation', () => {
         totalRequiredMargin.toBN()
       );
 
+      const availableMargin = wei(100).add(
+        expectedStartingPnl(ETH_MARKET_PRICE, fillPrice, wei(3))
+      );
+
       await assertRevert(
         systems()
           .PerpsMarket.connect(trader1())
@@ -133,7 +142,10 @@ describe('Orders - margin validation', () => {
             referrer: ethers.constants.AddressZero,
             trackingCode: ethers.constants.HashZero,
           }),
-        `InsufficientMargin("${bn(100)}", "${totalRequiredMargin.toString(18, true)}")`
+        `InsufficientMargin("${availableMargin.toBN()}", "${totalRequiredMargin.toString(
+          18,
+          true
+        )}")`
       );
     });
   });
@@ -186,6 +198,7 @@ describe('Orders - margin validation', () => {
         wei(10_000)
       );
 
+      const fillPrice = calculateFillPrice(wei(0), wei(1000), wei(5), BTC_MARKET_PRICE);
       const { initialMargin: btcInitialMargin, liquidationMargin: btcLiqMargin } = requiredMargins(
         {
           initialMarginRatio: liqParams.btc.imRatio,
@@ -194,7 +207,7 @@ describe('Orders - margin validation', () => {
           liquidationRewardRatio: liqParams.btc.liqRatio,
         },
         wei(5),
-        calculateFillPrice(wei(0), wei(1000), wei(5), wei(10_000)),
+        fillPrice,
         wei(1000)
       );
 
@@ -217,6 +230,11 @@ describe('Orders - margin validation', () => {
         totalRequiredMargin.toBN()
       );
 
+      const currentAvailableMargin = await systems().PerpsMarket.getAvailableMargin(2);
+      const availableMargin = wei(currentAvailableMargin).add(
+        expectedStartingPnl(BTC_MARKET_PRICE, fillPrice, wei(5))
+      );
+
       await assertRevert(
         systems()
           .PerpsMarket.connect(trader1())
@@ -229,9 +247,10 @@ describe('Orders - margin validation', () => {
             referrer: ethers.constants.AddressZero,
             trackingCode: ethers.constants.HashZero,
           }),
-        `InsufficientMargin("${await systems().PerpsMarket.getAvailableMargin(
-          2
-        )}", "${totalRequiredMargin.toString(18, true)}")`
+        `InsufficientMargin("${availableMargin.toBN()}", "${totalRequiredMargin.toString(
+          18,
+          true
+        )}")`
       );
     });
   });
@@ -281,6 +300,8 @@ describe('Orders - margin validation', () => {
         wei(10_000)
       );
 
+      const newBtcSize = wei(10);
+      const fillPrice = calculateFillPrice(wei(5), wei(1000), wei(5), wei(10_000));
       const { initialMargin: btcInitialMargin, liquidationMargin: btcLiqMargin } = requiredMargins(
         {
           initialMarginRatio: liqParams.btc.imRatio,
@@ -288,8 +309,8 @@ describe('Orders - margin validation', () => {
           maintenanceMarginScalar: liqParams.btc.mmScalar,
           liquidationRewardRatio: liqParams.btc.liqRatio,
         },
-        wei(10),
-        calculateFillPrice(wei(5), wei(1000), wei(5), wei(10_000)),
+        newBtcSize,
+        fillPrice,
         wei(1000)
       );
 
@@ -312,6 +333,11 @@ describe('Orders - margin validation', () => {
         totalRequiredMargin.toBN()
       );
 
+      const currentAvailableMargin = await systems().PerpsMarket.getAvailableMargin(2);
+      const availableMargin = wei(currentAvailableMargin).add(
+        expectedStartingPnl(BTC_MARKET_PRICE, fillPrice, wei(10))
+      );
+
       await assertRevert(
         systems()
           .PerpsMarket.connect(trader1())
@@ -324,9 +350,10 @@ describe('Orders - margin validation', () => {
             referrer: ethers.constants.AddressZero,
             trackingCode: ethers.constants.HashZero,
           }),
-        `InsufficientMargin("${await systems().PerpsMarket.getAvailableMargin(
-          2
-        )}", "${totalRequiredMargin.toString(18, true)}")`
+        `InsufficientMargin("${availableMargin.toBN()}", "${totalRequiredMargin.toString(
+          18,
+          true
+        )}")`
       );
     });
   });

--- a/markets/perps-market/test/integration/Orders/Order.marginWithPd.test.ts
+++ b/markets/perps-market/test/integration/Orders/Order.marginWithPd.test.ts
@@ -1,0 +1,138 @@
+import assertBn from '@synthetixio/core-utils/utils/assertions/assert-bignumber';
+import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
+import { bn, bootstrapMarkets } from '../bootstrap';
+import {
+  calculateFillPrice,
+  openPosition,
+  requiredMargins,
+  getRequiredLiquidationRewardMargin,
+  expectedStartingPnl,
+} from '../helpers';
+import { wei } from '@synthetixio/wei';
+import { ethers } from 'ethers';
+
+const RNDR_PRICE = wei(2.85);
+const RNDR_SKEW_SCALE = wei(7_500_000);
+
+describe('Orders - margin validation with p/d', () => {
+  const liqParams = {
+    imRatio: wei(0.01),
+    minIm: wei(0.03),
+    mmScalar: wei(0.5),
+    liqRatio: wei(0.01),
+  };
+  const liqGuards = {
+    minLiquidationReward: wei(1),
+    minKeeperProfitRatioD18: wei(0.01),
+    maxLiquidationReward: wei(110),
+    maxKeeperScalingRatioD18: wei(10),
+  };
+
+  const { systems, provider, trader1, trader2, perpsMarkets, keeper } = bootstrapMarkets({
+    liquidationGuards: {
+      minLiquidationReward: liqGuards.minLiquidationReward.bn,
+      minKeeperProfitRatioD18: liqGuards.minKeeperProfitRatioD18.bn,
+      maxLiquidationReward: liqGuards.maxLiquidationReward.bn,
+      maxKeeperScalingRatioD18: liqGuards.maxKeeperScalingRatioD18.bn,
+    },
+    synthMarkets: [],
+    perpsMarkets: [
+      {
+        requestedMarketId: 50,
+        name: 'rndr',
+        token: 'RNDR',
+        price: RNDR_PRICE.toBN(),
+        fundingParams: { skewScale: RNDR_SKEW_SCALE.toBN(), maxFundingVelocity: bn(0) },
+        liquidationParams: {
+          initialMarginFraction: liqParams.imRatio.toBN(),
+          minimumInitialMarginRatio: liqParams.minIm.toBN(),
+          maintenanceMarginScalar: liqParams.mmScalar.toBN(),
+          maxLiquidationLimitAccumulationMultiplier: bn(1),
+          liquidationRewardRatio: liqParams.liqRatio.toBN(),
+          maxSecondsInLiquidationWindow: ethers.BigNumber.from(10),
+          minimumPositionMargin: bn(0),
+        },
+        settlementStrategy: {
+          settlementReward: bn(0),
+        },
+      },
+    ],
+    traderAccountIds: [2, 3],
+  });
+
+  const startingMargin = wei(49_250);
+  before('add margin to account', async () => {
+    await systems().PerpsMarket.connect(trader1()).modifyCollateral(2, 0, bn(500_000));
+    await systems().PerpsMarket.connect(trader2()).modifyCollateral(3, 0, startingMargin.bn);
+  });
+
+  before('trader1 opens position', async () => {
+    await openPosition({
+      systems,
+      provider,
+      trader: trader1(),
+      accountId: 2,
+      keeper: keeper(),
+      marketId: perpsMarkets()[0].marketId(),
+      sizeDelta: bn(250_000),
+      settlementStrategyId: perpsMarkets()[0].strategyId(),
+      price: bn(2.85),
+    });
+  });
+
+  describe('trader 2 attempts to open position', () => {
+    let orderFees: ethers.BigNumber;
+    const newSize = wei(240_000);
+    before('get order fees', async () => {
+      [orderFees] = await systems().PerpsMarket.computeOrderFees(50, newSize.bn);
+    });
+
+    it('reverts if not enough margin', async () => {
+      const fillPrice = calculateFillPrice(wei(250_000), RNDR_SKEW_SCALE, newSize, wei(2.85));
+      const { initialMargin, liquidationMargin } = requiredMargins(
+        {
+          initialMarginRatio: liqParams.imRatio,
+          minimumInitialMarginRatio: liqParams.minIm,
+          maintenanceMarginScalar: liqParams.mmScalar,
+          liquidationRewardRatio: liqParams.liqRatio,
+        },
+        newSize,
+        fillPrice,
+        RNDR_SKEW_SCALE
+      );
+
+      const totalRequiredMargin = initialMargin
+        .add(
+          getRequiredLiquidationRewardMargin(liquidationMargin, liqGuards, {
+            costOfTx: wei(0),
+            margin: startingMargin,
+          })
+        )
+        .add(orderFees);
+
+      assertBn.equal(
+        await systems().PerpsMarket.requiredMarginForOrder(3, 50, newSize.bn),
+        totalRequiredMargin.toBN()
+      );
+
+      const availableMargin = startingMargin.add(
+        expectedStartingPnl(RNDR_PRICE, fillPrice, newSize)
+      );
+
+      await assertRevert(
+        systems()
+          .PerpsMarket.connect(trader2())
+          .commitOrder({
+            marketId: 50,
+            accountId: 3,
+            sizeDelta: bn(240_000),
+            settlementStrategyId: perpsMarkets()[0].strategyId(),
+            acceptablePrice: bn(4),
+            referrer: ethers.constants.AddressZero,
+            trackingCode: ethers.constants.HashZero,
+          }),
+        `InsufficientMargin("${availableMargin.toBN()}", "${totalRequiredMargin.bn}")`
+      );
+    });
+  });
+});

--- a/markets/perps-market/test/integration/Suspend.test.ts
+++ b/markets/perps-market/test/integration/Suspend.test.ts
@@ -81,7 +81,7 @@ describe('System suspend', async () => {
 
       it('created order', async () => {
         // add collateral
-        await systems().PerpsMarket.connect(trader1()).modifyCollateral(2, 0, bn(1000));
+        await systems().PerpsMarket.connect(trader1()).modifyCollateral(2, 0, bn(1200));
         const commitTxn = await systems()
           .PerpsMarket.connect(trader1())
           .commitOrder({

--- a/markets/perps-market/test/integration/helpers/requiredMargins.ts
+++ b/markets/perps-market/test/integration/helpers/requiredMargins.ts
@@ -1,4 +1,4 @@
-import { Wei } from '@synthetixio/wei';
+import { wei, Wei } from '@synthetixio/wei';
 
 type Config = {
   initialMarginRatio: Wei;
@@ -45,4 +45,8 @@ export const getRequiredLiquidationRewardMargin = (
     liqParams.margin.mul(liqGuards.maxKeeperScalingRatioD18)
   );
   return Wei.min(Wei.max(reward, minCap), maxCap);
+};
+
+export const expectedStartingPnl = (marketPrice: Wei, fillPrice: Wei, positionSize: Wei) => {
+  return Wei.min(positionSize.mul(marketPrice.sub(fillPrice)), wei(0));
 };


### PR DESCRIPTION
When validating an order, the current logic is:
```
currentAvailableMargin > requiredMargin
```

but the new logic will reduce `currentAvailableMargin` by the immediate pnl that the fill price would create due to skew:
```
currentAvailableMargin += immediatePnlFromOrder
currentAvailableMargin > requiredMargin
```

Note: the pnl is only applied if it's negative, when it's positive, it's ignored and does not _add_ to your currentAvailableMargin