### PR TITLE
Rerun failed tests only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,6 +266,22 @@ jobs:
       #CANNON_IPFS_URL: "http://127.0.0.1:5001"
     steps:
       - checkout
+
+      - run:
+          name: "Split tests"
+          command: |
+            _dir=$(yarn workspace "<< parameters.workspace >>" exec pwd)
+            echo "Workspace: $_dir"
+            cd $_dir
+
+            circleci tests glob 'test/**/*.test.ts' | circleci tests run --command="cat > /tmp/files.txt" --verbose
+
+            # if there are no tests, terminate execution after this step
+            [ -s /tmp/tests.txt ] || circleci-agent step halt
+
+      - store_artifacts:
+          path: "/tmp/files.txt"
+
       - install-foundry
       #- install-ipfs
       #- run-ipfs-daemon
@@ -307,11 +323,9 @@ jobs:
             _dir=$(yarn workspace "<< parameters.workspace >>" exec pwd)
             echo "Workspace: $_dir"
             cd $_dir
-            export TEST_FILES=$(circleci tests glob 'test/**/*.test.ts' | circleci tests split --split-by=timings)
 
-            echo "$TEST_FILES" | circleci tests run --verbose --split-by=timings --command="echo"
-
-            # node $RUNNER
+            export TEST_FILES=$(cat /tmp/files.txt)
+            node $RUNNER
 
       - store_test_results:
           path: "/tmp/junit"
@@ -557,13 +571,13 @@ workflows:
           name: "test-perps-market"
           requires: [build-testable]
           workspace: "@synthetixio/perps-market"
-          parallelism: 8
-
-      - test-contracts:
-          name: "test-bfp-market"
-          requires: [build-testable]
-          workspace: "@synthetixio/bfp-market"
           parallelism: 4
+
+  #      - test-contracts:
+  #          name: "test-bfp-market"
+  #          requires: [build-testable]
+  #          workspace: "@synthetixio/bfp-market"
+  #          parallelism: 4
 
   tests:
     unless:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,7 +308,10 @@ jobs:
             echo "Workspace: $_dir"
             cd $_dir
             export TEST_FILES=$(circleci tests glob 'test/**/*.test.ts' | circleci tests split --split-by=timings)
-            node $RUNNER
+
+            echo "$TEST_FILES" | circleci tests run --verbose --split-by=timings --command="echo"
+
+            # node $RUNNER
 
       - store_test_results:
           path: "/tmp/junit"
@@ -543,10 +546,10 @@ jobs:
 workflows:
   version: 2.1
 
-  anvil-per-test:
+  Rerun-failed-tests-only:
     when:
       or:
-        - equal: ["skip", << pipeline.git.branch >>]
+        - equal: ["Rerun-failed-tests-only", << pipeline.git.branch >>]
     jobs:
       - build-testable
 
@@ -565,7 +568,7 @@ workflows:
   tests:
     unless:
       or:
-        - equal: ["skip", << pipeline.git.branch >>]
+        - equal: ["Rerun-failed-tests-only", << pipeline.git.branch >>]
         - equal: ["update-subgraphs", << pipeline.git.branch >>]
         - equal: ["scheduled_pipeline", << pipeline.trigger_source >>]
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,7 +245,7 @@ jobs:
 
   test-contracts:
     parameters:
-      workspace:
+      dir:
         type: string
       parallelism:
         type: integer
@@ -269,15 +269,17 @@ jobs:
 
       - run:
           name: "Split tests"
+          working_directory: "<< parameters.dir >>"
           command: |
-            _dir=$(yarn workspace "<< parameters.workspace >>" exec pwd)
-            echo "Workspace: $_dir"
-            cd $_dir
-
-            circleci tests glob 'test/**/*.test.ts' | circleci tests run --command="cat > /tmp/files.txt" --verbose
-
+            circleci tests glob 'test/**/*.test.ts' | circleci tests run --command=">/tmp/tests.txt xargs echo" --verbose
             # if there are no tests, terminate execution after this step
-            [ -s /tmp/tests.txt ] || circleci-agent step halt
+            if [ -s "/tmp/tests.txt" ]; then
+              echo cat "/tmp/tests.txt"
+              cat "/tmp/tests.txt" 
+            else
+              echo "SKIP: No tests found" 
+              circleci-agent step halt
+            fi
 
       - store_artifacts:
           path: "/tmp/files.txt"
@@ -304,10 +306,11 @@ jobs:
 
       - run:
           name: "Compile TS"
-          command: yarn workspaces foreach --topological-dev --recursive --verbose --from "<< parameters.workspace >>" run build:ts
+          command: yarn workspaces foreach --topological-dev --recursive --verbose --from $(node -p "require('./package.json').name") run build:ts
 
       - run:
           name: "Run tests"
+          working_directory: "<< parameters.dir >>"
           environment:
             REPORT_GAS: true
             CANNON_REGISTRY_PRIORITY: local
@@ -317,14 +320,10 @@ jobs:
             TS_NODE_TRANSPILE_ONLY: true
             TS_NODE_TYPE_CHECK: false
           command: |
-            set -eo pipefail
-            export RUNNER=$PWD/.circleci/test-batch.js
-            export PATH=$PATH:$PWD/node_modules/.bin
-            _dir=$(yarn workspace "<< parameters.workspace >>" exec pwd)
-            echo "Workspace: $_dir"
-            cd $_dir
-
-            export TEST_FILES=$(cat /tmp/files.txt)
+            set -eou pipefail
+            export RUNNER=$HOME/project/.circleci/test-batch.js
+            export PATH=$PATH:$HOME/project/node_modules/.bin
+            export TEST_FILES=$(cat /tmp/tests.txt)
             node $RUNNER
 
       - store_test_results:
