### PR TITLE
🔮 Arbitrum Gas Price Oracle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,6 +191,9 @@ jobs:
             - "markets/legacy-market/cache"
             - "markets/legacy-market/typechain-types"
 
+            - "auxiliary/ArbitrumGasPriceOracle/artifacts"
+            - "auxiliary/ArbitrumGasPriceOracle/cache"
+            - "auxiliary/ArbitrumGasPriceOracle/typechain-types"
             - "auxiliary/BuybackSnx/artifacts"
             - "auxiliary/BuybackSnx/cache"
             - "auxiliary/BuybackSnx/typechain-types"

--- a/auxiliary/ArbitrumGasPriceOracle/.gitignore
+++ b/auxiliary/ArbitrumGasPriceOracle/.gitignore
@@ -1,0 +1,8 @@
+cannon
+test/generated
+contracts/generated
+contracts/modules/test
+contracts/Router.sol
+deployments/hardhat
+deployments/local
+typechain-types

--- a/auxiliary/ArbitrumGasPriceOracle/LICENSE
+++ b/auxiliary/ArbitrumGasPriceOracle/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Synthetix
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/auxiliary/ArbitrumGasPriceOracle/README.md
+++ b/auxiliary/ArbitrumGasPriceOracle/README.md
@@ -1,0 +1,13 @@
+### Synthetix-auxiliary
+
+- This package houses any external contracts (i.e external oracle manager nodes) which the core/markets systems use.
+
+#### Arbitrum Gas Price Oracle
+
+TODO
+
+- Precompiles
+- L1 Batching Costs
+- Buffers
+- L2 Gas Price
+- etc.

--- a/auxiliary/ArbitrumGasPriceOracle/cannonfile.test.toml
+++ b/auxiliary/ArbitrumGasPriceOracle/cannonfile.test.toml
@@ -1,0 +1,2 @@
+name = "arbitrum-gas-price-oracle"
+version = "<%= package.version %>-testable"

--- a/auxiliary/ArbitrumGasPriceOracle/cannonfile.toml
+++ b/auxiliary/ArbitrumGasPriceOracle/cannonfile.toml
@@ -1,0 +1,3 @@
+name = "arbitrum-gas-price-oracle"
+version = "<%= package.version %>"
+description = "Arbiturm Gas Price Oracle Node"

