### PR TITLE
Add snxUSD collateral to minCredit

### DIFF
--- a/markets/perps-market/contracts/interfaces/IGlobalPerpsMarketModule.sol
+++ b/markets/perps-market/contracts/interfaces/IGlobalPerpsMarketModule.sol
@@ -175,6 +175,15 @@ interface IGlobalPerpsMarketModule {
     function totalGlobalCollateralValue() external view returns (uint256 totalCollateralValue);
 
     /**
+     * @notice Gets the total collateral value of all deposited collateral from all traders.
+     * @param collateralId the id of the collateral (0 for snxUSD)
+     * @return collateralValue value of all collateral for collateral id
+     */
+    function globalCollateralValue(
+        uint128 collateralId
+    ) external view returns (uint256 collateralValue);
+
+    /**
      * @notice Sets the fee collector contract.
      * @dev must conform to the IFeeCollector interface
      * @param feeCollector address of the fee collector contract

--- a/markets/perps-market/contracts/modules/GlobalPerpsMarketModule.sol
+++ b/markets/perps-market/contracts/modules/GlobalPerpsMarketModule.sol
@@ -146,6 +146,15 @@ contract GlobalPerpsMarketModule is IGlobalPerpsMarketModule {
     /**
      * @inheritdoc IGlobalPerpsMarketModule
      */
+    function globalCollateralValue(
+        uint128 collateralId
+    ) external view override returns (uint256 collateralValue) {
+        return GlobalPerpsMarket.load().collateralAmounts[collateralId];
+    }
+
+    /**
+     * @inheritdoc IGlobalPerpsMarketModule
+     */
     function setFeeCollector(address feeCollector) external override {
         OwnableStorage.onlyOwner();
         if (feeCollector != address(0)) {

--- a/markets/perps-market/contracts/storage/GlobalPerpsMarket.sol
+++ b/markets/perps-market/contracts/storage/GlobalPerpsMarket.sol
@@ -94,6 +94,9 @@ library GlobalPerpsMarket {
 
             accumulatedMinimumCredit += PerpsMarket.requiredCredit(marketId);
         }
+
+        // add the sUSD collateral value to the minimum credit since it's used as escrow
+        accumulatedMinimumCredit += self.collateralAmounts[SNX_USD_MARKET_ID];
     }
 
     function totalCollateralValue(Data storage self) internal view returns (uint256 total) {

--- a/markets/perps-market/test/integration/Market/Market.minimumCredit.test.ts
+++ b/markets/perps-market/test/integration/Market/Market.minimumCredit.test.ts
@@ -49,9 +49,9 @@ describe('Market Minimum Credit', () => {
   });
 
   describe('with no positions', () => {
-    it('should report total minimumCredit as zero', async () => {
+    it('should report total minimumCredit as snxUSD value owed to traders', async () => {
       const minimumCredit = await systems().PerpsMarket.minimumCredit(superMarketId());
-      assertBn.equal(minimumCredit, bn(0));
+      assertBn.equal(minimumCredit, bn(20_000));
     });
   });
 
@@ -87,7 +87,12 @@ describe('Market Minimum Credit', () => {
       const ethExpectedMinCredit = wei(150).mul(_ETH_PRICE).mul(wei(0.01)); // size * price * lockedOiRatio
       const btcExpectedMinCredit = wei(5).mul(_BTC_PRICE).mul(wei(0.02));
 
-      assertBn.equal(minimumCredit, ethExpectedMinCredit.add(btcExpectedMinCredit).bn);
+      const snxUSDDeposited = await systems().PerpsMarket.globalCollateralValue(0);
+
+      assertBn.equal(
+        minimumCredit,
+        ethExpectedMinCredit.add(btcExpectedMinCredit).add(snxUSDDeposited).bn
+      );
     });
   });
 });


### PR DESCRIPTION
- snxUSD is escrowed in the core system and is added to the credit capacity which is what is compared with minimumCredit to determine the capacity required for the market.
- in this PR, we account for this by adding the snxUSD owed to traders to minimumCredit


- [x] ~Requires SIP~ https://sips.synthetix.io/sips/sip-390/