### PR TITLE
update reward distributor to support owner override

### DIFF
--- a/protocol/synthetix/contracts/interfaces/IRewardsManagerModule.sol
+++ b/protocol/synthetix/contracts/interfaces/IRewardsManagerModule.sol
@@ -121,6 +121,28 @@ interface IRewardsManagerModule {
     ) external;
 
     /**
+     * @notice Called by owner of a pool to set rewards for vault participants. This method
+     * of reward setting is generally intended to only be used to recover from a case where the
+     * distributor state is out of sync with the core system state, or if the distributor is only
+     * able to payout and not capable of distributing its own rewards.
+     * @dev Will revert if the caller is not the owner of the pool.
+     * @param poolId The id of the pool to distribute rewards to.
+     * @param collateralType The address of the collateral used in the pool's rewards.
+     * @param rewardsDistributor The address of the reward distributor which pays out the tokens.
+     * @param amount The amount of rewards to be distributed.
+     * @param start The date at which the rewards will begin to be claimable.
+     * @param duration The period after which all distributed rewards will be claimable.
+     */
+    function distributeRewardsByOwner(
+        uint128 poolId,
+        address collateralType,
+        address rewardsDistributor,
+        uint256 amount,
+        uint64 start,
+        uint32 duration
+    ) external;
+
+    /**
      * @notice Allows a user with appropriate permissions to claim rewards associated with a position.
      * @param accountId The id of the account that is to claim the rewards.
      * @param poolId The id of the pool to claim rewards on.

--- a/protocol/synthetix/contracts/modules/core/RewardsManagerModule.sol
+++ b/protocol/synthetix/contracts/modules/core/RewardsManagerModule.sol
@@ -92,31 +92,7 @@ contract RewardsManagerModule is IRewardsManagerModule {
         uint64 start,
         uint32 duration
     ) external override {
-        Pool.Data storage pool = Pool.load(poolId);
-        SetUtil.Bytes32Set storage rewardIds = pool.vaults[collateralType].rewardIds;
-
-        // Identify the reward id for the caller, and revert if it is not a registered reward distributor.
-        bytes32 rewardId = _getRewardId(poolId, collateralType, ERC2771Context._msgSender());
-        if (!rewardIds.contains(rewardId)) {
-            revert ParameterError.InvalidParameter(
-                "poolId-collateralType-distributor",
-                "reward is not registered"
-            );
-        }
-
-        RewardDistribution.Data storage reward = pool.vaults[collateralType].rewards[rewardId];
-
-        reward.rewardPerShareD18 += reward
-            .distribute(
-                pool.vaults[collateralType].currentEpoch().accountsDebtDistribution,
-                amount.toInt(),
-                start,
-                duration
-            )
-            .toUint()
-            .to128();
-
-        emit RewardsDistributed(
+        _distributeRewards(
             poolId,
             collateralType,
             ERC2771Context._msgSender(),
@@ -124,6 +100,22 @@ contract RewardsManagerModule is IRewardsManagerModule {
             start,
             duration
         );
+    }
+
+    function distributeRewardsByOwner(
+        uint128 poolId,
+        address collateralType,
+        address rewardsDistributor,
+        uint256 amount,
+        uint64 start,
+        uint32 duration
+    ) external override {
+        Pool.Data storage pool = Pool.load(poolId);
+        if (pool.owner != ERC2771Context._msgSender()) {
+            revert AccessError.Unauthorized(ERC2771Context._msgSender());
+        }
+
+        _distributeRewards(poolId, collateralType, rewardsDistributor, amount, start, duration);
     }
 
     /**
@@ -223,6 +215,48 @@ contract RewardsManagerModule is IRewardsManagerModule {
         );
 
         return rewardAmount;
+    }
+
+    function _distributeRewards(
+        uint128 poolId,
+        address collateralType,
+        address rewardsDistributor,
+        uint256 amount,
+        uint64 start,
+        uint32 duration
+    ) internal {
+        Pool.Data storage pool = Pool.load(poolId);
+        SetUtil.Bytes32Set storage rewardIds = pool.vaults[collateralType].rewardIds;
+
+        // Identify the reward id for the caller, and revert if it is not a registered reward distributor.
+        bytes32 rewardId = _getRewardId(poolId, collateralType, rewardsDistributor);
+        if (!rewardIds.contains(rewardId)) {
+            revert ParameterError.InvalidParameter(
+                "poolId-collateralType-distributor",
+                "reward is not registered"
+            );
+        }
+
+        RewardDistribution.Data storage reward = pool.vaults[collateralType].rewards[rewardId];
+
+        reward.rewardPerShareD18 += reward
+            .distribute(
+                pool.vaults[collateralType].currentEpoch().accountsDebtDistribution,
+                amount.toInt(),
+                start,
+                duration
+            )
+            .toUint()
+            .to128();
+
+        emit RewardsDistributed(
+            poolId,
+            collateralType,
+            ERC2771Context._msgSender(),
+            amount,
+            start,
+            duration
+        );
     }
 
     /**

--- a/protocol/synthetix/test/integration/modules/core/RewardsManagerModule.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/RewardsManagerModule.test.ts
@@ -496,6 +496,43 @@ describe('RewardsManagerModule', function () {
         });
       });
     });
+
+    describe('distributeRewardsByOwner', () => {
+      before(restore);
+
+      it('reverts if not pool owner', async () => {
+        await assertRevert(
+          systems()
+            .Core.connect(await user1.getAddress())
+            .distributeRewardsByOwner(
+              poolId,
+              collateralAddress(),
+              RewardDistributor.address,
+              rewardAmount,
+              0, // timestamp
+              0
+            ),
+          `Unauthorized("${await user1.getAddress()}")`
+        );
+      });
+
+      it('reverts if RD does not exist', async () => {
+        await assertRevert(
+          systems()
+            .Core.connect(owner)
+            .distributeRewardsByOwner(
+              poolId,
+              collateralAddress(),
+              await user1.getAddress(),
+              rewardAmount,
+              0, // timestamp
+              0
+            ),
+          'InvalidParameter("poolId-collateralType-distributor", "reward is not registered")'
+        );
+      });
+    });
+
     describe('wallets joining and leaving', () => {});
   });
 


### PR DESCRIPTION
adds a new method to rewards manager module, `distributeRewardsByOwner`, which allows for an owner of the pool to change the rewards distribution setting outside of RD operation.

notes:
* it was previously intended that RD should always drive the distribution settings on the core system. however, there doesn't seem to be any downsides in allowing pool owner to have control over the distribution as well, and can provide a helpful lever in recovering from errorneous situations such as these
* renamed the function instead of overdubbing the same method to prevent confusion in function, since there are a lot of params for both and they look similar.
* tests added