### PR TITLE
SIP-341: Add Configurer Address (#2061)

### DIFF
--- a/utils/core-contracts/contracts/interfaces/IConfigurable.sol
+++ b/utils/core-contracts/contracts/interfaces/IConfigurable.sol
@@ -1,0 +1,62 @@
+//SPDX-License-Identifier: MIT
+pragma solidity >=0.8.11 <0.9.0;
+
+import "./IOwnable.sol";
+
+/**
+ * @title Contract for facilitating ownership by a configurer, meant to be used in tandem with IOwnable.sol.
+ */
+interface IConfigurable {
+    /**
+     * @notice Thrown when an address tries to accept ownership of the configurer role but has not been nominated.
+     * @param addr The address that is trying to accept ownership.
+     */
+    error NotNominatedAsConfigurer(address addr);
+
+    /**
+     * @notice Emitted when an address has been nominated as configurer.
+     * @param newConfigurer The address that has been nominated.
+     */
+    event ConfigurerNominated(address newConfigurer);
+
+    /**
+     * @notice Emitted when the configurer of the contract has changed.
+     * @param oldConfigurer The previous configurer of the contract.
+     * @param newConfigurer The new configurer of the contract.
+     */
+    event ConfigurerChanged(address oldConfigurer, address newConfigurer);
+
+    /**
+     * @notice Allows a nominated address to accept the configurer role of the contract.
+     * @dev Reverts if the caller is not nominated.
+     */
+    function acceptConfigurerRole() external;
+
+    /**
+     * @notice Allows the current owner or configurer to nominate a new configurer.
+     * @dev The nominated owner will have to call `acceptOwnership` in a separate transaction in order to finalize the action and become the new contract owner.
+     * @param newNominatedConfigurer The address that is to become nominated.
+     */
+    function nominateNewConfigurer(address newNominatedConfigurer) external;
+
+    /**
+     * @notice Allows a nominated configurer to reject the nomination.
+     */
+    function renounceConfigurerNomination() external;
+
+    /**
+     * @notice Allows the owner of the contract to set the configurer address.
+     */
+    function setConfigurer(address newConfigurer) external;
+
+    /**
+     * @notice Returns the current configurer of the contract.
+     */
+    function configurer() external view returns (address);
+
+    /**
+     * @notice Returns the current nominated configurer of the contract.
+     * @dev Only one address can be nominated at a time.
+     */
+    function nominatedConfigurer() external view returns (address);
+}

--- a/utils/core-contracts/contracts/mocks/utils/ConfigurableMock.sol
+++ b/utils/core-contracts/contracts/mocks/utils/ConfigurableMock.sol
@@ -1,0 +1,28 @@
+//SPDX-License-Identifier: MIT
+pragma solidity >=0.8.11 <0.9.0;
+
+import "../../ownership/Configurable.sol";
+import "../../ownership/ConfigurableStorage.sol";
+import "../../ownership/Ownable.sol";
+import "../../ownership/OwnableStorage.sol";
+
+/**
+ * @title Mock Contract that has an owner and a configurer.
+ */
+contract ConfigurableMock is Ownable, Configurable {
+    uint256 public counter;
+
+    constructor(address owner_) Ownable(owner_) {}
+
+    // for testing onlyOwnerOrConfigurer
+    function countUp() external {
+        ConfigurableStorage.onlyOwnerOrConfigurer();
+        counter++;
+    }
+
+    // for testing that the configurer cannot call onlyOwner functions
+    function setCounter(uint256 _counter) external {
+        OwnableStorage.onlyOwner();
+        counter = _counter;
+    }
+}

--- a/utils/core-contracts/contracts/ownership/Configurable.sol
+++ b/utils/core-contracts/contracts/ownership/Configurable.sol
@@ -1,0 +1,101 @@
+//SPDX-License-Identifier: MIT
+pragma solidity >=0.8.11 <0.9.0;
+
+import "./ConfigurableStorage.sol";
+import "./OwnableStorage.sol";
+import "../errors/AddressError.sol";
+import "../errors/ChangeError.sol";
+import "../interfaces/IConfigurable.sol";
+import "../utils/ERC2771Context.sol";
+
+/**
+ * @title Contract for facilitating ownership by an owner and a configurer.
+ * @dev Not intended for use without Ownable.sol.
+ * See IConfigurable for natspec.
+ */
+contract Configurable is IConfigurable {
+    /**
+     * @inheritdoc IConfigurable
+     */
+    function acceptConfigurerRole() public override {
+        ConfigurableStorage.ConfigurerData storage store = ConfigurableStorage.loadConfigurer();
+
+        address currentNominatedConfigurer = store.nominatedConfigurer;
+        if (ERC2771Context._msgSender() != currentNominatedConfigurer) {
+            revert NotNominatedAsConfigurer(ERC2771Context._msgSender());
+        }
+
+        emit ConfigurerChanged(store.configurer, currentNominatedConfigurer);
+        store.configurer = currentNominatedConfigurer;
+
+        store.nominatedConfigurer = address(0);
+        emit ConfigurerNominated(address(0));
+    }
+
+    /**
+     * @inheritdoc IConfigurable
+     */
+    function nominateNewConfigurer(address newNominatedConfigurer) public override {
+        ConfigurableStorage.onlyOwnerOrConfigurer();
+        ConfigurableStorage.ConfigurerData storage store = ConfigurableStorage.loadConfigurer();
+
+        if (newNominatedConfigurer == address(0)) {
+            revert AddressError.ZeroAddress();
+        }
+
+        if (newNominatedConfigurer == store.nominatedConfigurer) {
+            revert ChangeError.NoChange();
+        }
+
+        store.nominatedConfigurer = newNominatedConfigurer;
+        emit ConfigurerNominated(newNominatedConfigurer);
+    }
+
+    /**
+     * @inheritdoc IConfigurable
+     */
+    function renounceConfigurerNomination() external override {
+        ConfigurableStorage.ConfigurerData storage store = ConfigurableStorage.loadConfigurer();
+
+        if (store.nominatedConfigurer != ERC2771Context._msgSender()) {
+            revert NotNominatedAsConfigurer(ERC2771Context._msgSender());
+        }
+
+        store.nominatedConfigurer = address(0);
+        emit ConfigurerNominated(address(0));
+    }
+
+    /**
+     * @inheritdoc IConfigurable
+     */
+    function setConfigurer(address newConfigurer) external override {
+        OwnableStorage.onlyOwner(); // reverts if not the owner
+        ConfigurableStorage.ConfigurerData storage store = ConfigurableStorage.loadConfigurer();
+
+        if (newConfigurer == store.configurer) {
+            revert ChangeError.NoChange();
+        }
+
+        if (store.nominatedConfigurer != address(0)) {
+            store.nominatedConfigurer = address(0); // reset nominated configurer to address(0)
+            emit ConfigurerNominated(address(0));
+        }
+
+        emit ConfigurerChanged(store.configurer, newConfigurer);
+        store.configurer = newConfigurer;
+    }
+
+    /**
+     * @inheritdoc IConfigurable
+     */
+    function configurer() external view override returns (address) {
+        return ConfigurableStorage.loadConfigurer().configurer;
+    }
+
+    /**
+     * @inheritdoc IConfigurable
+     */
+    function nominatedConfigurer() external view override returns (address) {
+        return ConfigurableStorage.loadConfigurer().nominatedConfigurer;
+    }
+}

--- a/utils/core-contracts/contracts/ownership/ConfigurableStorage.sol
+++ b/utils/core-contracts/contracts/ownership/ConfigurableStorage.sol
@@ -1,0 +1,37 @@
+//SPDX-License-Identifier: MIT
+pragma solidity >=0.8.11 <0.9.0;
+
+import "../errors/AccessError.sol";
+import "../utils/ERC2771Context.sol";
+import "./OwnableStorage.sol";
+
+library ConfigurableStorage {
+    bytes32 private constant _SLOT_CONFIGURER_STORAGE =
+        keccak256(abi.encode("io.synthetix.core-contracts.Configurer"));
+
+    struct ConfigurerData {
+        address configurer;
+        address nominatedConfigurer;
+    }
+
+    function loadConfigurer() internal pure returns (ConfigurerData storage store) {
+        bytes32 s = _SLOT_CONFIGURER_STORAGE;
+        assembly {
+            store.slot := s
+        }
+    }
+
+    ///@dev reverts if the sender is not the owner or the configurer
+    function onlyOwnerOrConfigurer() internal view {
+        if (
+            ERC2771Context._msgSender() != OwnableStorage.getOwner() &&
+            ERC2771Context._msgSender() != getConfigurer()
+        ) {
+            revert AccessError.Unauthorized(ERC2771Context._msgSender());
+        }
+    }
+
+    function getConfigurer() internal view returns (address) {
+        return ConfigurableStorage.loadConfigurer().configurer;
+    }
+}

--- a/utils/core-contracts/package.json
+++ b/utils/core-contracts/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "clean": "hardhat clean",
     "test": "hardhat test --network hardhat",
-    "coverage": "hardhat coverage --network hardhat",
+    "coverage": "hardhat coverage",
     "compile-contracts": "hardhat compile",
     "build-testable": "hardhat compile",
     "size-contracts": "hardhat compile && hardhat size-contracts"

--- a/utils/core-contracts/test/contracts/ownership/Configurable.test.ts
+++ b/utils/core-contracts/test/contracts/ownership/Configurable.test.ts
@@ -1,0 +1,241 @@
+import assert from 'node:assert/strict';
+import assertBn from '@synthetixio/core-utils/utils/assertions/assert-bignumber';
+import { TransactionReceipt } from '@ethersproject/abstract-provider';
+import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
+import { findEvent } from '@synthetixio/core-utils/utils/ethers/events';
+import { ethers } from 'ethers';
+import hre from 'hardhat';
+import { Configurable, ConfigurableMock } from '../../../typechain-types';
+
+describe('Configurable', function () {
+  let Configurable: Configurable;
+  let ConfigurableMock: ConfigurableMock;
+
+  let owner: ethers.Signer;
+  let configurer: ethers.Signer;
+  let newConfigurer: ethers.Signer;
+  let user: ethers.Signer;
+
+  const addressZero = '0x0000000000000000000000000000000000000000';
+
+  before('identify signers', async function () {
+    [owner, configurer, newConfigurer, user] = await hre.ethers.getSigners();
+  });
+
+  before('deploy the contract', async function () {
+    const factoryConfigurable = await hre.ethers.getContractFactory('Configurable');
+    Configurable = await factoryConfigurable.deploy();
+    const factoryConfigurableMock = await hre.ethers.getContractFactory('ConfigurableMock');
+    ConfigurableMock = await factoryConfigurableMock.deploy(await owner.getAddress());
+  });
+
+  describe('before a configurer is set', function () {
+    it('shows that the  configurer is 0x0', async function () {
+      assert.equal(await Configurable.configurer(), addressZero);
+      assert.equal(await ConfigurableMock.configurer(), addressZero);
+    });
+
+    it('shows that no new configurer is nominated', async function () {
+      assert.equal(await Configurable.nominatedConfigurer(), addressZero);
+      assert.equal(await ConfigurableMock.nominatedConfigurer(), addressZero);
+    });
+  });
+
+  describe('when the owner sets the configurer during a nomination', function () {
+    it('cancels the current nomination', async function () {
+      await ConfigurableMock.connect(owner).setConfigurer(await configurer.getAddress());
+      await ConfigurableMock.connect(configurer).nominateNewConfigurer(
+        await newConfigurer.getAddress()
+      );
+      assert.equal(await ConfigurableMock.nominatedConfigurer(), await newConfigurer.getAddress());
+      await ConfigurableMock.connect(owner).setConfigurer(addressZero);
+      assert.equal(await ConfigurableMock.configurer(), addressZero);
+      assert.equal(await ConfigurableMock.nominatedConfigurer(), addressZero);
+    });
+  });
+
+  describe('allows owner to set configurer', function () {
+    it('shows that the owner can call `setConfigurer`', async function () {
+      await ConfigurableMock.connect(owner).setConfigurer(await configurer.getAddress());
+      assert.equal(await ConfigurableMock.configurer(), await configurer.getAddress());
+      assert.equal(await ConfigurableMock.nominatedConfigurer(), addressZero);
+    });
+
+    it('shows that the owner cannot set the configurer to the same address as the current configurer', async function () {
+      await assertRevert(
+        ConfigurableMock.connect(owner).setConfigurer(await configurer.getAddress()),
+        'NoChange'
+      );
+    });
+  });
+  describe('after a configurer is set', function () {
+    describe('Allows', function () {
+      let receipt: TransactionReceipt;
+
+      describe('when an non-configurer tries to nominate a new configurer', function () {
+        it('reverts', async function () {
+          await assertRevert(
+            ConfigurableMock.connect(newConfigurer).nominateNewConfigurer(
+              await newConfigurer.getAddress()
+            ),
+            `Unauthorized("${await newConfigurer.getAddress()}")`
+          );
+        });
+      });
+
+      describe('reverts if configurer nominates address 0x0 as the new configurer', function () {
+        it('reverts', async function () {
+          await assertRevert(
+            ConfigurableMock.connect(configurer).nominateNewConfigurer(addressZero),
+            'ZeroAddress'
+          );
+        });
+      });
+
+      before('nominateNewConfigurer', async function () {
+        const tx = await ConfigurableMock.connect(configurer).nominateNewConfigurer(
+          await newConfigurer.getAddress()
+        );
+        receipt = await tx.wait();
+      });
+
+      it('shows that the configurer address is nominated', async function () {
+        assert.equal(
+          await ConfigurableMock.nominatedConfigurer(),
+          await newConfigurer.getAddress()
+        );
+      });
+
+      it('emitted an ConfigurerNominated event', async function () {
+        const evt = findEvent({ receipt, eventName: 'ConfigurerNominated' });
+
+        assert(!Array.isArray(evt) && evt?.args);
+        assert.equal(evt.args.newConfigurer, await newConfigurer.getAddress());
+      });
+
+      describe('when attempting to re-nominate the same configurer', function () {
+        it('reverts', async function () {
+          await assertRevert(
+            ConfigurableMock.connect(configurer).nominateNewConfigurer(
+              await newConfigurer.getAddress()
+            ),
+            'NoChange'
+          );
+        });
+      });
+
+      describe('when the owner and configurer are set', function () {
+        it('the owner and configurer can call functions with the onlyOwnerOrConfigurer modifier', async function () {
+          assertBn.equal(await ConfigurableMock.counter(), 0);
+          await ConfigurableMock.connect(owner).countUp();
+          assertBn.equal(await ConfigurableMock.counter(), 1);
+          await ConfigurableMock.connect(configurer).countUp();
+          assertBn.equal(await ConfigurableMock.counter(), 2);
+        });
+
+        it('a user cannot call functions with the onlyOwnerOrConfigurer modifier', async function () {
+          await assertRevert(ConfigurableMock.connect(user).countUp(), 'Unauthorized');
+        });
+
+        it('configurer cannot call onlyOwner functions but owner can', async function () {
+          await assertRevert(ConfigurableMock.connect(configurer).setCounter(1337), 'Unauthorized');
+          await ConfigurableMock.connect(owner).setCounter(1337);
+          assertBn.equal(await ConfigurableMock.counter(), 1337);
+        });
+      });
+
+      describe('Accepting the configurer role', function () {
+        describe('when an non nominated address tries to accept the configurer role', function () {
+          it('reverts', async function () {
+            await assertRevert(
+              ConfigurableMock.connect(owner).acceptConfigurerRole(),
+              `NotNominatedAsConfigurer("${await owner.getAddress()}")`
+            );
+          });
+        });
+
+        describe('when the nominated address accepts the configurer role', function () {
+          before('accept configurer role', async function () {
+            const tx = await ConfigurableMock.connect(newConfigurer).acceptConfigurerRole();
+            receipt = await tx.wait();
+          });
+
+          after('return configurer role', async function () {
+            let tx;
+
+            tx = await ConfigurableMock.connect(newConfigurer).nominateNewConfigurer(
+              await configurer.getAddress()
+            );
+            await tx.wait();
+
+            tx = await ConfigurableMock.connect(configurer).acceptConfigurerRole();
+            await tx.wait();
+          });
+
+          it('emits an ConfigurerChanged event', async function () {
+            const evt = findEvent({ receipt, eventName: 'ConfigurerChanged' });
+
+            assert(!Array.isArray(evt) && evt?.args);
+            assert.equal(evt.args.newConfigurer, await newConfigurer.getAddress());
+          });
+
+          it('shows that the address is the new configurer', async function () {
+            assert.equal(await ConfigurableMock.configurer(), await newConfigurer.getAddress());
+          });
+
+          it('shows that the address is no longer nominated', async function () {
+            assert.equal(await ConfigurableMock.nominatedConfigurer(), addressZero);
+          });
+        });
+      });
+
+      describe('Renouncing nomination', function () {
+        describe('when there is no nomination', function () {
+          it('reverts', async function () {
+            await assertRevert(
+              ConfigurableMock.connect(newConfigurer).renounceConfigurerNomination(),
+              `NotNominatedAsConfigurer("${await newConfigurer.getAddress()}")`
+            );
+          });
+        });
+
+        describe('when there is a nomination', function () {
+          before('nominateNewConfigurer', async function () {
+            const tx = await ConfigurableMock.connect(configurer).nominateNewConfigurer(
+              await newConfigurer.getAddress()
+            );
+            await tx.wait();
+          });
+
+          it('shows that the right address is nominated', async function () {
+            assert.equal(
+              await ConfigurableMock.nominatedConfigurer(),
+              await newConfigurer.getAddress()
+            );
+          });
+
+          describe('when a non nominated user tries to renounce', function () {
+            it('reverts', async function () {
+              await assertRevert(
+                ConfigurableMock.connect(user).renounceConfigurerNomination(),
+                `NotNominatedAsConfigurer("${await user.getAddress()}")`
+              );
+            });
+          });
+
+          describe('when the nominated configurer renounces', function () {
+            before('renounce nomination', async function () {
+              const tx =
+                await ConfigurableMock.connect(newConfigurer).renounceConfigurerNomination();
+              await tx.wait();
+            });
+
+            it('shows that there is no address nominated', async function () {
+              assert.equal(await ConfigurableMock.nominatedConfigurer(), addressZero);
+            });
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
* saving work so far

* contracts draft finished

* added set configurer and changed fn name

* changed to configurable, context msg sender, and seperated contracts

* removed setConfigurer from ownable

* before a configurer is set

* added edge case protection

* tests

* added edge case test

* added tests

* added comment

* 100% coverage

* removed modifier onlyOwnerOrConfigurer

* Update utils/core-contracts/test/contracts/ownership/Configurable.test.ts



* audit refactor

---------