### PR TITLE
Fix getRequiredAccountMargins

### DIFF
--- a/markets/perps-market/contracts/storage/PerpsAccount.sol
+++ b/markets/perps-market/contracts/storage/PerpsAccount.sol
@@ -127,9 +127,7 @@ library PerpsAccount {
         )
     {
         availableMargin = getAvailableMargin(self, stalenessTolerance);
-        if (self.openPositionMarketIds.length() == 0) {
-            return (false, availableMargin, 0, 0, 0);
-        }
+
         (
             requiredInitialMargin,
             requiredMaintenanceMargin,
@@ -308,8 +306,13 @@ library PerpsAccount {
         view
         returns (uint initialMargin, uint maintenanceMargin, uint possibleLiquidationReward)
     {
+        uint256 openPositionMarketIdsLength = self.openPositionMarketIds.length();
+        if (openPositionMarketIdsLength == 0) {
+            return (0, 0, 0);
+        }
+
         // use separate accounting for liquidation rewards so we can compare against global min/max liquidation reward values
-        for (uint i = 1; i <= self.openPositionMarketIds.length(); i++) {
+        for (uint i = 1; i <= openPositionMarketIdsLength; i++) {
             uint128 marketId = self.openPositionMarketIds.valueAt(i).to128();
             Position.Data storage position = PerpsMarket.load(marketId).positions[self.id];
             PerpsMarketConfiguration.Data storage marketConfig = PerpsMarketConfiguration.load(

--- a/markets/perps-market/test/integration/Account/ModifyCollateral.withdrawFull.test.ts
+++ b/markets/perps-market/test/integration/Account/ModifyCollateral.withdrawFull.test.ts
@@ -1,0 +1,38 @@
+import { bn, bootstrapMarkets } from '../bootstrap';
+import assertBn from '@synthetixio/core-utils/src/utils/assertions/assert-bignumber';
+
+describe('ModifyCollateral Withdraw Deposit/Withdraw', () => {
+  const accountIds = [10];
+
+  const { systems, trader1 } = bootstrapMarkets({
+    liquidationGuards: {
+      minLiquidationReward: bn(1),
+      minKeeperProfitRatioD18: bn(1),
+      maxLiquidationReward: bn(1),
+      maxKeeperScalingRatioD18: bn(1),
+    },
+    synthMarkets: [],
+    perpsMarkets: [],
+    traderAccountIds: accountIds,
+  });
+
+  describe('deposit and withdraw fully', () => {
+    before('deposit collateral', async () => {
+      await systems().PerpsMarket.connect(trader1()).modifyCollateral(10, 0, bn(1500));
+    });
+
+    it('should show full withdrawable margin', async () => {
+      assertBn.equal(await systems().PerpsMarket.getWithdrawableMargin(10), bn(1500));
+    });
+
+    it('should withdraw fully', async () => {
+      const traderAmountBefore = await systems().USD.balanceOf(await trader1().getAddress());
+      await systems().PerpsMarket.connect(trader1()).modifyCollateral(10, 0, bn(-1500));
+
+      assertBn.equal(
+        await systems().USD.balanceOf(await trader1().getAddress()),
+        traderAmountBefore.add(bn(1500))
+      );
+    });
+  });
+});


### PR DESCRIPTION
- `getRequiredAccountMargins` was using min liquidation reward even with no open positions.  This PR fixes this and adds a test