### PR TITLE
Update payDebt with recomputeUtilization

### DIFF
--- a/markets/bfp-market/contracts/modules/MarginModule.sol
+++ b/markets/bfp-market/contracts/modules/MarginModule.sol
@@ -527,6 +527,16 @@ contract MarginModule is IMarginModule {
         // Infer the remaining sUSD to burn from `ERC2771Context._msgSender()` after attributing sUSD in margin.
         uint128 amountToBurn = decreaseDebtAmount - sUsdToDeduct;
         if (amountToBurn > 0) {
+            AddressRegistry.Data memory addresses = AddressRegistry.Data({
+                synthetix: ISynthetixSystem(SYNTHETIX_CORE),
+                sUsd: SYNTHETIX_SUSD,
+                oracleManager: ORACLE_MANAGER
+            });
+
+            uint256 oraclePrice = market.getOraclePrice(addresses);
+            (uint128 utilizationRate, ) = market.recomputeUtilization(oraclePrice, addresses);
+            emit UtilizationRecomputed(marketId, market.skew, utilizationRate);
+
             ISynthetixSystem(SYNTHETIX_CORE).depositMarketUsd(
                 marketId,
                 ERC2771Context._msgSender(),

--- a/markets/bfp-market/contracts/modules/MarginModule.sol
+++ b/markets/bfp-market/contracts/modules/MarginModule.sol
@@ -533,8 +533,10 @@ contract MarginModule is IMarginModule {
                 oracleManager: ORACLE_MANAGER
             });
 
-            uint256 oraclePrice = market.getOraclePrice(addresses);
-            (uint128 utilizationRate, ) = market.recomputeUtilization(oraclePrice, addresses);
+            (uint128 utilizationRate, ) = market.recomputeUtilization(
+                market.getOraclePrice(addresses),
+                addresses
+            );
             emit UtilizationRecomputed(marketId, market.skew, utilizationRate);
 
             ISynthetixSystem(SYNTHETIX_CORE).depositMarketUsd(

--- a/markets/bfp-market/test/integration/modules/MarginModule.debt.test.ts
+++ b/markets/bfp-market/test/integration/modules/MarginModule.debt.test.ts
@@ -4,7 +4,12 @@ import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert
 import assert from 'assert';
 import Wei, { wei } from '@synthetixio/wei';
 import { bootstrap } from '../../bootstrap';
-import { calcPricePnl, calcTransactionCostInUsd } from '../../calculations';
+import {
+  calcPricePnl,
+  calcTransactionCostInUsd,
+  calcUtilization,
+  calcUtilizationRate,
+} from '../../calculations';
 import {
   bn,
   genBootstrap,
@@ -228,6 +233,100 @@ describe('MarginModule Debt', async () => {
           ),
         provider()
       );
+      await assertEvent(
+        receipt,
+        `DebtPaid(${trader.accountId}, ${marketId}, ${d2.debtUsd}, 0, 0)`,
+        BfpMarketProxy
+      );
+
+      // All debt paid off.
+      const d3 = await BfpMarketProxy.getAccountDigest(trader.accountId, marketId);
+      assertBn.isZero(d3.debtUsd);
+    });
+
+    it('should remove debt and emit event for utilization recomputed', async () => {
+      const { BfpMarketProxy } = systems();
+
+      const { trader, market, marketId, collateral, collateralDepositAmount } = await depositMargin(
+        bs,
+        genTrader(bs, {
+          desiredCollateral: genOneOf(collateralsWithoutSusd()),
+          desiredMarginUsdDepositAmount: 10_000,
+        })
+      );
+
+      // Before doing anything, verify this trader has zero debt.
+      const d1 = await BfpMarketProxy.getAccountDigest(trader.accountId, marketId);
+      assertBn.isZero(d1.debtUsd);
+
+      const orderSide = genSide();
+      const openOrder = await genOrder(bs, market, collateral, collateralDepositAmount, {
+        desiredLeverage: 1,
+        desiredSide: orderSide,
+      });
+
+      // Price moves, causing a 10% loss.
+      const newMarketOraclePrice = wei(openOrder.oraclePrice)
+        .mul(orderSide === 1 ? 0.9 : 1.1)
+        .toBN();
+      await market.aggregator().mockSetCurrentPrice(newMarketOraclePrice);
+
+      // Fast-forward to accrue utilization and funding.
+      await fastForwardBySec(provider(), SECONDS_ONE_DAY);
+
+      // Close the position at a loss.
+      const closeOrder = await genOrder(bs, market, collateral, collateralDepositAmount, {
+        desiredSize: openOrder.sizeDelta.mul(-1),
+      });
+      const { receipt: closeReceipt } = await commitAndSettle(bs, marketId, trader, closeOrder);
+
+      const closeOrderEvent = findEventSafe(closeReceipt, 'OrderSettled', BfpMarketProxy);
+
+      // Amount of debt on emitted matches current reported digest.
+      const d2 = await BfpMarketProxy.getAccountDigest(trader.accountId, marketId);
+
+      // Mint an exact amount of sUSD to pay the accountDebt.
+      await mintAndApprove(
+        bs,
+        getSusdCollateral(collaterals()), // sUSD
+        closeOrderEvent.args.accountDebt,
+        trader.signer
+      );
+      const { receipt } = await withExplicitEvmMine(
+        () =>
+          BfpMarketProxy.connect(trader.signer).payDebt(
+            trader.accountId,
+            marketId,
+            closeOrderEvent.args.accountDebt
+          ),
+        provider()
+      );
+
+      const utilizationRecomputedEvent = findEventSafe(
+        receipt,
+        'UtilizationRecomputed',
+        BfpMarketProxy
+      );
+
+      const marketSkew = utilizationRecomputedEvent.args.skew;
+      const { skew } = await BfpMarketProxy.getMarketDigest(marketId);
+
+      const computedUtilizationRate = utilizationRecomputedEvent.args.utilizationRate;
+      const expectedUtilization = await calcUtilization(bs, marketId);
+      const expectedUtilizationRate = await calcUtilizationRate(bs, expectedUtilization);
+      const utilizationDigest = await BfpMarketProxy.getUtilizationDigest(marketId);
+
+      assertBn.equal(utilizationDigest.utilization, expectedUtilization.toBN());
+      assertBn.equal(utilizationDigest.currentUtilizationRate, expectedUtilizationRate.toBN());
+      assertBn.equal(utilizationDigest.lastComputedUtilizationRate, computedUtilizationRate);
+      assertBn.equal(skew, marketSkew);
+
+      await assertEvent(
+        receipt,
+        `UtilizationRecomputed(${marketId}, ${marketSkew}, ${computedUtilizationRate})`,
+        BfpMarketProxy
+      );
+
       await assertEvent(
         receipt,
         `DebtPaid(${trader.accountId}, ${marketId}, ${d2.debtUsd}, 0, 0)`,


### PR DESCRIPTION
Updates `payDebt` function with `recomputeUtilization` becase the `amountToBurn` increases the creditCapacity of the market.