### PR TITLE
Gas optimisations

### DIFF
--- a/markets/bfp-market/cannonfile.test.toml
+++ b/markets/bfp-market/cannonfile.test.toml
@@ -31,6 +31,7 @@ args = [120, 1] # 120s, 1wei
 [contract.OrderModule]
 artifact = "OrderModule"
 args = [
+    "<%= imports.synthetix.contracts.CoreProxy.address %>",
     "<%= imports.synthetix.contracts.USDProxy.address %>",
     "<%= imports.synthetix.imports.oracle_manager.contracts.Proxy.address %>",
 ]
@@ -38,6 +39,7 @@ args = [
 [contract.LiquidationModule]
 artifact = "LiquidationModule"
 args = [
+    "<%= imports.synthetix.contracts.CoreProxy.address %>",
     "<%= imports.synthetix.contracts.USDProxy.address %>",
     "<%= imports.synthetix.imports.oracle_manager.contracts.Proxy.address %>",
 ]
@@ -45,6 +47,7 @@ args = [
 [contract.PerpMarketFactoryModule]
 artifact = "PerpMarketFactoryModule"
 args = [
+    "<%= imports.synthetix.contracts.CoreProxy.address %>",
     "<%= imports.synthetix.contracts.USDProxy.address %>",
     "<%= imports.synthetix.imports.oracle_manager.contracts.Proxy.address %>",
 ]
@@ -63,13 +66,14 @@ args = [
 [contract.MarginModule]
 artifact = "MarginModule"
 args = [
+    "<%= imports.synthetix.contracts.CoreProxy.address %>",
     "<%= imports.synthetix.contracts.USDProxy.address %>",
     "<%= imports.synthetix.imports.oracle_manager.contracts.Proxy.address %>",
 ]
 
 [contract.PerpRewardDistributorFactoryModule]
 artifact = "contracts/modules/PerpRewardDistributorModule/PerpRewardDistributorFactoryModule.sol:PerpRewardDistributorFactoryModule"
-args = []
+args = ["<%= imports.synthetix.contracts.CoreProxy.address %>"]
 
 [contract.FeatureFlagModule]
 artifact = "contracts/modules/FeatureFlagModule.sol:FeatureFlagModule"
@@ -207,12 +211,6 @@ args = ["<%= contracts.InitialBfpMarketProxy.address %>"]
 salt = "3"
 
 # --- Market Post BFP Deployment Configuration --- #
-
-[invoke.set_synthetix]
-target = ["BfpMarketProxy"]
-fromCall.func = "owner"
-func = "setSynthetix"
-args = ["<%= imports.synthetix.contracts.CoreProxy.address %>"]
 
 [invoke.set_pyth]
 target = ["BfpMarketProxy"]

--- a/markets/bfp-market/cannonfile.test.toml
+++ b/markets/bfp-market/cannonfile.test.toml
@@ -30,15 +30,24 @@ args = [120, 1] # 120s, 1wei
 
 [contract.OrderModule]
 artifact = "OrderModule"
-args = ["<%= imports.synthetix.contracts.USDProxy.address %>"]
+args = [
+    "<%= imports.synthetix.contracts.USDProxy.address %>",
+    "<%= imports.synthetix.imports.oracle_manager.contracts.Proxy.address %>",
+]
 
 [contract.LiquidationModule]
 artifact = "LiquidationModule"
-args = ["<%= imports.synthetix.contracts.USDProxy.address %>"]
+args = [
+    "<%= imports.synthetix.contracts.USDProxy.address %>",
+    "<%= imports.synthetix.imports.oracle_manager.contracts.Proxy.address %>",
+]
 
 [contract.PerpMarketFactoryModule]
 artifact = "PerpMarketFactoryModule"
-args = ["<%= imports.synthetix.contracts.USDProxy.address %>"]
+args = [
+    "<%= imports.synthetix.contracts.USDProxy.address %>",
+    "<%= imports.synthetix.imports.oracle_manager.contracts.Proxy.address %>",
+]
 
 [contract.MarketConfigurationModule]
 artifact = "MarketConfigurationModule"
@@ -46,11 +55,17 @@ args = []
 
 [contract.PerpAccountModule]
 artifact = "PerpAccountModule"
-args = ["<%= imports.synthetix.contracts.USDProxy.address %>"]
+args = [
+    "<%= imports.synthetix.contracts.USDProxy.address %>",
+    "<%= imports.synthetix.imports.oracle_manager.contracts.Proxy.address %>",
+]
 
 [contract.MarginModule]
 artifact = "MarginModule"
-args = ["<%= imports.synthetix.contracts.USDProxy.address %>"]
+args = [
+    "<%= imports.synthetix.contracts.USDProxy.address %>",
+    "<%= imports.synthetix.imports.oracle_manager.contracts.Proxy.address %>",
+]
 
 [contract.PerpRewardDistributorFactoryModule]
 artifact = "contracts/modules/PerpRewardDistributorModule/PerpRewardDistributorFactoryModule.sol:PerpRewardDistributorFactoryModule"

--- a/markets/bfp-market/cannonfile.test.toml
+++ b/markets/bfp-market/cannonfile.test.toml
@@ -38,7 +38,7 @@ args = ["<%= imports.synthetix.contracts.USDProxy.address %>"]
 
 [contract.PerpMarketFactoryModule]
 artifact = "PerpMarketFactoryModule"
-args = []
+args = ["<%= imports.synthetix.contracts.USDProxy.address %>"]
 
 [contract.MarketConfigurationModule]
 artifact = "MarketConfigurationModule"

--- a/markets/bfp-market/cannonfile.toml
+++ b/markets/bfp-market/cannonfile.toml
@@ -26,15 +26,24 @@ preset = "<%= settings.synthetixPreset %>"
 
 [contract.OrderModule]
 artifact = "OrderModule"
-args = ["<%= imports.synthetix.contracts.USDProxy.address %>"]
+args = [
+    "<%= imports.synthetix.contracts.USDProxy.address %>",
+    "<%= imports.synthetix.imports.oracle_manager.contracts.Proxy.address %>",
+]
 
 [contract.LiquidationModule]
 artifact = "LiquidationModule"
-args = ["<%= imports.synthetix.contracts.USDProxy.address %>"]
+args = [
+    "<%= imports.synthetix.contracts.USDProxy.address %>",
+    "<%= imports.synthetix.imports.oracle_manager.contracts.Proxy.address %>",
+]
 
 [contract.PerpMarketFactoryModule]
 artifact = "PerpMarketFactoryModule"
-args = ["<%= imports.synthetix.contracts.USDProxy.address %>"]
+args = [
+    "<%= imports.synthetix.contracts.USDProxy.address %>",
+    "<%= imports.synthetix.imports.oracle_manager.contracts.Proxy.address %>",
+]
 
 [contract.MarketConfigurationModule]
 artifact = "MarketConfigurationModule"
@@ -42,11 +51,17 @@ args = []
 
 [contract.PerpAccountModule]
 artifact = "PerpAccountModule"
-args = ["<%= imports.synthetix.contracts.USDProxy.address %>"]
+args = [
+    "<%= imports.synthetix.contracts.USDProxy.address %>",
+    "<%= imports.synthetix.imports.oracle_manager.contracts.Proxy.address %>",
+]
 
 [contract.MarginModule]
 artifact = "MarginModule"
-args = ["<%= imports.synthetix.contracts.USDProxy.address %>"]
+args = [
+    "<%= imports.synthetix.contracts.USDProxy.address %>",
+    "<%= imports.synthetix.imports.oracle_manager.contracts.Proxy.address %>",
+]
 
 [contract.PerpRewardDistributorFactoryModule]
 artifact = "contracts/modules/PerpRewardDistributorModule/PerpRewardDistributorFactoryModule.sol:PerpRewardDistributorFactoryModule"

--- a/markets/bfp-market/cannonfile.toml
+++ b/markets/bfp-market/cannonfile.toml
@@ -34,7 +34,7 @@ args = ["<%= imports.synthetix.contracts.USDProxy.address %>"]
 
 [contract.PerpMarketFactoryModule]
 artifact = "PerpMarketFactoryModule"
-args = []
+args = ["<%= imports.synthetix.contracts.USDProxy.address %>"]
 
 [contract.MarketConfigurationModule]
 artifact = "MarketConfigurationModule"

--- a/markets/bfp-market/cannonfile.toml
+++ b/markets/bfp-market/cannonfile.toml
@@ -27,6 +27,7 @@ preset = "<%= settings.synthetixPreset %>"
 [contract.OrderModule]
 artifact = "OrderModule"
 args = [
+    "<%= imports.synthetix.contracts.CoreProxy.address %>",
     "<%= imports.synthetix.contracts.USDProxy.address %>",
     "<%= imports.synthetix.imports.oracle_manager.contracts.Proxy.address %>",
 ]
@@ -34,6 +35,7 @@ args = [
 [contract.LiquidationModule]
 artifact = "LiquidationModule"
 args = [
+    "<%= imports.synthetix.contracts.CoreProxy.address %>",
     "<%= imports.synthetix.contracts.USDProxy.address %>",
     "<%= imports.synthetix.imports.oracle_manager.contracts.Proxy.address %>",
 ]
@@ -41,6 +43,7 @@ args = [
 [contract.PerpMarketFactoryModule]
 artifact = "PerpMarketFactoryModule"
 args = [
+    "<%= imports.synthetix.contracts.CoreProxy.address %>",
     "<%= imports.synthetix.contracts.USDProxy.address %>",
     "<%= imports.synthetix.imports.oracle_manager.contracts.Proxy.address %>",
 ]
@@ -59,13 +62,14 @@ args = [
 [contract.MarginModule]
 artifact = "MarginModule"
 args = [
+    "<%= imports.synthetix.contracts.CoreProxy.address %>",
     "<%= imports.synthetix.contracts.USDProxy.address %>",
     "<%= imports.synthetix.imports.oracle_manager.contracts.Proxy.address %>",
 ]
 
 [contract.PerpRewardDistributorFactoryModule]
 artifact = "contracts/modules/PerpRewardDistributorModule/PerpRewardDistributorFactoryModule.sol:PerpRewardDistributorFactoryModule"
-args = []
+args = ["<%= imports.synthetix.contracts.CoreProxy.address %>"]
 
 [contract.FeatureFlagModule]
 artifact = "contracts/modules/FeatureFlagModule.sol:FeatureFlagModule"

--- a/markets/bfp-market/contracts/interfaces/IPerpMarketFactoryModule.sol
+++ b/markets/bfp-market/contracts/interfaces/IPerpMarketFactoryModule.sol
@@ -71,10 +71,6 @@ interface IPerpMarketFactoryModule is IMarket, IBasePerpMarket {
 
     // --- Mutations --- //
 
-    /// @notice Stores a reference to the Synthetix core system.
-    /// @param synthetix Address of core Synthetix proxy
-    function setSynthetix(ISynthetixSystem synthetix) external;
-
     /// @notice Stores a reference to the Pyth EVM contract.
     /// @param pyth Address of Pyth verification contract
     function setPyth(IPyth pyth) external;

--- a/markets/bfp-market/contracts/modules/LiquidationModule.sol
+++ b/markets/bfp-market/contracts/modules/LiquidationModule.sol
@@ -87,7 +87,7 @@ contract LiquidationModule is ILiquidationModule {
 
         emit MarketSizeUpdated(marketId, updatedMarketSize, updatedMarketSkew);
 
-        (uint256 utilizationRate, ) = market.recomputeUtilization(oraclePrice);
+        (uint256 utilizationRate, ) = market.recomputeUtilization(oraclePrice, SYNTHETIX_SUSD);
         emit UtilizationRecomputed(marketId, market.skew, utilizationRate);
 
         // Update market debt relative to the keeperFee incurred.
@@ -224,7 +224,8 @@ contract LiquidationModule is ILiquidationModule {
         Margin.MarginValues memory marginValues = Margin.getMarginUsd(
             accountId,
             market,
-            oraclePrice
+            oraclePrice,
+            SYNTHETIX_SUSD
         );
 
         // Cannot flag for liquidation unless they are liquidatable.
@@ -332,7 +333,8 @@ contract LiquidationModule is ILiquidationModule {
         Margin.MarginValues memory marginValues = Margin.getMarginUsd(
             accountId,
             market,
-            market.getOraclePrice()
+            market.getOraclePrice(),
+            SYNTHETIX_SUSD
         );
         if (
             marginValues.collateralUsd == 0 ||
@@ -390,7 +392,8 @@ contract LiquidationModule is ILiquidationModule {
         Margin.MarginValues memory marginValues = Margin.getMarginUsd(
             accountId,
             market,
-            oraclePrice
+            oraclePrice,
+            SYNTHETIX_SUSD
         );
         uint256 ethPrice = globalConfig
             .oracleManager
@@ -442,7 +445,7 @@ contract LiquidationModule is ILiquidationModule {
                 market,
                 oraclePrice,
                 PerpMarketConfiguration.load(marketId),
-                Margin.getMarginUsd(accountId, market, oraclePrice)
+                Margin.getMarginUsd(accountId, market, oraclePrice, SYNTHETIX_SUSD)
             );
     }
 
@@ -457,7 +460,8 @@ contract LiquidationModule is ILiquidationModule {
         Margin.MarginValues memory marginValues = Margin.getMarginUsd(
             accountId,
             market,
-            market.getOraclePrice()
+            market.getOraclePrice(),
+            SYNTHETIX_SUSD
         );
 
         if (marginValues.collateralUsd == 0) {
@@ -478,11 +482,16 @@ contract LiquidationModule is ILiquidationModule {
         PerpMarketConfiguration.Data storage marketConfig = PerpMarketConfiguration.load(marketId);
 
         uint256 oraclePrice = market.getOraclePrice();
-
+        (uint256 collateralUsd, ) = Margin.getCollateralUsd(
+            accountId,
+            marketId,
+            SYNTHETIX_SUSD,
+            PerpMarketConfiguration.load()
+        );
         (im, mm, ) = Position.getLiquidationMarginUsd(
             market.positions[accountId].size + sizeDelta,
             oraclePrice,
-            Margin.getMarginUsd(accountId, market, oraclePrice).collateralUsd,
+            collateralUsd,
             marketConfig
         );
     }
@@ -504,7 +513,7 @@ contract LiquidationModule is ILiquidationModule {
             position.entryUtilizationAccrued,
             oraclePrice,
             PerpMarketConfiguration.load(marketId),
-            Margin.getMarginUsd(accountId, market, oraclePrice)
+            Margin.getMarginUsd(accountId, market, oraclePrice, SYNTHETIX_SUSD)
         );
         return healthData.healthFactor;
     }

--- a/markets/bfp-market/contracts/modules/MarginModule.sol
+++ b/markets/bfp-market/contracts/modules/MarginModule.sol
@@ -62,7 +62,8 @@ contract MarginModule is IMarginModule {
         Margin.MarginValues memory marginValues = Margin.getMarginUsd(
             accountId,
             market,
-            oraclePrice
+            oraclePrice,
+            SYNTHETIX_SUSD
         );
 
         // Make sure margin isn't liquidatable due to debt.
@@ -201,7 +202,7 @@ contract MarginModule is IMarginModule {
             market.getCurrentFundingVelocity()
         );
 
-        (uint256 utilizationRate, ) = market.recomputeUtilization(oraclePrice);
+        (uint256 utilizationRate, ) = market.recomputeUtilization(oraclePrice, SYNTHETIX_SUSD);
         emit UtilizationRecomputed(marketId, market.skew, utilizationRate);
 
         Margin.GlobalData storage globalMarginConfig = Margin.load();
@@ -286,7 +287,7 @@ contract MarginModule is IMarginModule {
             market.getCurrentFundingVelocity()
         );
 
-        (uint256 utilizationRate, ) = market.recomputeUtilization(oraclePrice);
+        (uint256 utilizationRate, ) = market.recomputeUtilization(oraclePrice, SYNTHETIX_SUSD);
         emit UtilizationRecomputed(marketId, market.skew, utilizationRate);
 
         // > 0 is a deposit whilst < 0 is a withdrawal.
@@ -553,7 +554,7 @@ contract MarginModule is IMarginModule {
     ) external view returns (Margin.MarginValues memory) {
         Account.exists(accountId);
         PerpMarket.Data storage market = PerpMarket.exists(marketId);
-        return Margin.getMarginUsd(accountId, market, market.getOraclePrice());
+        return Margin.getMarginUsd(accountId, market, market.getOraclePrice(), SYNTHETIX_SUSD);
     }
 
     /// @inheritdoc IMarginModule
@@ -568,7 +569,8 @@ contract MarginModule is IMarginModule {
             Margin.getNetAssetValue(
                 accountId,
                 market,
-                oraclePrice == 0 ? market.getOraclePrice() : oraclePrice
+                oraclePrice == 0 ? market.getOraclePrice() : oraclePrice,
+                SYNTHETIX_SUSD
             );
     }
 
@@ -584,10 +586,15 @@ contract MarginModule is IMarginModule {
         return
             Margin.getDiscountedCollateralPrice(
                 amount,
-                globalMarginConfig.getCollateralPrice(collateralAddress, globalMarketConfig),
+                globalMarginConfig.getCollateralPrice(
+                    collateralAddress,
+                    globalMarketConfig,
+                    SYNTHETIX_SUSD
+                ),
                 collateralAddress,
                 globalMarketConfig,
-                globalMarginConfig
+                globalMarginConfig,
+                SYNTHETIX_SUSD
             );
     }
 
@@ -603,7 +610,8 @@ contract MarginModule is IMarginModule {
         Margin.MarginValues memory marginValues = Margin.getMarginUsd(
             accountId,
             market,
-            oraclePrice
+            oraclePrice,
+            SYNTHETIX_SUSD
         );
         Position.Data storage position = market.positions[accountId];
         int128 size = position.size;
@@ -645,7 +653,7 @@ contract MarginModule is IMarginModule {
 
         return
             Margin.getMarginLiquidationOnlyReward(
-                Margin.getCollateralUsdWithoutDiscount(accountId, marketId),
+                Margin.getCollateralUsdWithoutDiscount(accountId, marketId, SYNTHETIX_SUSD),
                 PerpMarketConfiguration.load(marketId),
                 PerpMarketConfiguration.load()
             );

--- a/markets/bfp-market/contracts/modules/OrderModule.sol
+++ b/markets/bfp-market/contracts/modules/OrderModule.sol
@@ -166,7 +166,7 @@ contract OrderModule is IOrderModule {
 
     /// @dev Generic helper for utilization recomputation during order management.
     function recomputeUtilization(PerpMarket.Data storage market, uint256 price) private {
-        (uint256 utilizationRate, ) = market.recomputeUtilization(price);
+        (uint256 utilizationRate, ) = market.recomputeUtilization(price, SYNTHETIX_SUSD);
         emit UtilizationRecomputed(market.id, market.skew, utilizationRate);
     }
 
@@ -231,7 +231,8 @@ contract OrderModule is IOrderModule {
                 marketConfig.takerFee,
                 limitPrice,
                 keeperFeeBufferUsd
-            )
+            ),
+            SYNTHETIX_SUSD
         );
 
         market.orders[accountId].update(
@@ -299,7 +300,7 @@ contract OrderModule is IOrderModule {
         );
         recomputeFunding(market, runtime.params.oraclePrice);
 
-        runtime.trade = Position.validateTrade(accountId, market, runtime.params);
+        runtime.trade = Position.validateTrade(accountId, market, runtime.params, SYNTHETIX_SUSD);
 
         runtime.updatedMarketSize = (market.size.to256() +
             MathUtil.abs(runtime.trade.newPosition.size) -

--- a/markets/bfp-market/contracts/modules/PerpRewardDistributorModule/PerpRewardDistributorFactoryModule.sol
+++ b/markets/bfp-market/contracts/modules/PerpRewardDistributorModule/PerpRewardDistributorFactoryModule.sol
@@ -13,6 +13,14 @@ import {ErrorUtil} from "../../utils/ErrorUtil.sol";
 contract PerpRewardDistributorFactoryModule is IPerpRewardDistributorFactoryModule {
     using Clones for address;
 
+    // --- Immutables --- //
+
+    address immutable SYNTHETIX_CORE;
+
+    constructor(address _synthetix_core) {
+        SYNTHETIX_CORE = _synthetix_core;
+    }
+
     // --- Mutations --- //
 
     /// @inheritdoc IPerpRewardDistributorFactoryModule
@@ -50,7 +58,7 @@ contract PerpRewardDistributorFactoryModule is IPerpRewardDistributorFactoryModu
         address distributorAddress = globalConfig.rewardDistributorImplementation.clone();
         IPerpRewardDistributor distributor = IPerpRewardDistributor(distributorAddress);
         distributor.initialize(
-            address(globalConfig.synthetix),
+            SYNTHETIX_CORE,
             address(this),
             data.poolId,
             data.collateralTypes,

--- a/markets/bfp-market/contracts/storage/Margin.sol
+++ b/markets/bfp-market/contracts/storage/Margin.sol
@@ -52,6 +52,7 @@ library Margin {
         address collateralAddress;
         uint256 available;
         uint256 collateralPrice;
+        uint256 i;
     }
 
     // --- Storage --- //
@@ -141,34 +142,33 @@ library Margin {
 
     /// @dev Returns the "raw" margin in USD before fees, `sum(p.collaterals.map(c => c.amount * c.price))`.
     function getCollateralUsd(
-        uint128 accountId,
-        uint128 marketId,
         address sUsdAddress,
+        address oracleManagerAddress,
+        Margin.Data storage accountMargin,
         PerpMarketConfiguration.GlobalData storage globalConfig
     ) internal view returns (uint256 collateralUsd, uint256 discountedCollateralUsd) {
         Margin.GlobalData storage globalMarginConfig = Margin.load();
-        Margin.Data storage accountMargin = Margin.load(accountId, marketId);
 
         Runtime_getCollateralUsd memory runtime;
 
-        for (uint256 i = 0; i < globalMarginConfig.supportedCollaterals.length; ) {
-            runtime.collateralAddress = globalMarginConfig.supportedCollaterals[i];
+        for (runtime.i = 0; runtime.i < globalMarginConfig.supportedCollaterals.length; ) {
+            runtime.collateralAddress = globalMarginConfig.supportedCollaterals[runtime.i];
             runtime.available = accountMargin.collaterals[runtime.collateralAddress];
 
             // `getCollateralPrice()` is an expensive op, skip if we can.
             if (runtime.available > 0) {
-                uint256 collateralPrice = getCollateralPrice(
+                runtime.collateralPrice = getCollateralPrice(
                     globalMarginConfig,
                     runtime.collateralAddress,
-                    globalConfig,
+                    oracleManagerAddress,
                     sUsdAddress
                 );
 
-                collateralUsd += runtime.available.mulDecimal(collateralPrice);
+                collateralUsd += runtime.available.mulDecimal(runtime.collateralPrice);
                 discountedCollateralUsd += runtime.available.mulDecimal(
                     getDiscountedCollateralPrice(
                         runtime.available,
-                        collateralPrice,
+                        runtime.collateralPrice,
                         runtime.collateralAddress,
                         globalConfig,
                         globalMarginConfig,
@@ -177,7 +177,7 @@ library Margin {
                 );
             }
             unchecked {
-                ++i;
+                ++runtime.i;
             }
         }
     }
@@ -221,12 +221,13 @@ library Margin {
         uint128 accountId,
         PerpMarket.Data storage market,
         uint256 price,
-        address SYNTHETIX_SUSD
+        address sUsdAddress,
+        address oracleManagerAddress
     ) internal view returns (MarginValues memory marginValues) {
         (uint256 collateralUsd, uint256 discountedCollateralUsd) = getCollateralUsd(
-            accountId,
-            market.id,
-            SYNTHETIX_SUSD,
+            sUsdAddress,
+            oracleManagerAddress,
+            Margin.load(accountId, market.id),
             PerpMarketConfiguration.load()
         );
         int256 adjustment = getPnlAdjustmentUsd(accountId, market, price, price);
@@ -273,13 +274,11 @@ library Margin {
      * you need both discounted and non-discounted values, sometimes you only need non-discounted.
      */
     function getCollateralUsdWithoutDiscount(
-        uint128 accountId,
-        uint128 marketId,
-        address sUsdAddress
+        address sUsdAddress,
+        address oracleManagerAddress,
+        Margin.Data storage accountMargin
     ) internal view returns (uint256) {
-        PerpMarketConfiguration.GlobalData storage globalConfig = PerpMarketConfiguration.load();
         Margin.GlobalData storage globalMarginConfig = Margin.load();
-        Margin.Data storage accountMargin = Margin.load(accountId, marketId);
 
         uint256 length = globalMarginConfig.supportedCollaterals.length;
         address collateralAddress;
@@ -295,7 +294,7 @@ library Margin {
                 collateralPrice = getCollateralPrice(
                     globalMarginConfig,
                     collateralAddress,
-                    globalConfig,
+                    oracleManagerAddress,
                     sUsdAddress
                 );
                 collateralUsd += available.mulDecimal(collateralPrice);
@@ -312,13 +311,17 @@ library Margin {
         uint128 accountId,
         PerpMarket.Data storage market,
         uint256 price,
-        address SYNTHETIX_SUSD
+        address sUsdAddress,
+        address oracleManagerAddress
     ) internal view returns (uint256) {
         return
             MathUtil
                 .max(
-                    getCollateralUsdWithoutDiscount(accountId, market.id, SYNTHETIX_SUSD).toInt() +
-                        getPnlAdjustmentUsd(accountId, market, price, price),
+                    getCollateralUsdWithoutDiscount(
+                        sUsdAddress,
+                        oracleManagerAddress,
+                        Margin.load(accountId, market.id)
+                    ).toInt() + getPnlAdjustmentUsd(accountId, market, price, price),
                     0
                 )
                 .toUint();
@@ -330,11 +333,10 @@ library Margin {
     function getOracleCollateralPrice(
         Margin.GlobalData storage self,
         address collateralAddress,
-        PerpMarketConfiguration.GlobalData storage globalConfig
+        address oracleManagerAddress
     ) internal view returns (uint256) {
         return
-            globalConfig
-                .oracleManager
+            INodeModule(oracleManagerAddress)
                 .process(self.supported[collateralAddress].oracleNodeId)
                 .price
                 .toUint();
@@ -344,13 +346,13 @@ library Margin {
     function getCollateralPrice(
         Margin.GlobalData storage self,
         address collateralAddress,
-        PerpMarketConfiguration.GlobalData storage globalConfig,
+        address oracleManagerAddress,
         address sUsdAddress
     ) internal view returns (uint256) {
         return
             collateralAddress == sUsdAddress
                 ? DecimalMath.UNIT
-                : getOracleCollateralPrice(self, collateralAddress, globalConfig);
+                : getOracleCollateralPrice(self, collateralAddress, oracleManagerAddress);
     }
 
     /**
@@ -395,11 +397,11 @@ library Margin {
     /// @dev Returns the reward for liquidating margin.
     function getMarginLiquidationOnlyReward(
         uint256 collateralValue,
+        address oracleManagerAddress,
         PerpMarketConfiguration.Data storage marketConfig,
         PerpMarketConfiguration.GlobalData storage globalConfig
     ) internal view returns (uint256) {
-        uint256 ethPrice = globalConfig
-            .oracleManager
+        uint256 ethPrice = INodeModule(oracleManagerAddress)
             .process(globalConfig.ethOracleNodeId)
             .price
             .toUint();
@@ -422,6 +424,7 @@ library Margin {
     /// @dev Returns whether an account in a specific market's margin can be liquidated.
     function isMarginLiquidatable(
         uint128 accountId,
+        address oracleManagerAddress,
         PerpMarket.Data storage market,
         Margin.MarginValues memory marginValues
     ) internal view returns (bool) {
@@ -434,6 +437,7 @@ library Margin {
             marginValues.discountedMarginUsd.toInt() -
                 getMarginLiquidationOnlyReward(
                     marginValues.collateralUsd,
+                    oracleManagerAddress,
                     PerpMarketConfiguration.load(market.id),
                     PerpMarketConfiguration.load()
                 ).toInt() <=

--- a/markets/bfp-market/contracts/storage/Order.sol
+++ b/markets/bfp-market/contracts/storage/Order.sol
@@ -99,14 +99,12 @@ library Order {
      *
      * See IOrderModule.getOrderFees for more details.
      */
-    function getSettlementKeeperFee(uint256 keeperFeeBufferUsd) internal view returns (uint256) {
+    function getSettlementKeeperFee(
+        uint256 keeperFeeBufferUsd,
+        uint256 ethPrice
+    ) internal view returns (uint256) {
         PerpMarketConfiguration.GlobalData storage globalConfig = PerpMarketConfiguration.load();
 
-        uint256 ethPrice = globalConfig
-            .oracleManager
-            .process(globalConfig.ethOracleNodeId)
-            .price
-            .toUint();
         uint256 baseKeeperFeeUsd = ethPrice.mulDecimal(
             globalConfig.keeperSettlementGasUnits * block.basefee
         );
@@ -121,14 +119,9 @@ library Order {
     }
 
     /// @dev Returns the keeper fee in USD for order cancellations.
-    function getCancellationKeeperFee() internal view returns (uint256) {
+    function getCancellationKeeperFee(uint256 ethPrice) internal view returns (uint256) {
         PerpMarketConfiguration.GlobalData storage globalConfig = PerpMarketConfiguration.load();
 
-        uint256 ethPrice = globalConfig
-            .oracleManager
-            .process(globalConfig.ethOracleNodeId)
-            .price
-            .toUint();
         uint256 baseKeeperFeeUsd = ethPrice.mulDecimal(
             globalConfig.keeperCancellationGasUnits * block.basefee
         );

--- a/markets/bfp-market/contracts/storage/PerpMarketConfiguration.sol
+++ b/markets/bfp-market/contracts/storage/PerpMarketConfiguration.sol
@@ -15,8 +15,6 @@ library PerpMarketConfiguration {
     struct GlobalData {
         /// A reference to the core Synthetix v3 system.
         ISynthetixSystem synthetix;
-        /// A reference to the Synthetix USD stablecoin.
-        ITokenModule usdToken;
         /// A reference to the Synthetix oracle manager (used to fetch market prices).
         INodeModule oracleManager;
         /// A reference to the Pyth EVM contract.

--- a/markets/bfp-market/contracts/storage/PerpMarketConfiguration.sol
+++ b/markets/bfp-market/contracts/storage/PerpMarketConfiguration.sol
@@ -13,8 +13,6 @@ library PerpMarketConfiguration {
     // --- Storage --- //
 
     struct GlobalData {
-        /// A reference to the core Synthetix v3 system.
-        ISynthetixSystem synthetix;
         /// A reference to the Pyth EVM contract.
         IPyth pyth;
         /// Oracle node id for for eth/usd.

--- a/markets/bfp-market/contracts/storage/PerpMarketConfiguration.sol
+++ b/markets/bfp-market/contracts/storage/PerpMarketConfiguration.sol
@@ -15,8 +15,6 @@ library PerpMarketConfiguration {
     struct GlobalData {
         /// A reference to the core Synthetix v3 system.
         ISynthetixSystem synthetix;
-        /// A reference to the Synthetix oracle manager (used to fetch market prices).
-        INodeModule oracleManager;
         /// A reference to the Pyth EVM contract.
         IPyth pyth;
         /// Oracle node id for for eth/usd.

--- a/markets/bfp-market/storage.dump.sol
+++ b/markets/bfp-market/storage.dump.sol
@@ -728,6 +728,12 @@ library Margin {
         uint256 discountedCollateralUsd;
         uint256 collateralUsd;
     }
+    struct Runtime_getCollateralUsd {
+        address collateralAddress;
+        uint256 available;
+        uint256 collateralPrice;
+        uint256 i;
+    }
     struct GlobalData {
         mapping(address => CollateralType) supported;
         address[] supportedCollaterals;
@@ -802,9 +808,6 @@ library PerpMarket {
 // @custom:artifact contracts/storage/PerpMarketConfiguration.sol:PerpMarketConfiguration
 library PerpMarketConfiguration {
     struct GlobalData {
-        address synthetix;
-        address usdToken;
-        address oracleManager;
         address pyth;
         bytes32 ethOracleNodeId;
         address rewardDistributorImplementation;
@@ -896,6 +899,17 @@ library Position {
         uint128 maxLiquidatableCapacity;
         uint128 remainingCapacity;
         uint128 lastLiquidationTime;
+    }
+    struct Runtime_validateTrade {
+        uint256 orderFee;
+        uint256 keeperFee;
+        bool positionDecreasing;
+        uint256 discountedNextMarginUsd;
+        uint256 im;
+        uint256 mm;
+        Position.Data newPosition;
+        Margin.MarginValues marginValuesForLiqValidation;
+        uint256 ethPrice;
     }
     struct Data {
         int128 size;

--- a/markets/bfp-market/test/integration/modules/LiquidationModule.partialLiquidation.test.ts
+++ b/markets/bfp-market/test/integration/modules/LiquidationModule.partialLiquidation.test.ts
@@ -944,7 +944,7 @@ describe('LiquidationModule', () => {
         const tradersToUse = traders().slice(0, 2);
 
         for (const trader of tradersToUse) {
-          const marginUsdDepositAmount = genOneOf([1000, 5000, 10_000]);
+          const marginUsdDepositAmount = genOneOf([2000, 5000, 10_000]);
           const collateral = genOneOf(collaterals());
 
           const { collateralDepositAmount: collateralDepositAmount1 } = await depositMargin(

--- a/markets/bfp-market/test/integration/modules/PerpMarketFactoryModule.test.ts
+++ b/markets/bfp-market/test/integration/modules/PerpMarketFactoryModule.test.ts
@@ -51,34 +51,6 @@ describe('PerpMarketFactoryModule', () => {
 
   beforeEach(restore);
 
-  describe('setSynthetix', () => {
-    it('should revert when invalid synthetix addr (due to needing USD token)', async () => {
-      const { BfpMarketProxy } = systems();
-      const from = owner();
-
-      const address = genAddress();
-      try {
-        // assertRevert couldn't handle this error.
-        await BfpMarketProxy.connect(from).setSynthetix(address);
-        assert.fail('should have reverted');
-      } catch (error) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        assert.ok((error as any).error.reason.includes('transaction reverted in contract unknown'));
-      }
-    });
-
-    it('should revert when not owner', async () => {
-      const { BfpMarketProxy } = systems();
-      const from = traders()[0].signer;
-      const address = genAddress();
-      await assertRevert(
-        BfpMarketProxy.connect(from).setSynthetix(address),
-        `Unauthorized("${await from.getAddress()}")`,
-        BfpMarketProxy
-      );
-    });
-  });
-
   describe('setPyth', () => {
     it('should set successfully', async () => {
       const { BfpMarketProxy } = systems();


### PR DESCRIPTION
This branch is based on remove spot market. Given the amount of change this is what the saving looks like.
Each method was called 200 times:

| Method           | main    | remove-spot-market | gas-optimisation |
|------------------|---------|--------------------|------------------|
| modifyCollateral | 403,580 | 366,752            | 360,254          |
| withdrawAll      | 440,326 | 374,100            | 368,110          |
| settleOrder      | 747,879 | 733,693            | 730,653          |
| commitOrder      | 330,954 | 324,794            | 322,354          |
| liquidatePosition| 350,435 | 351,239            | 345,828          |
| flagPosition     | 534,559 | 488,016            | 463,553          |
| payDebt          | 162,289 | 162,315            | 159,936          |


![image](https://github.com/Synthetixio/synthetix-v3/assets/5688912/9b982250-20f4-424a-a9fd-8e013efb7f83)
![image](https://github.com/Synthetixio/synthetix-v3/assets/5688912/9b982250-20f4-424a-a9fd-8e013efb7f83)
