### PR TITLE
SIP-361 Changes Part 2

### DIFF
--- a/markets/perps-market/contracts/interfaces/ILiquidationModule.sol
+++ b/markets/perps-market/contracts/interfaces/ILiquidationModule.sol
@@ -25,6 +25,22 @@ interface ILiquidationModule {
     );
 
     /**
+     * @notice Gets fired when an account is flagged for liquidation.
+     * @param accountId Id of the account flagged.
+     * @param availableMargin available margin after flagging.
+     * @param requiredMaintenanceMargin required maintenance margin which caused the flagging.
+     * @param liquidationReward reward for fully liquidating account paid when liquidation occurs.
+     * @param flagReward reward to keeper for flagging the account
+     */
+    event AccountFlaggedForLiquidation(
+        uint128 indexed accountId,
+        int256 availableMargin,
+        uint256 requiredMaintenanceMargin,
+        uint256 liquidationReward,
+        uint256 flagReward
+    );
+
+    /**
      * @notice Gets fired when an account is liquidated.
      * @dev this event is fired once per liquidation tx after the each position that can be liquidated at the time was liquidated.
      * @param accountId Id of the account liquidated.

--- a/markets/perps-market/contracts/modules/LiquidationModule.sol
+++ b/markets/perps-market/contracts/modules/LiquidationModule.sol
@@ -46,12 +46,25 @@ contract LiquidationModule is ILiquidationModule, IMarketEvents {
             .liquidatableAccounts;
         PerpsAccount.Data storage account = PerpsAccount.load(accountId);
         if (!liquidatableAccounts.contains(accountId)) {
-            (bool isEligible, , , , ) = account.isEligibleForLiquidation(
-                PerpsPrice.Tolerance.STRICT
-            );
+            (
+                bool isEligible,
+                int256 availableMargin,
+                ,
+                uint256 requiredMaintenaceMargin,
+                uint256 expectedLiquidationReward
+            ) = account.isEligibleForLiquidation(PerpsPrice.Tolerance.STRICT);
 
             if (isEligible) {
                 (uint256 flagCost, uint256 marginCollected) = account.flagForLiquidation();
+
+                emit AccountFlaggedForLiquidation(
+                    accountId,
+                    availableMargin,
+                    requiredMaintenaceMargin,
+                    expectedLiquidationReward,
+                    flagCost
+                );
+
                 liquidationReward = _liquidateAccount(account, flagCost, marginCollected, true);
             } else {
                 revert NotEligibleForLiquidation(accountId);

--- a/protocol/synthetix/contracts/interfaces/IMarketManagerModule.sol
+++ b/protocol/synthetix/contracts/interfaces/IMarketManagerModule.sol
@@ -39,7 +39,6 @@ interface IMarketManagerModule {
      * @param creditCapacity Updated credit capacity of the market after depositing.
      * @param netIssuance Updated net issuance.
      * @param depositedCollateralValue Updated deposited collateral value of the market.
-     * @param reportedDebt Updated reported debt of the market after depositing.
      */
     event MarketUsdDeposited(
         uint128 indexed marketId,
@@ -48,8 +47,7 @@ interface IMarketManagerModule {
         address indexed market,
         int128 creditCapacity,
         int128 netIssuance,
-        uint256 depositedCollateralValue,
-        uint256 reportedDebt
+        uint256 depositedCollateralValue
     );
 
     /**
@@ -60,8 +58,7 @@ interface IMarketManagerModule {
      * @param market The address of the external market that is withdrawing.
      * @param creditCapacity Updated credit capacity of the market after withdrawing.
      * @param netIssuance Updated net issuance.
-     * @param depositedCollateralValue Updated deposited collateral value of the market.
-     * @param reportedDebt Updated reported debt of the market after withdrawal.
+     * @param depositedCollateralValue Updated deposited collateral value of the market
      */
     event MarketUsdWithdrawn(
         uint128 indexed marketId,
@@ -70,8 +67,7 @@ interface IMarketManagerModule {
         address indexed market,
         int128 creditCapacity,
         int128 netIssuance,
-        uint256 depositedCollateralValue,
-        uint256 reportedDebt
+        uint256 depositedCollateralValue
     );
 
     event MarketSystemFeePaid(uint128 indexed marketId, uint256 feeAmount);

--- a/protocol/synthetix/contracts/modules/core/MarketManagerModule.sol
+++ b/protocol/synthetix/contracts/modules/core/MarketManagerModule.sol
@@ -242,8 +242,7 @@ contract MarketManagerModule is IMarketManagerModule {
             ERC2771Context._msgSender(),
             market.creditCapacityD18,
             market.netIssuanceD18,
-            market.getDepositedCollateralValue(),
-            market.getReportedDebt()
+            market.getDepositedCollateralValue()
         );
     }
 
@@ -297,8 +296,7 @@ contract MarketManagerModule is IMarketManagerModule {
             ERC2771Context._msgSender(),
             marketData.creditCapacityD18,
             marketData.netIssuanceD18,
-            marketData.getDepositedCollateralValue(),
-            marketData.getReportedDebt()
+            marketData.getDepositedCollateralValue()
         );
     }
 

--- a/protocol/synthetix/test/integration/modules/core/MarketManagerModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/MarketManagerModule.test.ts
@@ -155,7 +155,6 @@ describe('MarketManagerModule', function () {
           const creditCapacity = bn(1001).toString();
           const netIssuance = bn(-1).toString();
           const depositedCollateralValue = bn(0).toString();
-          const reportedDebt = bn(1).toString();
           await assertEvent(
             txn,
             `MarketUsdDeposited(${[
@@ -166,7 +165,6 @@ describe('MarketManagerModule', function () {
               creditCapacity,
               netIssuance,
               depositedCollateralValue,
-              reportedDebt,
             ].join(', ')})`,
             systems().Core
           );
@@ -315,7 +313,6 @@ describe('MarketManagerModule', function () {
           const creditCapacity = bn(1000.5).toString();
           const netIssuance = bn(-0.5).toString();
           const depositedCollateralValue = bn(0).toString();
-          const reportedDebt = bn(0.5).toString();
           await assertEvent(
             txn,
             `MarketUsdWithdrawn(${[
@@ -326,7 +323,6 @@ describe('MarketManagerModule', function () {
               creditCapacity,
               netIssuance,
               depositedCollateralValue,
-              reportedDebt,
             ].join(', ')})`,
             systems().Core
           );
@@ -357,7 +353,6 @@ describe('MarketManagerModule', function () {
             const creditCapacity = bn(1000).toString();
             const netIssuance = bn(0).toString();
             const depositedCollateralValue = bn(0).toString();
-            const reportedDebt = bn(0).toString();
             await assertEvent(
               txn,
               `MarketUsdWithdrawn(${[
@@ -368,7 +363,6 @@ describe('MarketManagerModule', function () {
                 creditCapacity,
                 netIssuance,
                 depositedCollateralValue,
-                reportedDebt,
               ].join(', ')})`,
               systems().Core
             );


### PR DESCRIPTION
- [x] Drop the [getReportedDebt](https://github.com/Synthetixio/synthetix-v3/blob/dcba4ade51c893b7eda5f50657ba4e10dd435fa6/protocol/synthetix/contracts/modules/core/MarketManagerModule.sol#L301) from the event emitted upon withdrawing sUSD from a given perp market.
- [x] Emit an event when an account is flagged for liquidation