### PR TITLE
remove name from initialize

### DIFF
--- a/markets/perps-market/contracts/interfaces/IPerpsMarketFactoryModule.sol
+++ b/markets/perps-market/contracts/interfaces/IPerpsMarketFactoryModule.sol
@@ -30,8 +30,7 @@ interface IPerpsMarketFactoryModule is IMarket {
      */
     function initializeFactory(
         ISynthetixSystem synthetix,
-        ISpotMarketSystem spotMarket,
-        string memory marketName
+        ISpotMarketSystem spotMarket
     ) external returns (uint128);
 
     /**

--- a/markets/perps-market/contracts/modules/PerpsMarketFactoryModule.sol
+++ b/markets/perps-market/contracts/modules/PerpsMarketFactoryModule.sol
@@ -41,8 +41,7 @@ contract PerpsMarketFactoryModule is IPerpsMarketFactoryModule {
      */
     function initializeFactory(
         ISynthetixSystem synthetix,
-        ISpotMarketSystem spotMarket,
-        string memory marketName
+        ISpotMarketSystem spotMarket
     ) external override returns (uint128) {
         OwnableStorage.onlyOwner();
 
@@ -50,7 +49,7 @@ contract PerpsMarketFactoryModule is IPerpsMarketFactoryModule {
 
         uint128 perpsMarketId;
         if (factory.perpsMarketId == 0) {
-            perpsMarketId = factory.initialize(synthetix, spotMarket, marketName);
+            perpsMarketId = factory.initialize(synthetix, spotMarket);
         } else {
             perpsMarketId = factory.perpsMarketId;
         }

--- a/markets/perps-market/contracts/storage/PerpsMarketFactory.sol
+++ b/markets/perps-market/contracts/storage/PerpsMarketFactory.sol
@@ -65,8 +65,7 @@ library PerpsMarketFactory {
     function initialize(
         Data storage self,
         ISynthetixSystem synthetix,
-        ISpotMarketSystem spotMarket,
-        string memory name
+        ISpotMarketSystem spotMarket
     ) internal returns (uint128 perpsMarketId) {
         onlyIfNotInitialized(self); // redundant check, but kept here in case this internal is called somewhere else
 
@@ -75,7 +74,6 @@ library PerpsMarketFactory {
 
         self.spotMarket = spotMarket;
         self.synthetix = synthetix;
-        self.name = name;
         self.usdToken = ITokenModule(usdTokenAddress);
         self.oracle = synthetix.getOracleManager();
         self.perpsMarketId = perpsMarketId;

--- a/markets/perps-market/storage.dump.sol
+++ b/markets/perps-market/storage.dump.sol
@@ -50,11 +50,11 @@ library ERC2771Context {
 
 // @custom:artifact @synthetixio/core-contracts/contracts/utils/HeapUtil.sol:HeapUtil
 library HeapUtil {
-    uint private constant _ROOT_INDEX = 1;
+    uint256 private constant _ROOT_INDEX = 1;
     struct Data {
         uint128 idCount;
         Node[] nodes;
-        mapping(uint128 => uint) indices;
+        mapping(uint128 => uint256) indices;
     }
     struct Node {
         uint128 id;
@@ -72,7 +72,7 @@ library SetUtil {
     }
     struct Bytes32Set {
         bytes32[] _values;
-        mapping(bytes32 => uint) _positions;
+        mapping(bytes32 => uint256) _positions;
     }
 }
 
@@ -372,6 +372,11 @@ library Vault {
         mapping(bytes32 => RewardDistribution.Data) rewards;
         SetUtil.Bytes32Set rewardIds;
     }
+    struct PositionSelector {
+        uint128 accountId;
+        uint128 poolId;
+        address collateralType;
+    }
 }
 
 // @custom:artifact @synthetixio/main/contracts/storage/VaultEpoch.sol:VaultEpoch
@@ -392,7 +397,7 @@ contract PythStructs {
         int64 price;
         uint64 conf;
         int32 expo;
-        uint publishTime;
+        uint256 publishTime;
     }
     struct PriceFeed {
         bytes32 id;
@@ -559,9 +564,9 @@ interface IAsyncOrderSettlementPythModule {
     struct SettleOrderRuntime {
         uint128 marketId;
         uint128 accountId;
-        int128 newPositionSize;
         int128 sizeDelta;
         int256 pnl;
+        uint256 chargedInterest;
         int256 accruedFunding;
         uint256 pnlUint;
         uint256 amountToDeduct;
@@ -572,6 +577,9 @@ interface IAsyncOrderSettlementPythModule {
         uint256 feeCollectorFees;
         Position.Data newPosition;
         MarketUpdate.Data updateData;
+        uint256 synthDeductionIterator;
+        uint128[] deductedSynthIds;
+        uint256[] deductedAmount;
     }
 }
 
@@ -581,9 +589,9 @@ interface IPerpsMarketModule {
         int256 skew;
         uint256 size;
         uint256 maxOpenInterest;
-        int currentFundingRate;
-        int currentFundingVelocity;
-        uint indexPrice;
+        int256 currentFundingRate;
+        int256 currentFundingVelocity;
+        uint256 indexPrice;
     }
 }
 
@@ -622,6 +630,7 @@ library AsyncOrder {
         address referrer;
     }
     struct SimulateDataRuntime {
+        bool isEligible;
         int128 sizeDelta;
         uint128 accountId;
         uint128 marketId;
@@ -633,7 +642,7 @@ library AsyncOrder {
         uint256 currentLiquidationReward;
         int128 newPositionSize;
         uint256 newNotionalValue;
-        int currentAvailableMargin;
+        int256 currentAvailableMargin;
         uint256 requiredInitialMargin;
         uint256 initialRequiredMargin;
         uint256 totalRequiredMargin;
@@ -644,9 +653,9 @@ library AsyncOrder {
         uint256 newRequiredMargin;
         uint256 oldRequiredMargin;
         uint256 requiredMarginForNewPosition;
-        uint accumulatedLiquidationRewards;
-        uint maxNumberOfWindows;
-        uint numberOfWindows;
+        uint256 accumulatedLiquidationRewards;
+        uint256 maxNumberOfWindows;
+        uint256 numberOfWindows;
         uint256 requiredRewardMargin;
     }
     function load(uint128 accountId) internal pure returns (Data storage order) {
@@ -662,7 +671,7 @@ library GlobalPerpsMarket {
     bytes32 private constant _SLOT_GLOBAL_PERPS_MARKET = keccak256(abi.encode("io.synthetix.perps-market.GlobalPerpsMarket"));
     struct Data {
         SetUtil.UintSet liquidatableAccounts;
-        mapping(uint128 => uint) collateralAmounts;
+        mapping(uint128 => uint256) collateralAmounts;
         SetUtil.UintSet activeCollateralTypes;
         SetUtil.UintSet activeMarkets;
     }
@@ -680,20 +689,40 @@ library GlobalPerpsMarketConfiguration {
     struct Data {
         address feeCollector;
         mapping(address => uint256) referrerShare;
-        mapping(uint128 => uint) maxCollateralAmounts;
+        mapping(uint128 => uint256) maxCollateralAmounts;
         uint128[] synthDeductionPriority;
-        uint minKeeperRewardUsd;
-        uint maxKeeperRewardUsd;
+        uint256 minKeeperRewardUsd;
+        uint256 maxKeeperRewardUsd;
         uint128 maxPositionsPerAccount;
         uint128 maxCollateralsPerAccount;
-        uint minKeeperProfitRatioD18;
-        uint maxKeeperScalingRatioD18;
+        uint256 minKeeperProfitRatioD18;
+        uint256 maxKeeperScalingRatioD18;
         SetUtil.UintSet supportedCollateralTypes;
+        uint128 lowUtilizationInterestRateGradient;
+        uint128 interestRateGradientBreakpoint;
+        uint128 highUtilizationInterestRateGradient;
     }
     function load() internal pure returns (Data storage globalMarketConfig) {
         bytes32 s = _SLOT_GLOBAL_PERPS_MARKET_CONFIGURATION;
         assembly {
             globalMarketConfig.slot := s
+        }
+    }
+}
+
+// @custom:artifact contracts/storage/InterestRate.sol:InterestRate
+library InterestRate {
+    uint256 private constant AVERAGE_SECONDS_PER_YEAR = 31557600;
+    bytes32 private constant _SLOT_INTEREST_RATE = keccak256(abi.encode("io.synthetix.perps-market.InterestRate"));
+    struct Data {
+        uint256 interestAccrued;
+        uint128 interestRate;
+        uint256 lastTimestamp;
+    }
+    function load() internal pure returns (Data storage interestRate) {
+        bytes32 s = _SLOT_INTEREST_RATE;
+        assembly {
+            interestRate.slot := s
         }
     }
 }
@@ -726,6 +755,7 @@ library Liquidation {
 library MarketUpdate {
     struct Data {
         uint128 marketId;
+        uint128 interestRate;
         int256 skew;
         uint256 size;
         int256 currentFundingRate;
@@ -771,9 +801,15 @@ library PerpsMarket {
         uint128 __unused_1;
         uint128 __unused_2;
         int256 debtCorrectionAccumulator;
-        mapping(uint => AsyncOrder.Data) asyncOrders;
-        mapping(uint => Position.Data) positions;
+        mapping(uint256 => AsyncOrder.Data) asyncOrders;
+        mapping(uint256 => Position.Data) positions;
         Liquidation.Data[] liquidationData;
+    }
+    struct PositionDataRuntime {
+        uint256 currentPrice;
+        int256 sizeDelta;
+        int256 fundingDelta;
+        int256 notionalDelta;
     }
     function load(uint128 marketId) internal pure returns (Data storage market) {
         bytes32 s = keccak256(abi.encode("io.synthetix.perps-market.PerpsMarket", marketId));
@@ -801,6 +837,7 @@ library PerpsMarketConfiguration {
         uint256 minimumInitialMarginRatioD18;
         uint256 maxLiquidationPd;
         address endorsedLiquidator;
+        uint256 maxMarketValue;
     }
     function load(uint128 marketId) internal pure returns (Data storage store) {
         bytes32 s = keccak256(abi.encode("io.synthetix.perps-market.PerpsMarketConfiguration", marketId));
@@ -853,6 +890,7 @@ library Position {
         uint128 marketId;
         int128 size;
         uint128 latestInteractionPrice;
+        uint256 latestInterestAccrued;
         int128 latestInteractionFunding;
     }
 }
@@ -871,6 +909,18 @@ library SettlementStrategy {
         uint256 settlementReward;
         bool disabled;
         uint256 commitmentPriceDelay;
+    }
+}
+
+// @custom:artifact contracts/utils/BigNumber.sol:BigNumber
+library BigNumber {
+    uint256 internal constant CHUNK_SIZE = 2 ** 255;
+    struct Data {
+        uint256[] chunks;
+    }
+    struct Snapshot {
+        uint256 currentChunkId;
+        uint256 valueAtChunk;
     }
 }
 

--- a/markets/perps-market/test/integration/Markets/GlobalPerpsMarket.test.ts
+++ b/markets/perps-market/test/integration/Markets/GlobalPerpsMarket.test.ts
@@ -50,11 +50,7 @@ describe('GlobalPerpsMarket', () => {
     await assertEvent(
       await systems()
         .PerpsMarket.connect(owner())
-        .initializeFactory(
-          await trader1().getAddress(),
-          await trader1().getAddress(),
-          'other name'
-        ),
+        .initializeFactory(await trader1().getAddress(), await trader1().getAddress()),
       'FactoryInitialized(1)',
       systems().PerpsMarket
     );

--- a/markets/perps-market/test/integration/bootstrap/bootstrapPerpsMarkets.ts
+++ b/markets/perps-market/test/integration/bootstrap/bootstrapPerpsMarkets.ts
@@ -83,8 +83,7 @@ export const bootstrapPerpsMarkets = (
   before('create super market', async () => {
     superMarketId = await contracts.PerpsMarket.callStatic.initializeFactory(
       contracts.Core.address,
-      contracts.SpotMarket.address,
-      'SuperMarket'
+      contracts.SpotMarket.address
     );
     await contracts.PerpsMarket.initializeFactory(
       contracts.Core.address,

--- a/markets/perps-market/test/integration/bootstrap/bootstrapPerpsMarkets.ts
+++ b/markets/perps-market/test/integration/bootstrap/bootstrapPerpsMarkets.ts
@@ -89,6 +89,8 @@ export const bootstrapPerpsMarkets = (
       contracts.Core.address,
       contracts.SpotMarket.address
     );
+
+    await contracts.PerpsMarket.connect(r.owner()).setPerpsMarketName('SuperMarket');
     await contracts.Core.connect(r.owner()).setPoolConfiguration(r.poolId, [
       {
         marketId: superMarketId,

--- a/markets/perps-market/test/integration/bootstrap/bootstrapPerpsMarkets.ts
+++ b/markets/perps-market/test/integration/bootstrap/bootstrapPerpsMarkets.ts
@@ -88,8 +88,7 @@ export const bootstrapPerpsMarkets = (
     );
     await contracts.PerpsMarket.initializeFactory(
       contracts.Core.address,
-      contracts.SpotMarket.address,
-      'SuperMarket'
+      contracts.SpotMarket.address
     );
     await contracts.Core.connect(r.owner()).setPoolConfiguration(r.poolId, [
       {


### PR DESCRIPTION
- will be using the setter for setting market name instead of as part of `initializeFactory`.  cannon caches the `initializeFactory` call so it wouldn't get called again and the function call in cannon was not updated to include name.  