### PR TITLE
support allocation of debt by debt shares

### DIFF
--- a/markets/legacy-market/contracts/RedeemableToken.sol
+++ b/markets/legacy-market/contracts/RedeemableToken.sol
@@ -1,0 +1,102 @@
+//SPDX-License-Identifier: MIT
+pragma solidity >=0.8.11 <0.9.0;
+
+
+import "@synthetixio/core-contracts/contracts/token/ERC20.sol";
+import "@synthetixio/core-contracts/contracts/ownership/Ownable.sol";
+import "@synthetixio/core-contracts/contracts/utils/SafeCast.sol";
+import "@synthetixio/oracle-manager/contracts/interfaces/external/IExternalNode.sol";
+import "./interfaces/external/IOracleManager.sol";
+import "./interfaces/IRedeemableToken.sol";
+
+contract RedeemableToken is IExternalNode, IRedeemableToken, ERC20, Ownable {
+		using SafeCastU256 for uint256;
+		IERC20 immutable redeemedToken;
+		bytes32 immutable priceOracleNode;
+
+		mapping(address => uint256) public allowance;
+
+		struct RedemptionRecord {
+			uint128 shares;
+			uint128 redeemableTokens;
+		}
+
+		mapping(address => RedemptionRecord) public redemptions;
+		RedemptionRecord totalRedemptions;
+
+
+		constructor(address _redeemedToken, bytes32 _priceOracleNode) Ownable(msg.sender) {
+			redeemedToken = IERC20(_redeemedToken);
+			priceOracleNode = _priceOracleNode;
+		}
+
+    /**
+     * @inheritdoc IRedeemableToken
+     */
+    function addRedemption(
+        address redeemer,
+				uint256 shareAmount,
+				uint256 tokenAmount
+    ) external onlyOwner {
+			redeemedToken.transferFrom(msg.sender, address(this), tokenAmount);
+			_mint(msg.sender, shareAmount);
+
+			redemptions[redeemer].shares = shareAmount.to128();
+			redemptions[redeemer].redeemableTokens = tokenAmount.to128();
+			totalRedemptions.redeemableTokens += tokenAmount.to128();
+			totalRedemptions.shares += shareAmount.to128();
+    }
+
+    /**
+     * @inheritdoc IRedeemableToken
+     */
+    function redeem(
+				uint256 shareAmount
+    ) external onlyOwner {
+			_burn(msg.sender, shareAmount);
+
+			uint256 tokenAmount = redemptions[msg.sender].redeemableTokens * shareAmount / redemptions[msg.sender].shares;
+
+			redeemedToken.transfer(msg.sender, tokenAmount);
+
+			redemptions[msg.sender].shares -= shareAmount.to128();
+			redemptions[msg.sender].redeemableTokens -= tokenAmount.to128();
+    }
+
+    /**
+     * @inheritdoc IExternalNode
+     */
+    function process(
+        NodeOutput.Data[] memory,
+        bytes memory,
+        bytes32[] memory,
+        bytes32[] memory
+		) external view returns (NodeOutput.Data memory) {
+			NodeOutput.Data memory redeemablePrice = IOracleManager(msg.sender).process(priceOracleNode);
+
+			return NodeOutput.Data(
+				redeemablePrice.price * int256(uint256(totalRedemptions.redeemableTokens)) / int256(uint256(totalRedemptions.shares)),
+				redeemablePrice.timestamp,
+				redeemablePrice.__slotAvailableForFutureUse1, 
+				redeemablePrice.__slotAvailableForFutureUse2
+			);
+		}
+
+    /**
+     * @inheritdoc IExternalNode
+     */
+		function isValid(NodeDefinition.Data memory) external pure returns (bool) {
+			return true;
+		}
+
+    /**
+     * @inheritdoc IERC165
+     */
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(IERC165) returns (bool) {
+        return
+            interfaceId == type(IRedeemableToken).interfaceId ||
+            interfaceId == this.supportsInterface.selector;
+    }
+}