--- a/auxiliary/ArbitrumGasPriceOracle/contracts/ArbGasPriceOracle.sol
+++ b/auxiliary/ArbitrumGasPriceOracle/contracts/ArbGasPriceOracle.sol
@@ -11,12 +11,19 @@ import {
 import "./interfaces/ArbGasInfo.sol";
 
 contract ArbGasPriceOracle is IExternalNode {
+    using SafeCastU256 for uint256;
+
     /*//////////////////////////////////////////////////////////////
                                CONSTANTS
     //////////////////////////////////////////////////////////////*/
 
+    /// @notice identifies resources consumed via async order settlement 
     uint256 public constant KIND_SETTLEMENT = 0;
+
+`   /// @notice identifies resources consumed via account flagged for liquidation
     uint256 public constant KIND_FLAG = 1;
+
+    /// @notice identifies resources consumed via account liquidation
     uint256 public constant KIND_LIQUIDATE = 2;
 
     /*//////////////////////////////////////////////////////////////
@@ -30,6 +37,8 @@ contract ArbGasPriceOracle is IExternalNode {
                                  TYPES
     //////////////////////////////////////////////////////////////*/
 
+    /// @notice runtime parameters for the cost of resources consumed 
+    /// during execution on L1 and L2
     struct RuntimeParams {
         // Order execution
         uint256 l1SettleGasUnits;
@@ -46,6 +55,13 @@ contract ArbGasPriceOracle is IExternalNode {
     }
 
     /*//////////////////////////////////////////////////////////////
+                             CUSTOM ERRORS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice thrown when the execution kind is invalid
+    error ArbGasPriceOracleInvalidExecutionKind();
+
+    /*//////////////////////////////////////////////////////////////
                               CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
 
@@ -59,19 +75,79 @@ contract ArbGasPriceOracle is IExternalNode {
                          EXTERNAL NODE METHODS
     //////////////////////////////////////////////////////////////*/
 
+    /// @notice process the cost of execution in ETH
+    /// @param parameters the parameters for the cost of execution calculation
+    /// @param runtimeKeys the runtime keys for the cost of execution calculation
+    /// @param runtimeValues the runtime values for the cost of execution calculation
+    /// @return nodeOutput the cost of execution in ETH and timestamp 
+    /// when the cost was calculated (other fields are not used in this implementation)
     function process(
-        NodeOutput.Data[] memory,
+        /* NodeOutput.Data[] memory */,
         bytes memory parameters,
         bytes32[] memory runtimeKeys,
         bytes32[] memory runtimeValues
     ) external view returns (NodeOutput.Data memory nodeOutput) {
-        revert("Not implemented");
+        RuntimeParams memory runtimeParams;
+        (
+            ,
+            runtimeParams.l1SettleGasUnits,
+            runtimeParams.l2SettleGasUnits,
+            runtimeParams.l1FlagGasUnits,
+            runtimeParams.l2FlagGasUnits,
+            runtimeParams.l1LiquidateGasUnits,
+            runtimeParams.l2LiquidateGasUnits
+        ) = abi.decode(parameters, (address, uint256, uint256, uint256, uint256, uint256, uint256));
+
+        for (uint256 i = 0; i < runtimeKeys.length; i++) {
+            if (runtimeKeys[i] == "executionKind") {
+                // solhint-disable-next-line numcast/safe-cast
+                runtimeParams.executionKind = uint256(runtimeValues[i]);
+                continue;
+            }
+            if (runtimeKeys[i] == "numberOfUpdatedFeeds") {
+                // solhint-disable-next-line numcast/safe-cast
+                runtimeParams.numberOfUpdatedFeeds = uint256(runtimeValues[i]);
+                continue;
+            }
+        }
+
+        uint256 costOfExecutionEth = getCostOfExecutionEth(runtimeParams);
+
+        return NodeOutput.Data(costOfExecutionEth.toInt(), block.timestamp, 0, 0);
     }
 
+    /// @notice verify the validity of the external node and its functionality
+    /// @param nodeDefinition the node definition to verify
+    /// @return valid true if the external node is valid, false otherwise
     function isValid(NodeDefinition.Data memory nodeDefinition) external view returns (bool valid) {
-        revert("Not implemented");
+        // Must have no parents
+        if (nodeDefinition.parents.length > 0) {
+            return false;
+        }
+
+        // must be able to decode parameters
+        RuntimeParams memory runtimeParams;
+        (
+            ,
+            runtimeParams.l1SettleGasUnits,
+            runtimeParams.l2SettleGasUnits,
+            runtimeParams.l1FlagGasUnits,
+            runtimeParams.l2FlagGasUnits,
+            runtimeParams.l1LiquidateGasUnits,
+            runtimeParams.l2LiquidateGasUnits
+        ) = abi.decode(nodeDefinition.parameters, (address, uint256, uint256, uint256, uint256, uint256, uint256));
+
+        // verify the oracle can be called; if not, the oracle is invalid
+        try precompile.getPricesInWei(runtimeParams) {
+            return true;
+        } catch {
+            return false;
+        }
     }
 
+    /// @notice check if the contract supports the given interface
+    /// @param interfaceId the interface ID to check
+    /// @return true if the contract supports the given interface, false otherwise
     function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
         return interfaceId == type(IExternalNode).interfaceId || interfaceId == this.supportsInterface.selector;
     }
@@ -80,38 +156,65 @@ contract ArbGasPriceOracle is IExternalNode {
                          INTERNAL NODE METHODS
     //////////////////////////////////////////////////////////////*/
 
+    /// @notice calculate and return the cost of execution in ETH
+    /// @dev gas costs are 2-dimensional: L1 and L2 resources
+    ///      - L1 resources include calldata
+    ///      - L2 resources include computation
+    /// @dev total fee charged to a transaction is the L2 basefee,
+    /// multiplied by the sum of the L2 gas used plus the L1 calldata charge
+    /// @param runtimeParams the runtime parameters for the cost of execution calculation
+    /// @return costOfExecutionGrossEth the cost of execution in ETH
     function getCostOfExecutionEth(RuntimeParams memory runtimeParams)
         internal
         view
         returns (uint256 costOfExecutionGrossEth)
     {
-        (
-            uint256 perL2Tx,
-            uint256 perL1CalldataByte,
-            uint256 perStorageAllocation,
-            uint256 perArbGasBase,
-            uint256 perArbGasCongestion,
-            uint256 perArbGasTotal
-        ) = precompile.getPricesInWei();
+        // fetch & define L2 gas price
+        /// @dev perArbGasTotal is the best estimate of the L2 gas price "base fee" in wei
+        (,,,,, uint256 perArbGasTotal) = precompile.getPricesInWei();
 
-        uint256 currentTxL1GasFees = precompile.getCurrentTxL1GasFees();
+        // fetch & define L1 gas base fee; incorporate overhead buffer
+        /// @dev if the estimate is too low or high at the time of the L1 batch submission,
+        /// the transaction will still be processed, but the arbitrum nitro mechanism will
+        /// amortize the deficit/surplus over subsequent users of the chain
+        /// (i.e. lowering/raising the L1 base fee for a period of time)
+        l1BaseFee = precompile.getL1BaseFeeEstimate();
 
-        // Calculate the cost of execution in ETH
+        // fetch & define gas units consumed on L1 and L2 for the given execution kind
+        (uint256 gasUnitsL1, uint256 gasUnitsL2) = getGasUnits(runtimeParams);
 
-        // step 1: fetch & define L2 gas price
+        // calculate the cost of resources consumed on L1
+        l1GasCost = (l1BaseFee * gasUnitsL1) / perArbGasTotal;
 
-        // step 2: fetch & define overhead buffer
+        // calculate the cost of resources consumed on L2
+        l2GasCost = gasUnitsL2 * perArbGasTotal;
 
-        // step 3: fetch & define L1 base fee
-
-        // step 4: fetch & define precision & units information
-
-        // step 5: calculate the cost of execution in ETH
+        // calculate the total cost of execution in ETH
+        costOfExecutionGrossEth = l1GasCost + l2GasCost;
     }
 
+    /// @notice get the gas units consumed on L1 and L2 for the given execution kind
+    /// @param runtimeParams the runtime parameters for the cost of execution calculation
+    /// @return gasUnitsL1 the gas units consumed on L1
+    /// @return gasUnitsL2 the gas units consumed on L2
     function getGasUnits(RuntimeParams memory runtimeParams)
         internal
         pure
         returns (uint256 gasUnitsL1, uint256 gasUnitsL2)
-    {}
+    {
+        if (runtimeParams.executionKind == KIND_SETTLEMENT) {
+            gasUnitsL1 = runtimeParams.l1SettleGasUnits;
+            gasUnitsL2 = runtimeParams.l2SettleGasUnits;
+        } else if (runtimeParams.executionKind == KIND_FLAG) {
+            // Flag gas units
+            gasUnitsL1 = runtimeParams.numberOfUpdatedFeeds * runtimeParams.l1FlagGasUnits;
+            gasUnitsL2 = runtimeParams.numberOfUpdatedFeeds * runtimeParams.l2FlagGasUnits;
+        } else if (runtimeParams.executionKind == KIND_LIQUIDATE) {
+            // Iterations is fixed to 1 for liquidations
+            gasUnitsL1 = runtimeParams.l1LiquidateGasUnits;
+            gasUnitsL2 = runtimeParams.l2LiquidateGasUnits;
+        } else {
+            revert("Invalid execution kind");
+        }
+    }
 }

--- a/auxiliary/ArbitrumGasPriceOracle/contracts/ArbGasPriceOracle.sol
+++ b/auxiliary/ArbitrumGasPriceOracle/contracts/ArbGasPriceOracle.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.11 <0.9.0;
+
+import {SafeCastU256} from "@synthetixio/core-contracts/contracts/utils/SafeCast.sol";
+import {DecimalMath} from "@synthetixio/core-contracts/contracts/utils/DecimalMath.sol";
+import {
+    IExternalNode,
+    NodeOutput,
+    NodeDefinition
+} from "@synthetixio/oracle-manager/contracts/interfaces/external/IExternalNode.sol";
+import "./interfaces/ArbGasInfo.sol";
+
+contract ArbGasPriceOracle is IExternalNode {
+    function process(
+        NodeOutput.Data[] memory,
+        bytes memory parameters,
+        bytes32[] memory runtimeKeys,
+        bytes32[] memory runtimeValues
+    ) external view returns (NodeOutput.Data memory nodeOutput) {
+        revert("Not implemented");
+    }
+
+    function isValid(NodeDefinition.Data memory nodeDefinition) external view returns (bool valid) {
+        revert("Not implemented");
+    }
+
+    function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
+        return interfaceId == type(IExternalNode).interfaceId || interfaceId == this.supportsInterface.selector;
+    }
+}

--- a/auxiliary/ArbitrumGasPriceOracle/contracts/ArbGasPriceOracle.sol
+++ b/auxiliary/ArbitrumGasPriceOracle/contracts/ArbGasPriceOracle.sol
@@ -11,6 +11,54 @@ import {
 import "./interfaces/ArbGasInfo.sol";
 
 contract ArbGasPriceOracle is IExternalNode {
+    /*//////////////////////////////////////////////////////////////
+                               CONSTANTS
+    //////////////////////////////////////////////////////////////*/
+
+    uint256 public constant KIND_SETTLEMENT = 0;
+    uint256 public constant KIND_FLAG = 1;
+    uint256 public constant KIND_LIQUIDATE = 2;
+
+    /*//////////////////////////////////////////////////////////////
+                               IMMUTABLES
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice the ArbGasInfo precompile contract on Arbitrum
+    ArbGasInfo public immutable precompile;
+
+    /*//////////////////////////////////////////////////////////////
+                                 TYPES
+    //////////////////////////////////////////////////////////////*/
+
+    struct RuntimeParams {
+        // Order execution
+        uint256 l1SettleGasUnits;
+        uint256 l2SettleGasUnits;
+        // Flag
+        uint256 l1FlagGasUnits;
+        uint256 l2FlagGasUnits;
+        // Liquidate (Rate limited)
+        uint256 l1LiquidateGasUnits;
+        uint256 l2LiquidateGasUnits;
+        // Call params
+        uint256 numberOfUpdatedFeeds;
+        uint256 executionKind;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                              CONSTRUCTOR
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice construct the ArbGasPriceOracle contract
+    /// @param _arbGasInfoPrecompileAddress the address of the ArbGasInfo precompile
+    constructor(address _arbGasInfoPrecompileAddress) {
+        precompile = ArbGasInfo(_arbGasInfoPrecompileAddress);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                         EXTERNAL NODE METHODS
+    //////////////////////////////////////////////////////////////*/
+
     function process(
         NodeOutput.Data[] memory,
         bytes memory parameters,
@@ -27,4 +75,43 @@ contract ArbGasPriceOracle is IExternalNode {
     function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
         return interfaceId == type(IExternalNode).interfaceId || interfaceId == this.supportsInterface.selector;
     }
+
+    /*//////////////////////////////////////////////////////////////
+                         INTERNAL NODE METHODS
+    //////////////////////////////////////////////////////////////*/
+
+    function getCostOfExecutionEth(RuntimeParams memory runtimeParams)
+        internal
+        view
+        returns (uint256 costOfExecutionGrossEth)
+    {
+        (
+            uint256 perL2Tx,
+            uint256 perL1CalldataByte,
+            uint256 perStorageAllocation,
+            uint256 perArbGasBase,
+            uint256 perArbGasCongestion,
+            uint256 perArbGasTotal
+        ) = precompile.getPricesInWei();
+
+        uint256 currentTxL1GasFees = precompile.getCurrentTxL1GasFees();
+
+        // Calculate the cost of execution in ETH
+
+        // step 1: fetch & define L2 gas price
+
+        // step 2: fetch & define overhead buffer
+
+        // step 3: fetch & define L1 base fee
+
+        // step 4: fetch & define precision & units information
+
+        // step 5: calculate the cost of execution in ETH
+    }
+
+    function getGasUnits(RuntimeParams memory runtimeParams)
+        internal
+        pure
+        returns (uint256 gasUnitsL1, uint256 gasUnitsL2)
+    {}
 }

--- a/auxiliary/ArbitrumGasPriceOracle/contracts/interfaces/ArbGasInfo.sol
+++ b/auxiliary/ArbitrumGasPriceOracle/contracts/interfaces/ArbGasInfo.sol
@@ -1,0 +1,152 @@
+// Copyright 2021-2022, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity >=0.4.21 <0.9.0;
+
+/// @title Provides insight into the cost of using the chain.
+/// @notice These methods have been adjusted to account for Nitro's heavy use of calldata compression.
+/// Of note to end-users, we no longer make a distinction between non-zero and zero-valued calldata bytes.
+/// Precompiled contract that exists in every Arbitrum chain at 0x000000000000000000000000000000000000006c.
+interface ArbGasInfo {
+    /// @notice Get gas prices for a provided aggregator
+    /// @return return gas prices in wei
+    ///        (
+    ///            per L2 tx,
+    ///            per L1 calldata byte
+    ///            per storage allocation,
+    ///            per ArbGas base,
+    ///            per ArbGas congestion,
+    ///            per ArbGas total
+    ///        )
+    function getPricesInWeiWithAggregator(address aggregator)
+        external
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256
+        );
+
+    /// @notice Get gas prices. Uses the caller's preferred aggregator, or the default if the caller doesn't have a preferred one.
+    /// @return return gas prices in wei
+    ///        (
+    ///            per L2 tx,
+    ///            per L1 calldata byte
+    ///            per storage allocation,
+    ///            per ArbGas base,
+    ///            per ArbGas congestion,
+    ///            per ArbGas total
+    ///        )
+    function getPricesInWei()
+        external
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256
+        );
+
+    /// @notice Get prices in ArbGas for the supplied aggregator
+    /// @return (per L2 tx, per L1 calldata byte, per storage allocation)
+    function getPricesInArbGasWithAggregator(address aggregator)
+        external
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256
+        );
+
+    /// @notice Get prices in ArbGas. Assumes the callers preferred validator, or the default if caller doesn't have a preferred one.
+    /// @return (per L2 tx, per L1 calldata byte, per storage allocation)
+    function getPricesInArbGas()
+        external
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256
+        );
+
+    /// @notice Get the gas accounting parameters. `gasPoolMax` is always zero, as the exponential pricing model has no such notion.
+    /// @return (speedLimitPerSecond, gasPoolMax, maxTxGasLimit)
+    function getGasAccountingParams()
+        external
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256
+        );
+
+    /// @notice Get the minimum gas price needed for a tx to succeed
+    function getMinimumGasPrice() external view returns (uint256);
+
+    /// @notice Get ArbOS's estimate of the L1 basefee in wei
+    function getL1BaseFeeEstimate() external view returns (uint256);
+
+    /// @notice Get how slowly ArbOS updates its estimate of the L1 basefee
+    function getL1BaseFeeEstimateInertia() external view returns (uint64);
+
+    /// @notice Get the L1 pricer reward rate, in wei per unit
+    /// Available in ArbOS version 11
+    function getL1RewardRate() external view returns (uint64);
+
+    /// @notice Get the L1 pricer reward recipient
+    /// Available in ArbOS version 11
+    function getL1RewardRecipient() external view returns (address);
+
+    /// @notice Deprecated -- Same as getL1BaseFeeEstimate()
+    function getL1GasPriceEstimate() external view returns (uint256);
+
+    /// @notice Get L1 gas fees paid by the current transaction
+    function getCurrentTxL1GasFees() external view returns (uint256);
+
+    /// @notice Get the backlogged amount of gas burnt in excess of the speed limit
+    function getGasBacklog() external view returns (uint64);
+
+    /// @notice Get how slowly ArbOS updates the L2 basefee in response to backlogged gas
+    function getPricingInertia() external view returns (uint64);
+
+    /// @notice Get the forgivable amount of backlogged gas ArbOS will ignore when raising the basefee
+    function getGasBacklogTolerance() external view returns (uint64);
+
+    /// @notice Returns the surplus of funds for L1 batch posting payments (may be negative).
+    function getL1PricingSurplus() external view returns (int256);
+
+    /// @notice Returns the base charge (in L1 gas) attributed to each data batch in the calldata pricer
+    function getPerBatchGasCharge() external view returns (int64);
+
+    /// @notice Returns the cost amortization cap in basis points
+    function getAmortizedCostCapBips() external view returns (uint64);
+
+    /// @notice Returns the available funds from L1 fees
+    function getL1FeesAvailable() external view returns (uint256);
+
+    /// @notice Returns the equilibration units parameter for L1 price adjustment algorithm
+    /// Available in ArbOS version 20
+    function getL1PricingEquilibrationUnits() external view returns (uint256);
+
+    /// @notice Returns the last time the L1 calldata pricer was updated.
+    /// Available in ArbOS version 20
+    function getLastL1PricingUpdateTime() external view returns (uint64);
+
+    /// @notice Returns the amount of L1 calldata payments due for rewards (per the L1 reward rate)
+    /// Available in ArbOS version 20
+    function getL1PricingFundsDueForRewards() external view returns (uint256);
+
+    /// @notice Returns the amount of L1 calldata posted since the last update.
+    /// Available in ArbOS version 20
+    function getL1PricingUnitsSinceUpdate() external view returns (uint64);
+
+    /// @notice Returns the L1 pricing surplus as of the last update (may be negative).
+    /// Available in ArbOS version 20
+    function getLastL1PricingSurplus() external view returns (int256);
+}

--- a/auxiliary/ArbitrumGasPriceOracle/contracts/interfaces/ArbGasInfo.sol
+++ b/auxiliary/ArbitrumGasPriceOracle/contracts/interfaces/ArbGasInfo.sol
@@ -23,16 +23,10 @@ interface ArbGasInfo {
     function getPricesInWeiWithAggregator(address aggregator)
         external
         view
-        returns (
-            uint256,
-            uint256,
-            uint256,
-            uint256,
-            uint256,
-            uint256
-        );
+        returns (uint256, uint256, uint256, uint256, uint256, uint256);
 
-    /// @notice Get gas prices. Uses the caller's preferred aggregator, or the default if the caller doesn't have a preferred one.
+    /// @notice Get gas prices. Uses the caller's preferred aggregator, or the default if
+    /// the caller doesn't have a preferred one.
     /// @return return gas prices in wei
     ///        (
     ///            per L2 tx,
@@ -42,50 +36,21 @@ interface ArbGasInfo {
     ///            per ArbGas congestion,
     ///            per ArbGas total
     ///        )
-    function getPricesInWei()
-        external
-        view
-        returns (
-            uint256,
-            uint256,
-            uint256,
-            uint256,
-            uint256,
-            uint256
-        );
+    function getPricesInWei() external view returns (uint256, uint256, uint256, uint256, uint256, uint256);
 
     /// @notice Get prices in ArbGas for the supplied aggregator
     /// @return (per L2 tx, per L1 calldata byte, per storage allocation)
-    function getPricesInArbGasWithAggregator(address aggregator)
-        external
-        view
-        returns (
-            uint256,
-            uint256,
-            uint256
-        );
+    function getPricesInArbGasWithAggregator(address aggregator) external view returns (uint256, uint256, uint256);
 
-    /// @notice Get prices in ArbGas. Assumes the callers preferred validator, or the default if caller doesn't have a preferred one.
+    /// @notice Get prices in ArbGas. Assumes the callers preferred validator, or the default
+    /// if caller doesn't have a preferred one.
     /// @return (per L2 tx, per L1 calldata byte, per storage allocation)
-    function getPricesInArbGas()
-        external
-        view
-        returns (
-            uint256,
-            uint256,
-            uint256
-        );
+    function getPricesInArbGas() external view returns (uint256, uint256, uint256);
 
-    /// @notice Get the gas accounting parameters. `gasPoolMax` is always zero, as the exponential pricing model has no such notion.
+    /// @notice Get the gas accounting parameters. `gasPoolMax` is always zero, as the exponential
+    /// pricing model has no such notion.
     /// @return (speedLimitPerSecond, gasPoolMax, maxTxGasLimit)
-    function getGasAccountingParams()
-        external
-        view
-        returns (
-            uint256,
-            uint256,
-            uint256
-        );
+    function getGasAccountingParams() external view returns (uint256, uint256, uint256);
 
     /// @notice Get the minimum gas price needed for a tx to succeed
     function getMinimumGasPrice() external view returns (uint256);

--- a/auxiliary/ArbitrumGasPriceOracle/contracts/interfaces/ArbGasInfo.sol
+++ b/auxiliary/ArbitrumGasPriceOracle/contracts/interfaces/ArbGasInfo.sol
@@ -8,6 +8,7 @@ pragma solidity >=0.4.21 <0.9.0;
 /// @notice These methods have been adjusted to account for Nitro's heavy use of calldata compression.
 /// Of note to end-users, we no longer make a distinction between non-zero and zero-valued calldata bytes.
 /// Precompiled contract that exists in every Arbitrum chain at 0x000000000000000000000000000000000000006c.
+/// @custom:reference https://github.com/OffchainLabs/nitro-contracts/blob/main/src/precompiles/ArbGasInfo.sol
 interface ArbGasInfo {
     /// @notice Get gas prices for a provided aggregator
     /// @return return gas prices in wei

--- a/auxiliary/ArbitrumGasPriceOracle/hardhat.config.ts
+++ b/auxiliary/ArbitrumGasPriceOracle/hardhat.config.ts
@@ -1,0 +1,23 @@
+import commonConfig from '@synthetixio/common-config/hardhat.config';
+
+import 'solidity-docgen';
+import { templates } from '@synthetixio/docgen';
+
+const config = {
+  ...commonConfig,
+  docgen: {
+    exclude: [
+      './interfaces/external',
+      './modules',
+      './mixins',
+      './mocks',
+      './utils',
+      './storage',
+      './Proxy.sol',
+      './Router.sol',
+    ],
+    templates,
+  },
+};
+
+export default config;

--- a/auxiliary/ArbitrumGasPriceOracle/package.json
+++ b/auxiliary/ArbitrumGasPriceOracle/package.json
@@ -1,0 +1,35 @@
+{
+    "name": "@synthetixio/arbitrum-gas-price-oracle",
+    "version": "3.3.14",
+    "description": "Arbitrum Gas Price Oracle Node",
+    "publishConfig": {
+        "access": "public"
+    },
+    "scripts": {
+        "test": "CANNON_REGISTRY_PRIORITY=local hardhat test",
+        "coverage": "hardhat coverage --network hardhat",
+        "clean": "hardhat clean",
+        "build": "yarn build:contracts",
+        "build:contracts": "hardhat storage:verify && hardhat cannon:build",
+        "build-testable": "CANNON_REGISTRY_PRIORITY=local hardhat cannon:build cannonfile.test.toml",
+        "check:storage": "git diff --exit-code storage.dump.sol",
+        "compile-contracts": "hardhat compile",
+        "size-contracts": "hardhat compile && hardhat size-contracts",
+        "publish-contracts": "cannon publish arbitrum-gas-price-oracle:$(node -p 'require(`./package.json`).version') --chain-id 42161 --quiet --tags $(node -p '/^\\d+\\.\\d+\\.\\d+$/.test(require(`./package.json`).version) ? `latest` : `dev`')",
+        "postpack": "yarn build && yarn publish-contracts",
+        "docgen": "hardhat docgen"
+    },
+    "keywords": [],
+    "author": "",
+    "license": "MIT",
+    "devDependencies": {
+        "@synthetixio/common-config": "workspace:*",
+        "@synthetixio/core-contracts": "workspace:*",
+        "@synthetixio/core-modules": "workspace:*",
+        "@synthetixio/docgen": "workspace:*",
+        "hardhat": "^2.19.5",
+        "solidity-docgen": "^0.6.0-beta.36",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.3.3"
+    }
+}

--- a/auxiliary/ArbitrumGasPriceOracle/storage.dump.sol
+++ b/auxiliary/ArbitrumGasPriceOracle/storage.dump.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.4.21<0.9.0;
+
+// @custom:artifact @synthetixio/core-contracts/contracts/utils/DecimalMath.sol:DecimalMath
+library DecimalMath {
+    uint256 public constant UNIT = 1e18;
+    int256 public constant UNIT_INT = int256(UNIT);
+    uint128 public constant UNIT_UINT128 = uint128(UNIT);
+    int128 public constant UNIT_INT128 = int128(UNIT_INT);
+    uint256 public constant UNIT_PRECISE = 1e27;
+    int256 public constant UNIT_PRECISE_INT = int256(UNIT_PRECISE);
+    int128 public constant UNIT_PRECISE_INT128 = int128(UNIT_PRECISE_INT);
+    uint256 public constant PRECISION_FACTOR = 9;
+}
+
+// @custom:artifact @synthetixio/oracle-manager/contracts/interfaces/external/IPyth.sol:PythStructs
+contract PythStructs {
+    struct Price {
+        int64 price;
+        uint64 conf;
+        int32 expo;
+        uint256 publishTime;
+    }
+    struct PriceFeed {
+        bytes32 id;
+        Price price;
+        Price emaPrice;
+    }
+}
+
+// @custom:artifact @synthetixio/oracle-manager/contracts/nodes/ChainlinkNode.sol:ChainlinkNode
+library ChainlinkNode {
+    uint256 public constant PRECISION = 18;
+}
+
+// @custom:artifact @synthetixio/oracle-manager/contracts/nodes/ReducerNode.sol:ReducerNode
+library ReducerNode {
+    enum Operations {
+        RECENT,
+        MIN,
+        MAX,
+        MEAN,
+        MEDIAN,
+        MUL,
+        DIV,
+        MULDECIMAL,
+        DIVDECIMAL
+    }
+}
+
+// @custom:artifact @synthetixio/oracle-manager/contracts/nodes/UniswapNode.sol:UniswapNode
+library UniswapNode {
+    uint8 public constant PRECISION = 18;
+}
+
+// @custom:artifact @synthetixio/oracle-manager/contracts/nodes/pyth/PythNode.sol:PythNode
+library PythNode {
+    int256 public constant PRECISION = 18;
+}
+
+// @custom:artifact @synthetixio/oracle-manager/contracts/nodes/pyth/PythOffchainLookupNode.sol:PythOffchainLookupNode
+library PythOffchainLookupNode {
+    int256 public constant PRECISION = 18;
+}
+
+// @custom:artifact @synthetixio/oracle-manager/contracts/storage/NodeDefinition.sol:NodeDefinition
+library NodeDefinition {
+    enum NodeType {
+        NONE,
+        REDUCER,
+        EXTERNAL,
+        CHAINLINK,
+        UNISWAP,
+        PYTH,
+        PRICE_DEVIATION_CIRCUIT_BREAKER,
+        STALENESS_CIRCUIT_BREAKER,
+        CONSTANT,
+        PYTH_OFFCHAIN_LOOKUP
+    }
+    struct Data {
+        NodeType nodeType;
+        bytes parameters;
+        bytes32[] parents;
+    }
+    function load(bytes32 id) internal pure returns (Data storage node) {
+        bytes32 s = keccak256(abi.encode("io.synthetix.oracle-manager.Node", id));
+        assembly {
+            node.slot := s
+        }
+    }
+}
+
+// @custom:artifact @synthetixio/oracle-manager/contracts/storage/NodeOutput.sol:NodeOutput
+library NodeOutput {
+    struct Data {
+        int256 price;
+        uint256 timestamp;
+        uint256 __slotAvailableForFutureUse1;
+        uint256 __slotAvailableForFutureUse2;
+    }
+}
+
+// @custom:artifact @synthetixio/oracle-manager/contracts/utils/TickMath.sol:TickMath
+library TickMath {
+    int24 internal constant MIN_TICK = -887272;
+    int24 internal constant MAX_TICK = -MIN_TICK;
+    uint160 internal constant MIN_SQRT_RATIO = 4295128739;
+    uint160 internal constant MAX_SQRT_RATIO = 1461446703485210103287273052203988822378723970342;
+}

--- a/auxiliary/ArbitrumGasPriceOracle/tsconfig.json
+++ b/auxiliary/ArbitrumGasPriceOracle/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../../utils/common-config/tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2876,6 +2876,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@synthetixio/arbitrum-gas-price-oracle@workspace:auxiliary/ArbitrumGasPriceOracle":
+  version: 0.0.0-use.local
+  resolution: "@synthetixio/arbitrum-gas-price-oracle@workspace:auxiliary/ArbitrumGasPriceOracle"
+  dependencies:
+    "@synthetixio/common-config": "workspace:*"
+    "@synthetixio/core-contracts": "workspace:*"
+    "@synthetixio/core-modules": "workspace:*"
+    "@synthetixio/docgen": "workspace:*"
+    hardhat: "npm:^2.19.5"
+    solidity-docgen: "npm:^0.6.0-beta.36"
+    ts-node: "npm:^10.9.2"
+    typescript: "npm:^5.3.3"
+  languageName: unknown
+  linkType: soft
+
 "@synthetixio/buyback-snx@workspace:auxiliary/BuybackSnx":
   version: 0.0.0-use.local
   resolution: "@synthetixio/buyback-snx@workspace:auxiliary/BuybackSnx"


### PR DESCRIPTION
Arbitrum deployment support

> does not include cannon deployment updates (incl. configuration, etc)

## Description
 * Create `IExternalNode` inheriting contract `ArbGasPriceOracle` to process and price gas
 * Fetch L2 gas price via `ArbGasInfo.getPricesInWei` (see Go implementation [here](https://github.com/OffchainLabs/nitro/blob/a20a1c70cc11ac52c7cfe6a20f00c880c2009a8f/precompiles/ArbGasInfo.go#L56))
 * Fetch L1 gas price via `ArbGasInfo.getL1BaseFeeEstimate` (see Go implementation [here](https://github.com/OffchainLabs/nitro/blob/22e80a4544b0e402ce58695c3d7f6048b06e16b0/arbos/l1pricing/l1pricing.go#L217))
 * Omitted `overhead` and `scalar` from `ArbGasPriceOracle .getCostOfExecutionEth` due to Arbitrum nitro mechanism (see [fee pool](https://research.arbitrum.io/t/l1-calldata-data-pricing-sequencer-reimbursement-fee-pool-model/107))

## Related issue(s)
N/A

## Motivation and Context
Synthetix v3 deployment to Arbitrum One (chain id: 42161)

## Resources
[L1 calldata data pricing / Sequencer reimbursement, “Fee Pool” Model](https://research.arbitrum.io/t/l1-calldata-data-pricing-sequencer-reimbursement-fee-pool-model/107)