### PR TITLE
fix spelling error

### DIFF
--- a/protocol/synthetix/contracts/storage/Collateral.sol
+++ b/protocol/synthetix/contracts/storage/Collateral.sol
@@ -17,7 +17,7 @@ library Collateral {
     /**
      * @dev Thrown when a specified market is not found.
      */
-    error InsufficentAvailableCollateral(
+    error InsufficientAvailableCollateral(
         uint256 amountAvailableForDelegationD18,
         uint256 amountD18
     );
@@ -53,7 +53,7 @@ library Collateral {
      */
     function decreaseAvailableCollateral(Data storage self, uint256 amountD18) internal {
         if (self.amountAvailableForDelegationD18 < amountD18) {
-            revert InsufficentAvailableCollateral(self.amountAvailableForDelegationD18, amountD18);
+            revert InsufficientAvailableCollateral(self.amountAvailableForDelegationD18, amountD18);
         }
         self.amountAvailableForDelegationD18 -= amountD18;
     }


### PR DESCRIPTION
while debugging an error on burnusd with nikita today we observed a peculiar error:

```
InsufficentAccountCollateral()
```

the error itself, once identified, was actually not too much of a crisis to resolve.

but if you look closely, insufficient was misspelled.

we can just go ahead and rename this and ship it in the next release?