--- a/markets/legacy-market/contracts/interfaces/IExternalNode.sol
+++ b/markets/legacy-market/contracts/interfaces/IExternalNode.sol
@@ -1,0 +1,57 @@
+//SPDX-License-Identifier: MIT
+pragma solidity >=0.8.11 <0.9.0;
+
+import "@synthetixio/core-contracts/contracts/interfaces/IERC165.sol";
+
+/// @title Interface for an external node
+interface IExternalNode is IERC165 {
+    enum NodeType {
+        NONE,
+        REDUCER,
+        EXTERNAL,
+        CHAINLINK,
+        UNISWAP,
+        PYTH,
+        PRICE_DEVIATION_CIRCUIT_BREAKER,
+        STALENESS_CIRCUIT_BREAKER,
+        CONSTANT
+    }
+
+    struct NodeDefinition {
+        /**
+         * @dev Oracle node type enum
+         */
+        NodeType nodeType;
+        /**
+         * @dev Node parameters, specific to each node type
+         */
+        bytes parameters;
+        /**
+         * @dev Parent node IDs, if any
+         */
+        bytes32[] parents;
+		}
+    struct NodeOutput {
+        /**
+         * @dev Price returned from the oracle node, expressed with 18 decimals of precision
+         */
+        int256 price;
+        /**
+         * @dev Timestamp associated with the price
+         */
+        uint256 timestamp;
+        // solhint-disable-next-line private-vars-leading-underscore
+        uint256 __slotAvailableForFutureUse1;
+        // solhint-disable-next-line private-vars-leading-underscore
+        uint256 __slotAvailableForFutureUse2;
+    }
+
+    function process(
+        NodeOutput[] memory parentNodeOutputs,
+        bytes memory parameters,
+        bytes32[] memory runtimeKeys,
+        bytes32[] memory runtimeValues
+    ) external view returns (NodeOutput memory);
+
+    function isValid(NodeDefinition memory nodeDefinition) external returns (bool);
+}

--- a/markets/legacy-market/contracts/interfaces/ILegacyMarket.sol
+++ b/markets/legacy-market/contracts/interfaces/ILegacyMarket.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.11 <0.9.0;
 
 import "./external/IAddressResolver.sol";
 import "./external/IV3CoreProxy.sol";
+import "./IRedeemableToken.sol";
 
 /**
  * @title Market enabling the V3 system to back debt issued by the V2 system, migrate positions from V2 to V3, and convert stablecoins issued from V2 into stablecoins issued by V3.
@@ -84,7 +85,8 @@ interface ILegacyMarket {
      */
     function setSystemAddresses(
         IAddressResolver v2xResolverAddress,
-        IV3CoreProxy v3SystemAddress
+        IV3CoreProxy v3SystemAddress,
+				IRedeemableToken redeemableTokenAddress
     ) external returns (bool didInitialize);
 
     /**

--- a/markets/legacy-market/contracts/interfaces/IRedeemableToken.sol
+++ b/markets/legacy-market/contracts/interfaces/IRedeemableToken.sol
@@ -1,0 +1,34 @@
+//SPDX-License-Identifier: MIT
+pragma solidity >=0.8.11 <0.9.0;
+
+import "./external/IAddressResolver.sol";
+import "./external/IV3CoreProxy.sol";
+import "@synthetixio/core-contracts/contracts/interfaces/IERC20.sol";
+
+/**
+ * @title A token that can be "unwrapped" into another token by the "owner" of a 
+ * redemption turning in shares of this token. This contract is used by the LegacyMarket
+ * to enable V3 staking while keeping the proportional distribution of debt the same.
+ */
+interface IRedeemableToken is IERC20 {
+    event Redeemed(
+        address indexed redeemer,
+        uint256 sharesRedeemed,
+        uint256 tokensRedeemed
+    );
+
+    /**
+     * @notice Called by the owner of the redeemable token to mint new redeemable tokens
+		 * and set up a redemption plan
+     */
+    function addRedemption(
+        address redeemer,
+				uint256 shareAmount,
+				uint256 tokenAmount
+			) external;
+
+    /**
+		 * @notice Called by a redemption holder to grain access to their redeemed tokens
+     */
+    function redeem(uint256 sharesAmount) external;
+}

--- a/markets/legacy-market/contracts/interfaces/external/IOracleManager.sol
+++ b/markets/legacy-market/contracts/interfaces/external/IOracleManager.sol
@@ -1,0 +1,10 @@
+//SPDX-License-Identifier: MIT
+pragma solidity >=0.8.11 <0.9.0;
+
+import "@synthetixio/oracle-manager/contracts/interfaces/INodeModule.sol";
+
+/// @title Effective interface for the oracle manager
+// solhint-disable-next-line no-empty-blocks
+interface IOracleManager is INodeModule {
+
+}


### PR DESCRIPTION
we have to have v3 record debt the same way that v2x does. Before this change, v3 was using the number of SNX tokens to allocate debt.

After this change, v3 will be using debt shares (which are redeemable into their equivalent snx) for collateral. there are some restrictions:
* the pool that is connected to the legacy market can be the only pool connected
* the pool can only accept this redeemable collateral

the pool can still be used to connect to other markets, such as the bfp market, in the future, and other pools can be connected to the bfp market, but this change is necessary to ensure that debt allocations are correctly maintained.