### PR TITLE
Testnet deployment fixes

### DIFF
--- a/markets/bfp-market/cannonfile.toml
+++ b/markets/bfp-market/cannonfile.toml
@@ -123,6 +123,12 @@ factory.PerpAccountProxy.abiOf = ["synthetix.AccountRouter"]
 factory.PerpAccountProxy.event = "AssociatedSystemSet"
 factory.PerpAccountProxy.arg = 2
 
+[invoke.set_reward_distributor_implementation]
+target = ["BfpMarketProxy"]
+fromCall.func = "owner"
+func = "setRewardDistributorImplementation"
+args = ["<%= contracts.PerpRewardDistributor.address %>"]
+
 # --- Core feature flags --- #
 
 [invoke.add_to_feature_flag_allowlist_register_market]

--- a/markets/bfp-market/contracts/interfaces/IMarketConfigurationModule.sol
+++ b/markets/bfp-market/contracts/interfaces/IMarketConfigurationModule.sol
@@ -37,6 +37,7 @@ interface IMarketConfigurationModule {
 
     /// @notice See PerpMarketConfiguration.Data for more details.
     struct ConfigureByMarketParameters {
+        uint128 marketId;
         bytes32 oracleNodeId;
         bytes32 pythPriceFeedId;
         uint128 makerFee;
@@ -77,10 +78,8 @@ interface IMarketConfigurationModule {
     ) external;
 
     /// @notice Configures a market specific parameters applied to the `marketId`.
-    /// @param marketId Market to configure
     /// @param data A struct of parameters to configure
     function setMarketConfigurationById(
-        uint128 marketId,
         IMarketConfigurationModule.ConfigureByMarketParameters memory data
     ) external;
 

--- a/markets/bfp-market/contracts/modules/MarketConfigurationModule.sol
+++ b/markets/bfp-market/contracts/modules/MarketConfigurationModule.sol
@@ -45,10 +45,10 @@ contract MarketConfigurationModule is IMarketConfigurationModule {
 
     /// @inheritdoc IMarketConfigurationModule
     function setMarketConfigurationById(
-        uint128 marketId,
         IMarketConfigurationModule.ConfigureByMarketParameters memory data
     ) external {
         OwnableStorage.onlyOwner();
+        uint128 marketId = data.marketId;
 
         // Only allow an existing per market to be configurable. Ensure it's first created then configure.
         PerpMarket.exists(marketId);

--- a/markets/bfp-market/storage.dump.sol
+++ b/markets/bfp-market/storage.dump.sol
@@ -525,6 +525,7 @@ interface IMarketConfigurationModule {
         uint128 highUtilizationSlopePercent;
     }
     struct ConfigureByMarketParameters {
+        uint128 marketId;
         bytes32 oracleNodeId;
         bytes32 pythPriceFeedId;
         uint128 makerFee;

--- a/markets/bfp-market/test/bootstrap.ts
+++ b/markets/bfp-market/test/bootstrap.ts
@@ -200,8 +200,9 @@ export const bootstrap = (args: GeneratedBootstrap) => {
       await BfpMarketProxy.createMarket({ name });
 
       // Configure market.
-      await BfpMarketProxy.connect(getOwner()).setMarketConfigurationById(marketId, {
+      await BfpMarketProxy.connect(getOwner()).setMarketConfigurationById({
         ...specific,
+        marketId,
         // Override the generic supplied oracleNodeId with the one that was just created.
         oracleNodeId,
       });

--- a/markets/bfp-market/test/helpers.ts
+++ b/markets/bfp-market/test/helpers.ts
@@ -142,7 +142,8 @@ export const setMarketConfigurationById = async (
   const data = await BfpMarketProxy.getMarketConfigurationById(marketId);
   await withExplicitEvmMine(
     () =>
-      BfpMarketProxy.connect(owner()).setMarketConfigurationById(marketId, {
+      BfpMarketProxy.connect(owner()).setMarketConfigurationById({
+        marketId,
         ...data,
         ...params,
       }),

--- a/markets/bfp-market/test/integration/modules/MarketConfigurationModule.test.ts
+++ b/markets/bfp-market/test/integration/modules/MarketConfigurationModule.test.ts
@@ -75,10 +75,11 @@ describe('MarketConfigurationModule', async () => {
       const { specific } = genMarket();
       const config = {
         ...specific,
+        marketId,
         skewScale: bn(0),
       };
       await assertRevert(
-        BfpMarketProxy.setMarketConfigurationById(marketId, config),
+        BfpMarketProxy.setMarketConfigurationById(config),
         'InvalidParameter("skewScale", "ZeroAmount")',
         BfpMarketProxy
       );
@@ -91,11 +92,12 @@ describe('MarketConfigurationModule', async () => {
       const { specific } = genMarket();
       const config = {
         ...specific,
+        marketId,
         minMarginUsd: globalConfig.maxKeeperFeeUsd.sub(bn(1)),
       };
 
       await assertRevert(
-        BfpMarketProxy.setMarketConfigurationById(marketId, config),
+        BfpMarketProxy.setMarketConfigurationById(config),
         `InvalidParameter("minMarginUsd", "minMarginUsd cannot be less than maxKeeperFeeUsd")`,
         BfpMarketProxy
       );
@@ -110,7 +112,7 @@ describe('MarketConfigurationModule', async () => {
       const { specific } = genMarket();
 
       const { receipt } = await withExplicitEvmMine(
-        () => BfpMarketProxy.connect(from).setMarketConfigurationById(marketId, specific),
+        () => BfpMarketProxy.connect(from).setMarketConfigurationById({ ...specific, marketId }),
         provider()
       );
 
@@ -151,7 +153,7 @@ describe('MarketConfigurationModule', async () => {
       const { specific } = genMarket();
 
       await assertRevert(
-        BfpMarketProxy.connect(from).setMarketConfigurationById(marketId, specific),
+        BfpMarketProxy.connect(from).setMarketConfigurationById({ ...specific, marketId }),
         `Unauthorized("${await from.getAddress()}")`,
         BfpMarketProxy
       );
@@ -164,7 +166,10 @@ describe('MarketConfigurationModule', async () => {
       const { specific } = genMarket();
 
       await assertRevert(
-        BfpMarketProxy.connect(from).setMarketConfigurationById(notFoundMarketId, specific),
+        BfpMarketProxy.connect(from).setMarketConfigurationById({
+          ...specific,
+          marketId: notFoundMarketId,
+        }),
         `MarketNotFound("${notFoundMarketId}")`,
         BfpMarketProxy
       );


### PR DESCRIPTION
Some minor changes discovered while working on testnet deployemnet.

-  Make `marketId` part of `ConfigureByMarketParameters`, this makes the cannon file in synthetix-deployments behave a bit nicer. 
-  Include `setRewardDistributorImplementation` in the production cannonfile. We already have it in the cannon test file, and I think it make sense to have it here rather than in synthetix-deployment as it should behave differently on different networks 