@@ -570,14 +569,14 @@ workflows:
       - test-contracts:
           name: "test-perps-market"
           requires: [build-testable]
-          workspace: "@synthetixio/perps-market"
-          parallelism: 4
+          dir: "./markets/perps-market"
+          parallelism: 8
 
-  #      - test-contracts:
-  #          name: "test-bfp-market"
-  #          requires: [build-testable]
-  #          workspace: "@synthetixio/bfp-market"
-  #          parallelism: 4
+      - test-contracts:
+          name: "test-bfp-market"
+          requires: [build-testable]
+          dir: "./markets/bfp-market"
+          parallelism: 4
 
   tests:
     unless:
@@ -597,66 +596,56 @@ workflows:
       - test-contracts:
           name: "test-main"
           requires: [build-testable]
-          workspace: "@synthetixio/main"
+          dir: "./protocol/synthetix"
           parallelism: 2
           batch-size: 8
 
       - test-contracts:
           name: "test-oracle-manager"
           requires: [build-testable]
-          workspace: "@synthetixio/oracle-manager"
+          dir: "./protocol/oracle-manager"
           parallelism: 1
           batch-size: 5
-
-      #- test-contracts: TODO: enable when we have some tests
-      #    name: "test-governance"
-      #    requires: [build-testable]
-      #    workspace: "@synthetixio/governance"
 
       - test-contracts:
           name: "test-spot-market"
           requires: [build-testable]
-          workspace: "@synthetixio/spot-market"
+          dir: "./markets/spot-market"
           parallelism: 2
           batch-size: 3
 
       - test-contracts:
           name: "test-perps-market"
           requires: [build-testable]
-          workspace: "@synthetixio/perps-market"
+          dir: "./markets/perps-market"
           parallelism: 8
           batch-size: 1
 
       - test-contracts:
           name: "test-bfp-market"
           requires: [build-testable]
-          workspace: "@synthetixio/bfp-market"
+          dir: "./markets/bfp-market"
           parallelism: 6
           batch-size: 1
 
       - test-contracts:
           name: "test-core-modules"
-          workspace: "@synthetixio/core-modules"
+          dir: "./utils/core-modules"
           parallelism: 1
           batch-size: 5
 
       - test-contracts:
           name: "test-core-contracts"
           requires: [build-testable]
-          workspace: "@synthetixio/core-contracts"
+          dir: "./utils/core-contracts"
           parallelism: 2
           batch-size: 5
 
       - test-contracts:
           name: "test-core-utils"
-          workspace: "@synthetixio/core-utils"
+          dir: "./utils/core-utils"
           parallelism: 2
           batch-size: 5
-
-      #- test-contracts: TODO: enable when tests are fixed
-      #    name: "test-legacy-market"
-      #    requires: [build-testable]
-      #    workspace: "@synthetixio/legacy-market"
 
       - test-forge:
           name: "test-rewards-distributor"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -559,10 +559,10 @@ jobs:
 workflows:
   version: 2.1
 
-  Rerun-failed-tests-only:
+  skip:
     when:
       or:
-        - equal: ["Rerun-failed-tests-only", << pipeline.git.branch >>]
+        - equal: ["skip", << pipeline.git.branch >>]
     jobs:
       - build-testable
 
@@ -581,7 +581,7 @@ workflows:
   tests:
     unless:
       or:
-        - equal: ["Rerun-failed-tests-only", << pipeline.git.branch >>]
+        - equal: ["skip", << pipeline.git.branch >>]
         - equal: ["update-subgraphs", << pipeline.git.branch >>]
         - equal: ["scheduled_pipeline", << pipeline.trigger_source >>]
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "generate-testable": "CANNON_REGISTRY_PRIORITY=local yarn workspaces foreach --all --topological-dev --verbose run generate-testable",
     "build-testable": "CANNON_REGISTRY_PRIORITY=local yarn workspaces foreach --all --topological-dev --verbose run build-testable",
     "compile-contracts": "CANNON_REGISTRY_PRIORITY=local yarn workspaces foreach --all --topological-dev --verbose run compile-contracts",
+    "build:ts": "yarn workspaces foreach --all --topological-dev --verbose run build:ts",
     "build": "CANNON_REGISTRY_PRIORITY=local yarn workspaces foreach --all --topological-dev --verbose run build",
     "test": "CANNON_REGISTRY_PRIORITY=local yarn workspaces foreach --all --parallel --verbose run test",
     "coverage": "yarn workspaces foreach --all --verbose run coverage",


### PR DESCRIPTION
Now we have ability to rerun only failed tests, skipping all the successful ones.

<img width="788" alt="_ 2024-04-19 at 21 09 47" src="https://github.com/Synthetixio/synthetix-v3/assets/28145325/af53cf14-83c9-4f12-981b-3784d462d045">

<img width="795" alt="_ 2024-04-19 at 21 11 04" src="https://github.com/Synthetixio/synthetix-v3/assets/28145325/e25ef73f-2319-4834-9862-73a4c5c901a0">

There is also an optimisation that skips the full yarn install and few more steps if there is no tests in the job, so we have an early successful exit.

<img width="785" alt="_ 2024-04-19 at 21 10 25" src="https://github.com/Synthetixio/synthetix-v3/assets/28145325/b949d09d-60b2-4ca3-a9bf-80b1bb3664b9">
