### PR TITLE
Fix for underflow error when offchain price timestamp is bigger than current block timestamp

### DIFF
--- a/protocol/oracle-manager/contracts/nodes/StalenessCircuitBreakerNode.sol
+++ b/protocol/oracle-manager/contracts/nodes/StalenessCircuitBreakerNode.sol
@@ -31,6 +31,10 @@ library StalenessCircuitBreakerNode {
             runtimeValues
         );
 
+        if (block.timestamp <= priceNodeOutput.timestamp) {
+            return priceNodeOutput;
+        }
+
         if (block.timestamp - priceNodeOutput.timestamp <= stalenessTolerance) {
             return priceNodeOutput;
         } else if (nodeDefinition.parents.length == 1) {

--- a/protocol/oracle-manager/contracts/nodes/StalenessCircuitBreakerNode.sol
+++ b/protocol/oracle-manager/contracts/nodes/StalenessCircuitBreakerNode.sol
@@ -31,11 +31,7 @@ library StalenessCircuitBreakerNode {
             runtimeValues
         );
 
-        if (block.timestamp <= priceNodeOutput.timestamp) {
-            return priceNodeOutput;
-        }
-
-        if (block.timestamp - priceNodeOutput.timestamp <= stalenessTolerance) {
+        if (block.timestamp - stalenessTolerance <= priceNodeOutput.timestamp) {
             return priceNodeOutput;
         } else if (nodeDefinition.parents.length == 1) {
             revert StalenessToleranceExceeded(


### PR DESCRIPTION
On arbitrum sepolia block is minted with a reasonable delay so after getting the fresh price update txn - the timestamp of the update will be "in the future" for the current block and we get underflow error

Example: https://www.tdly.co/shared/simulation/8e997e25-04d6-47a9-b566-56a779efed4c