### PR TITLE
Rollback breaking change + minor issue fix

### DIFF
--- a/markets/perps-market/contracts/interfaces/IMarketConfigurationModule.sol
+++ b/markets/perps-market/contracts/interfaces/IMarketConfigurationModule.sol
@@ -302,11 +302,15 @@ interface IMarketConfigurationModule {
      * @notice Gets the max size of an specific market.
      * @param marketId id of the market.
      * @return maxMarketSize the max market size in market asset units.
+     */
+    function getMaxMarketSize(uint128 marketId) external view returns (uint256 maxMarketSize);
+
+    /**
+     * @notice Gets the max size (in value) of an specific market.
+     * @param marketId id of the market.
      * @return maxMarketValue the max market size in market USD value.
      */
-    function getMaxMarketSize(
-        uint128 marketId
-    ) external view returns (uint256 maxMarketSize, uint256 maxMarketValue);
+    function getMaxMarketValue(uint128 marketId) external view returns (uint256 maxMarketValue);
 
     /**
      * @notice Gets the order fees of a market.

--- a/markets/perps-market/contracts/modules/MarketConfigurationModule.sol
+++ b/markets/perps-market/contracts/modules/MarketConfigurationModule.sol
@@ -297,10 +297,20 @@ contract MarketConfigurationModule is IMarketConfigurationModule {
      */
     function getMaxMarketSize(
         uint128 marketId
-    ) external view override returns (uint256 maxMarketSize, uint256 maxMarketValue) {
+    ) external view override returns (uint256 maxMarketSize) {
         PerpsMarketConfiguration.Data storage config = PerpsMarketConfiguration.load(marketId);
 
         maxMarketSize = config.maxMarketSize;
+    }
+
+    /**
+     * @inheritdoc IMarketConfigurationModule
+     */
+    function getMaxMarketValue(
+        uint128 marketId
+    ) external view override returns (uint256 maxMarketValue) {
+        PerpsMarketConfiguration.Data storage config = PerpsMarketConfiguration.load(marketId);
+
         maxMarketValue = config.maxMarketValue;
     }
 

--- a/markets/perps-market/contracts/storage/GlobalPerpsMarket.sol
+++ b/markets/perps-market/contracts/storage/GlobalPerpsMarket.sol
@@ -80,7 +80,9 @@ library GlobalPerpsMarket {
             return (DecimalMath.UNIT_UINT128, 0, lockedCredit);
         }
 
-        rate = lockedCredit.divDecimal(delegatedCollateralValueInt.toUint()).to128();
+        delegatedCollateralValue = delegatedCollateralValueInt.toUint();
+
+        rate = lockedCredit.divDecimal(delegatedCollateralValue).to128();
     }
 
     function minimumCredit(

--- a/markets/perps-market/test/integration/Market/MarketConfiguration.test.ts
+++ b/markets/perps-market/test/integration/Market/MarketConfiguration.test.ts
@@ -415,8 +415,13 @@ describe('MarketConfiguration', () => {
   });
 
   it('get maxMarketSize', async () => {
-    const maxMarketSizes = await systems().PerpsMarket.getMaxMarketSize(marketId);
-    assertBn.equal(maxMarketSizes[0], fixture.maxMarketSize);
+    const maxMarketSize = await systems().PerpsMarket.getMaxMarketSize(marketId);
+    assertBn.equal(maxMarketSize, fixture.maxMarketSize);
+  });
+
+  it('get maxMarketValue', async () => {
+    const maxMarketValue = await systems().PerpsMarket.getMaxMarketValue(marketId);
+    assertBn.equal(maxMarketValue, fixture.maxMarketValue);
   });
 
   it('get orderFees', async () => {

--- a/markets/perps-market/test/integration/Position/InterestRate.test.ts
+++ b/markets/perps-market/test/integration/Position/InterestRate.test.ts
@@ -80,8 +80,12 @@ describe('Position - interest rates', () => {
         currentInterestRate.toBN(),
         bn(0.0001)
       );
-      const { rate: expectedUtilizationRate } = await systems().PerpsMarket.utilizationRate();
+      const {
+        rate: expectedUtilizationRate,
+        delegatedCollateral: expectedDelegatedCollateralValue,
+      } = await systems().PerpsMarket.utilizationRate();
       assertBn.near(expectedUtilizationRate, utilRate.toBN(), bn(0.0001));
+      assertBn.equal(expectedDelegatedCollateralValue, delegatedCollateral.toBN());
     });
 
     return {


### PR DESCRIPTION
This PR rolls back the change on getMaxMarketSize to return only one value and adds a new getMaxMarketValue to obtain the other parameter.

It also fixes an issue with `utilizationRate()` where the 2nd returned a value was always zero due to missing initialization of the value itself.  