### PR TITLE
msg.sender -> ERC2771Context._msgSender()

### DIFF
--- a/markets/bfp-market/contracts/modules/FeatureFlagModule.sol
+++ b/markets/bfp-market/contracts/modules/FeatureFlagModule.sol
@@ -6,8 +6,7 @@ import {FeatureFlag} from "@synthetixio/core-modules/contracts/storage/FeatureFl
 import {OwnableStorage} from "@synthetixio/core-contracts/contracts/ownership/OwnableStorage.sol";
 import {IFeatureFlagModule} from "../interfaces/IFeatureFlagModule.sol";
 import {Flags} from "../utils/Flags.sol";
-
-/* solhint-disable meta-transactions/no-msg-sender */
+import {ERC2771Context} from "@synthetixio/core-contracts/contracts/utils/ERC2771Context.sol";
 
 contract FeatureFlagModule is IFeatureFlagModule, BaseFeatureFlagModule {
     using FeatureFlag for FeatureFlag.Data;
@@ -28,7 +27,7 @@ contract FeatureFlagModule is IFeatureFlagModule, BaseFeatureFlagModule {
     function suspendFeature(bytes32 feature) internal {
         FeatureFlag.Data storage flag = FeatureFlag.load(feature);
 
-        if (!flag.isDenier(msg.sender)) {
+        if (!flag.isDenier(ERC2771Context._msgSender())) {
             OwnableStorage.onlyOwner();
         }
 

--- a/markets/bfp-market/contracts/modules/LiquidationModule.sol
+++ b/markets/bfp-market/contracts/modules/LiquidationModule.sol
@@ -16,8 +16,7 @@ import {Position} from "../storage/Position.sol";
 import {ErrorUtil} from "../utils/ErrorUtil.sol";
 import {MathUtil} from "../utils/MathUtil.sol";
 import {Flags} from "../utils/Flags.sol";
-
-/* solhint-disable meta-transactions/no-msg-sender */
+import {ERC2771Context} from "@synthetixio/core-contracts/contracts/utils/ERC2771Context.sol";
 
 contract LiquidationModule is ILiquidationModule {
     using DecimalMath for uint256;
@@ -254,12 +253,18 @@ contract LiquidationModule is ILiquidationModule {
         liquidateCollateral(accountId, marketId, market, globalConfig);
 
         // Flag and emit event.
-        market.flaggedLiquidations[accountId] = msg.sender;
+        market.flaggedLiquidations[accountId] = ERC2771Context._msgSender();
 
         // Pay flagger.
-        globalConfig.synthetix.withdrawMarketUsd(marketId, msg.sender, flagReward);
+        globalConfig.synthetix.withdrawMarketUsd(marketId, ERC2771Context._msgSender(), flagReward);
 
-        emit PositionFlaggedLiquidation(accountId, marketId, msg.sender, flagReward, oraclePrice);
+        emit PositionFlaggedLiquidation(
+            accountId,
+            marketId,
+            ERC2771Context._msgSender(),
+            flagReward,
+            oraclePrice
+        );
     }
 
     /**
@@ -298,14 +303,18 @@ contract LiquidationModule is ILiquidationModule {
         }
 
         // Pay the keeper
-        globalConfig.synthetix.withdrawMarketUsd(marketId, msg.sender, liqKeeperFee);
+        globalConfig.synthetix.withdrawMarketUsd(
+            marketId,
+            ERC2771Context._msgSender(),
+            liqKeeperFee
+        );
 
         emit PositionLiquidated(
             accountId,
             marketId,
             oldPositionSize,
             newPosition.size,
-            msg.sender,
+            ERC2771Context._msgSender(),
             flagger,
             liqKeeperFee,
             oraclePrice
@@ -378,7 +387,11 @@ contract LiquidationModule is ILiquidationModule {
         liquidateCollateral(accountId, marketId, market, PerpMarketConfiguration.load());
 
         // Pay flagger.
-        globalConfig.synthetix.withdrawMarketUsd(marketId, msg.sender, keeperReward);
+        globalConfig.synthetix.withdrawMarketUsd(
+            marketId,
+            ERC2771Context._msgSender(),
+            keeperReward
+        );
 
         emit MarginLiquidated(accountId, marketId, keeperReward);
     }

--- a/markets/bfp-market/contracts/modules/LiquidationModule.sol
+++ b/markets/bfp-market/contracts/modules/LiquidationModule.sol
@@ -252,19 +252,14 @@ contract LiquidationModule is ILiquidationModule {
 
         liquidateCollateral(accountId, marketId, market, globalConfig);
 
+        address msgSender = ERC2771Context._msgSender();
         // Flag and emit event.
-        market.flaggedLiquidations[accountId] = ERC2771Context._msgSender();
+        market.flaggedLiquidations[accountId] = msgSender;
 
         // Pay flagger.
-        globalConfig.synthetix.withdrawMarketUsd(marketId, ERC2771Context._msgSender(), flagReward);
+        globalConfig.synthetix.withdrawMarketUsd(marketId, msgSender, flagReward);
 
-        emit PositionFlaggedLiquidation(
-            accountId,
-            marketId,
-            ERC2771Context._msgSender(),
-            flagReward,
-            oraclePrice
-        );
+        emit PositionFlaggedLiquidation(accountId, marketId, msgSender, flagReward, oraclePrice);
     }
 
     /**
@@ -302,19 +297,17 @@ contract LiquidationModule is ILiquidationModule {
             market.positions[accountId].update(newPosition);
         }
 
+        address msgSender = ERC2771Context._msgSender();
+
         // Pay the keeper
-        globalConfig.synthetix.withdrawMarketUsd(
-            marketId,
-            ERC2771Context._msgSender(),
-            liqKeeperFee
-        );
+        globalConfig.synthetix.withdrawMarketUsd(marketId, msgSender, liqKeeperFee);
 
         emit PositionLiquidated(
             accountId,
             marketId,
             oldPositionSize,
             newPosition.size,
-            ERC2771Context._msgSender(),
+            msgSender,
             flagger,
             liqKeeperFee,
             oraclePrice

--- a/markets/bfp-market/contracts/modules/MarginModule.sol
+++ b/markets/bfp-market/contracts/modules/MarginModule.sol
@@ -83,14 +83,15 @@ contract MarginModule is IMarginModule {
         uint128 synthMarketId,
         PerpMarketConfiguration.GlobalData storage globalConfig
     ) private {
+        address msgSender = ERC2771Context._msgSender();
         if (synthMarketId == SYNTHETIX_USD_MARKET_ID) {
-            globalConfig.synthetix.withdrawMarketUsd(marketId, ERC2771Context._msgSender(), amount);
+            globalConfig.synthetix.withdrawMarketUsd(marketId, msgSender, amount);
         } else {
             ITokenModule synth = ITokenModule(globalConfig.spotMarket.getSynth(synthMarketId));
             globalConfig.synthetix.withdrawMarketCollateral(marketId, address(synth), amount);
-            synth.transfer(ERC2771Context._msgSender(), amount);
+            synth.transfer(msgSender, amount);
         }
-        emit MarginWithdraw(address(this), ERC2771Context._msgSender(), amount, synthMarketId);
+        emit MarginWithdraw(address(this), msgSender, amount, synthMarketId);
     }
 
     /**
@@ -102,14 +103,15 @@ contract MarginModule is IMarginModule {
         uint128 synthMarketId,
         PerpMarketConfiguration.GlobalData storage globalConfig
     ) private {
+        address msgSender = ERC2771Context._msgSender();
         if (synthMarketId == SYNTHETIX_USD_MARKET_ID) {
-            globalConfig.synthetix.depositMarketUsd(marketId, ERC2771Context._msgSender(), amount);
+            globalConfig.synthetix.depositMarketUsd(marketId, msgSender, amount);
         } else {
             ITokenModule synth = ITokenModule(globalConfig.spotMarket.getSynth(synthMarketId));
-            synth.transferFrom(ERC2771Context._msgSender(), address(this), amount);
+            synth.transferFrom(msgSender, address(this), amount);
             globalConfig.synthetix.depositMarketCollateral(marketId, address(synth), amount);
         }
-        emit MarginDeposit(ERC2771Context._msgSender(), address(this), amount, synthMarketId);
+        emit MarginDeposit(msgSender, address(this), amount, synthMarketId);
     }
 
     /**

--- a/markets/bfp-market/contracts/modules/MarketConfigurationModule.sol
+++ b/markets/bfp-market/contracts/modules/MarketConfigurationModule.sol
@@ -5,8 +5,7 @@ import {OwnableStorage} from "@synthetixio/core-contracts/contracts/ownership/Ow
 import {IMarketConfigurationModule} from "../interfaces/IMarketConfigurationModule.sol";
 import {PerpMarket} from "../storage/PerpMarket.sol";
 import {PerpMarketConfiguration} from "../storage/PerpMarketConfiguration.sol";
-
-/* solhint-disable meta-transactions/no-msg-sender */
+import {ERC2771Context} from "@synthetixio/core-contracts/contracts/utils/ERC2771Context.sol";
 
 contract MarketConfigurationModule is IMarketConfigurationModule {
     /**
@@ -41,7 +40,7 @@ contract MarketConfigurationModule is IMarketConfigurationModule {
         config.lowUtilizationSlopePercent = data.lowUtilizationSlopePercent;
         config.highUtilizationSlopePercent = data.highUtilizationSlopePercent;
 
-        emit ConfigurationUpdated(msg.sender);
+        emit ConfigurationUpdated(ERC2771Context._msgSender());
     }
 
     /**
@@ -77,7 +76,7 @@ contract MarketConfigurationModule is IMarketConfigurationModule {
         config.liquidationWindowDuration = data.liquidationWindowDuration;
         config.liquidationMaxPd = data.liquidationMaxPd;
 
-        emit MarketConfigurationUpdated(marketId, msg.sender);
+        emit MarketConfigurationUpdated(marketId, ERC2771Context._msgSender());
     }
 
     // --- Views --- //

--- a/markets/bfp-market/contracts/modules/OrderModule.sol
+++ b/markets/bfp-market/contracts/modules/OrderModule.sol
@@ -18,8 +18,7 @@ import {ErrorUtil} from "../utils/ErrorUtil.sol";
 import {MathUtil} from "../utils/MathUtil.sol";
 import {PythUtil} from "../utils/PythUtil.sol";
 import {Flags} from "../utils/Flags.sol";
-
-/* solhint-disable meta-transactions/no-msg-sender */
+import {ERC2771Context} from "@synthetixio/core-contracts/contracts/utils/ERC2771Context.sol";
 
 contract OrderModule is IOrderModule {
     using DecimalMath for int256;
@@ -359,7 +358,11 @@ contract OrderModule is IOrderModule {
 
         // Keeper fees can be set to zero.
         if (runtime.trade.keeperFee > 0) {
-            globalConfig.synthetix.withdrawMarketUsd(marketId, msg.sender, runtime.trade.keeperFee);
+            globalConfig.synthetix.withdrawMarketUsd(
+                marketId,
+                ERC2771Context._msgSender(),
+                runtime.trade.keeperFee
+            );
         }
 
         emit OrderSettled(
@@ -467,7 +470,7 @@ contract OrderModule is IOrderModule {
         }
 
         // If `isAccountOwner` then 0 else chargeFee.
-        uint256 keeperFee = msg.sender == account.rbac.owner
+        uint256 keeperFee = ERC2771Context._msgSender() == account.rbac.owner
             ? 0
             : Order.getSettlementKeeperFee(order.keeperFeeBufferUsd);
 
@@ -476,7 +479,11 @@ contract OrderModule is IOrderModule {
                 market,
                 -keeperFee.toInt()
             );
-            globalConfig.synthetix.withdrawMarketUsd(marketId, msg.sender, keeperFee);
+            globalConfig.synthetix.withdrawMarketUsd(
+                marketId,
+                ERC2771Context._msgSender(),
+                keeperFee
+            );
         }
 
         emit OrderCanceled(accountId, marketId, keeperFee, commitmentTime);

--- a/markets/bfp-market/contracts/modules/OrderModule.sol
+++ b/markets/bfp-market/contracts/modules/OrderModule.sol
@@ -468,9 +468,9 @@ contract OrderModule is IOrderModule {
                 );
             }
         }
-        address msgSender = ERC2771Context._msgSender();
+
         // If `isAccountOwner` then 0 else chargeFee.
-        uint256 keeperFee = msgSender == account.rbac.owner
+        uint256 keeperFee = ERC2771Context._msgSender() == account.rbac.owner
             ? 0
             : Order.getSettlementKeeperFee(order.keeperFeeBufferUsd);
 
@@ -479,7 +479,11 @@ contract OrderModule is IOrderModule {
                 market,
                 -keeperFee.toInt()
             );
-            globalConfig.synthetix.withdrawMarketUsd(marketId, msgSender, keeperFee);
+            globalConfig.synthetix.withdrawMarketUsd(
+                marketId,
+                ERC2771Context._msgSender(),
+                keeperFee
+            );
         }
 
         emit OrderCanceled(accountId, marketId, keeperFee, commitmentTime);

--- a/markets/bfp-market/contracts/modules/OrderModule.sol
+++ b/markets/bfp-market/contracts/modules/OrderModule.sol
@@ -468,9 +468,9 @@ contract OrderModule is IOrderModule {
                 );
             }
         }
-
+        address msgSender = ERC2771Context._msgSender();
         // If `isAccountOwner` then 0 else chargeFee.
-        uint256 keeperFee = ERC2771Context._msgSender() == account.rbac.owner
+        uint256 keeperFee = msgSender == account.rbac.owner
             ? 0
             : Order.getSettlementKeeperFee(order.keeperFeeBufferUsd);
 
@@ -479,11 +479,7 @@ contract OrderModule is IOrderModule {
                 market,
                 -keeperFee.toInt()
             );
-            globalConfig.synthetix.withdrawMarketUsd(
-                marketId,
-                ERC2771Context._msgSender(),
-                keeperFee
-            );
+            globalConfig.synthetix.withdrawMarketUsd(marketId, msgSender, keeperFee);
         }
 
         emit OrderCanceled(accountId, marketId, keeperFee, commitmentTime);

--- a/markets/bfp-market/contracts/modules/SettlementHookModule.sol
+++ b/markets/bfp-market/contracts/modules/SettlementHookModule.sol
@@ -8,8 +8,7 @@ import {ISettlementHookModule} from "../interfaces/ISettlementHookModule.sol";
 import {ISettlementHook} from "../interfaces/hooks/ISettlementHook.sol";
 import {SettlementHookConfiguration} from "../storage/SettlementHookConfiguration.sol";
 import {ErrorUtil} from "../utils/ErrorUtil.sol";
-
-/* solhint-disable meta-transactions/no-msg-sender */
+import {ERC2771Context} from "@synthetixio/core-contracts/contracts/utils/ERC2771Context.sol";
 
 contract SettlementHookModule is ISettlementHookModule {
     // --- Mutations --- //
@@ -54,7 +53,7 @@ contract SettlementHookModule is ISettlementHookModule {
         config.whitelistedHookAddresses = data.whitelistedHookAddresses;
         config.maxHooksPerOrder = data.maxHooksPerOrder;
 
-        emit SettlementHookConfigured(msg.sender, hooksLengthAfter);
+        emit SettlementHookConfigured(ERC2771Context._msgSender(), hooksLengthAfter);
     }
 
     // --- Views --- //

--- a/markets/bfp-market/contracts/storage/Position.sol
+++ b/markets/bfp-market/contracts/storage/Position.sol
@@ -9,8 +9,7 @@ import {PerpMarketConfiguration} from "./PerpMarketConfiguration.sol";
 import {Margin} from "./Margin.sol";
 import {MathUtil} from "../utils/MathUtil.sol";
 import {ErrorUtil} from "../utils/ErrorUtil.sol";
-
-/* solhint-disable meta-transactions/no-msg-sender */
+import {ERC2771Context} from "@synthetixio/core-contracts/contracts/utils/ERC2771Context.sol";
 
 library Position {
     using DecimalMath for uint256;
@@ -353,7 +352,8 @@ library Position {
         ) = market.getRemainingLiquidatableSizeCapacity(marketConfig);
 
         if (
-            msg.sender == globalConfig.keeperLiquidationEndorsed && runtime.remainingCapacity == 0
+            ERC2771Context._msgSender() == globalConfig.keeperLiquidationEndorsed &&
+            runtime.remainingCapacity == 0
         ) {
             runtime.remainingCapacity = runtime.oldPositionSizeAbs;
         }


### PR DESCRIPTION
Use ERC2771Context_msgSender() instead of msg sender.
Except PerpRewardDistributor and mocks