### PR TITLE
Various Perps v3 audit fixes

### DIFF
--- a/markets/perps-market/contracts/modules/PerpsMarketFactoryModule.sol
+++ b/markets/perps-market/contracts/modules/PerpsMarketFactoryModule.sol
@@ -9,6 +9,7 @@ import {PerpsMarketFactory} from "../storage/PerpsMarketFactory.sol";
 import {GlobalPerpsMarket} from "../storage/GlobalPerpsMarket.sol";
 import {PerpsMarket} from "../storage/PerpsMarket.sol";
 import {PerpsPrice} from "../storage/PerpsPrice.sol";
+import {SNX_USD_MARKET_ID} from "../storage/PerpsAccount.sol";
 import {Flags} from "../utils/Flags.sol";
 import {MathUtil} from "../utils/MathUtil.sol";
 import {InterestRate} from "../storage/InterestRate.sol";
@@ -141,7 +142,11 @@ contract PerpsMarketFactoryModule is IPerpsMarketFactoryModule {
      */
     function minimumCredit(uint128 perpsMarketId) external view override returns (uint256) {
         if (PerpsMarketFactory.load().perpsMarketId == perpsMarketId) {
-            return GlobalPerpsMarket.load().minimumCredit(PerpsPrice.Tolerance.DEFAULT);
+            GlobalPerpsMarket.Data storage globalMarket = GlobalPerpsMarket.load();
+            uint256 minRequiredCredit = globalMarket.minimumCredit(PerpsPrice.Tolerance.DEFAULT);
+
+            // add the sUSD collateral value to the minimum credit since it's used as escrow
+            return minRequiredCredit + globalMarket.collateralAmounts[SNX_USD_MARKET_ID];
         }
 
         return 0;

--- a/markets/perps-market/contracts/storage/AsyncOrder.sol
+++ b/markets/perps-market/contracts/storage/AsyncOrder.sol
@@ -313,7 +313,7 @@ library AsyncOrder {
 
         // only account for negative pnl
         runtime.currentAvailableMargin += MathUtil.min(
-            calculateStartingPnl(runtime.fillPrice, orderPrice, runtime.newPositionSize),
+            calculateFillPricePnl(runtime.fillPrice, orderPrice, runtime.sizeDelta),
             0
         );
 
@@ -511,14 +511,14 @@ library AsyncOrder {
     }
 
     /**
-     * @notice Initial pnl of a position after it's opened due to p/d fill price delta.
+     * @notice PnL incurred from closing old position/opening new position based on fill price
      */
-    function calculateStartingPnl(
+    function calculateFillPricePnl(
         uint256 fillPrice,
         uint256 marketPrice,
-        int128 size
+        int128 sizeDelta
     ) internal pure returns (int256) {
-        return size.mulDecimal(marketPrice.toInt() - fillPrice.toInt());
+        return sizeDelta.mulDecimal(marketPrice.toInt() - fillPrice.toInt());
     }
 
     /**

--- a/markets/perps-market/contracts/storage/GlobalPerpsMarket.sol
+++ b/markets/perps-market/contracts/storage/GlobalPerpsMarket.sol
@@ -97,9 +97,6 @@ library GlobalPerpsMarket {
 
             accumulatedMinimumCredit += PerpsMarket.requiredCredit(marketId, priceTolerance);
         }
-
-        // add the sUSD collateral value to the minimum credit since it's used as escrow
-        accumulatedMinimumCredit += self.collateralAmounts[SNX_USD_MARKET_ID];
     }
 
     function totalCollateralValue(Data storage self) internal view returns (uint256 total) {

--- a/markets/perps-market/contracts/storage/PerpsMarket.sol
+++ b/markets/perps-market/contracts/storage/PerpsMarket.sol
@@ -426,6 +426,17 @@ library PerpsMarket {
         return positionPnl + fundingPnl - self.debtCorrectionAccumulator;
     }
 
+    function requiredCreditForSize(
+        Data storage self,
+        int256 positionSize,
+        PerpsPrice.Tolerance tolerance
+    ) internal view returns (int256) {
+        return
+            positionSize
+                .mulDecimal(PerpsPrice.getCurrentPrice(self.id, tolerance).toInt())
+                .mulDecimal(PerpsMarketConfiguration.load(self.id).lockedOiRatioD18.toInt());
+    }
+
     function requiredCredit(
         uint128 marketId,
         PerpsPrice.Tolerance tolerance

--- a/markets/perps-market/test/integration/Insolvent.test.ts
+++ b/markets/perps-market/test/integration/Insolvent.test.ts
@@ -4,6 +4,7 @@ import Wei, { wei } from '@synthetixio/wei';
 import { ethers } from 'ethers';
 import { fastForwardTo, getTime } from '@synthetixio/core-utils/utils/hardhat/rpc';
 import assertBn from '@synthetixio/core-utils/utils/assertions/assert-bignumber';
+import assertRevert from '@synthetixio/core-utils/utils/assertions/assert-revert';
 
 const _SECONDS_IN_DAY = 24 * 60 * 60;
 
@@ -80,12 +81,14 @@ describe('Insolvent test', () => {
     await fastForwardTo((await getTime(provider())) + _SECONDS_IN_DAY * 10, provider());
   });
 
+  let delegatedCollateralValue: Wei;
   before('undelegate', async () => {
     const currentCollateralAmount = await systems().Core.getPositionCollateral(
       1,
       1,
       systems().CollateralMock.address
     );
+    console.log(currentCollateralAmount);
     // very low amount to make market insolvent
     await systems()
       .Core.connect(staker())
@@ -96,31 +99,30 @@ describe('Insolvent test', () => {
         wei(currentCollateralAmount).mul(wei(0.1)).toBN(),
         ethers.utils.parseEther('1')
       );
+    // this ends up being total delegated collateral value
+    delegatedCollateralValue = wei(200_000);
   });
 
-  // trader 1
-  before('open 20 eth position', async () => {
-    await openPosition({
-      systems,
-      provider,
-      trader: trader1(),
-      accountId: 2,
-      keeper: keeper(),
-      marketId: ethMarket.marketId(),
-      sizeDelta: _TRADER_SIZE.toBN(),
-      settlementStrategyId: ethMarket.strategyId(),
-      price: _ETH_PRICE.toBN(),
-    });
+  it('reverts if attempting to open position when market insolved', async () => {
+    await assertRevert(
+      systems()
+        .PerpsMarket.connect(trader1())
+        .commitOrder({
+          marketId: ethMarket.marketId(),
+          accountId: 2,
+          sizeDelta: _TRADER_SIZE.toBN(),
+          settlementStrategyId: ethMarket.strategyId(),
+          acceptablePrice: _ETH_PRICE.mul(2).toBN(),
+          referrer: ethers.constants.AddressZero,
+          trackingCode: ethers.constants.HashZero,
+        }),
+      `ExceedsMarketCreditCapacity("${delegatedCollateralValue.toString(18, true)}", "${_TRADER_SIZE.mul(_ETH_PRICE).toString(18, true)}")`,
+      systems().PerpsMarket
+    );
   });
 
-  checkMarketInterestRate();
-
-  describe('close for large profit making market insolvent', () => {
-    before('make price higher', async () => {
-      await ethMarket.aggregator().mockSetCurrentPrice(bn(10_000));
-    });
-
-    before('close position', async () => {
+  describe('open position', () => {
+    before(async () => {
       await openPosition({
         systems,
         provider,
@@ -128,17 +130,91 @@ describe('Insolvent test', () => {
         accountId: 2,
         keeper: keeper(),
         marketId: ethMarket.marketId(),
-        sizeDelta: _TRADER_SIZE.mul(-1).toBN(),
+        sizeDelta: bn(50),
         settlementStrategyId: ethMarket.strategyId(),
-        price: bn(10_000),
+        price: bn(2_000),
       });
     });
 
-    it('sets util rate at 1', async () => {
-      const utilRate = await systems().PerpsMarket.utilizationRate();
-      assertBn.equal(utilRate.rate, bn(1));
+    it('reverts when attempting to open position above market credit capacity', async () => {
+      await assertRevert(
+        systems()
+          .PerpsMarket.connect(trader1())
+          .commitOrder({
+            marketId: ethMarket.marketId(),
+            accountId: 2,
+            sizeDelta: bn(60),
+            settlementStrategyId: ethMarket.strategyId(),
+            acceptablePrice: _ETH_PRICE.mul(2).toBN(),
+            referrer: ethers.constants.AddressZero,
+            trackingCode: ethers.constants.HashZero,
+          }),
+        `ExceedsMarketCreditCapacity("${delegatedCollateralValue.toString(18, true)}", "${wei(60).add(wei(50)).mul(_ETH_PRICE).toString(18, true)}")`,
+        systems().PerpsMarket
+      );
+    });
+
+    it('reverts when attempting to open position in the opposite direction above market credit capacity', async () => {
+      await assertRevert(
+        systems()
+          .PerpsMarket.connect(trader1())
+          .commitOrder({
+            marketId: ethMarket.marketId(),
+            accountId: 2,
+            sizeDelta: bn(-160),
+            settlementStrategyId: ethMarket.strategyId(),
+            acceptablePrice: _ETH_PRICE.mul(2).toBN(),
+            referrer: ethers.constants.AddressZero,
+            trackingCode: ethers.constants.HashZero,
+          }),
+        `ExceedsMarketCreditCapacity("${delegatedCollateralValue.toString(18, true)}", "${wei(60).add(wei(50)).mul(_ETH_PRICE).toString(18, true)}")`,
+        systems().PerpsMarket
+      );
+    });
+  });
+
+  describe('open position with profit', () => {
+    before('open 100 eth position', async () => {
+      await openPosition({
+        systems,
+        provider,
+        trader: trader1(),
+        accountId: 2,
+        keeper: keeper(),
+        marketId: ethMarket.marketId(),
+        sizeDelta: bn(50),
+        settlementStrategyId: ethMarket.strategyId(),
+        price: _ETH_PRICE.toBN(),
+      });
     });
 
     checkMarketInterestRate();
+
+    describe('close for large profit making market insolvent', () => {
+      before('make price higher', async () => {
+        await ethMarket.aggregator().mockSetCurrentPrice(bn(10_000));
+      });
+
+      before('close position', async () => {
+        await openPosition({
+          systems,
+          provider,
+          trader: trader1(),
+          accountId: 2,
+          keeper: keeper(),
+          marketId: ethMarket.marketId(),
+          sizeDelta: bn(-100),
+          settlementStrategyId: ethMarket.strategyId(),
+          price: bn(10_000),
+        });
+      });
+
+      it('sets util rate at 1', async () => {
+        const utilRate = await systems().PerpsMarket.utilizationRate();
+        assertBn.equal(utilRate.rate, bn(1));
+      });
+
+      checkMarketInterestRate();
+    });
   });
 });

--- a/markets/perps-market/test/integration/Insolvent.test.ts
+++ b/markets/perps-market/test/integration/Insolvent.test.ts
@@ -17,7 +17,7 @@ const interestRateParams = {
   highUtilGradient: wei(0.01),
 };
 
-describe('Position - interest rates', () => {
+describe('Insolvent test', () => {
   const { systems, perpsMarkets, superMarketId, provider, trader1, keeper, staker } =
     bootstrapMarkets({
       interestRateParams: {
@@ -54,7 +54,11 @@ describe('Position - interest rates', () => {
       const withdrawableUsd = wei(await systems().Core.getWithdrawableMarketUsd(superMarketId()));
       const totalCollateralValue = wei(await systems().PerpsMarket.totalGlobalCollateralValue());
       const delegatedCollateral = withdrawableUsd.sub(totalCollateralValue);
-      const minCredit = wei(await systems().PerpsMarket.minimumCredit(superMarketId()));
+
+      const snxUsdValue = wei(await systems().PerpsMarket.globalCollateralValue(0));
+      const minCredit = wei(await systems().PerpsMarket.minimumCredit(superMarketId())).sub(
+        snxUsdValue
+      );
 
       const utilRate = delegatedCollateral.gt(0) ? minCredit.div(delegatedCollateral) : wei(1);
       currentInterestRate = calculateInterestRate(utilRate, interestRateParams);

--- a/markets/perps-market/test/integration/Orders/Order.marginValidation.capped.test.ts
+++ b/markets/perps-market/test/integration/Orders/Order.marginValidation.capped.test.ts
@@ -6,7 +6,7 @@ import {
   openPosition,
   requiredMargins,
   getRequiredLiquidationRewardMargin,
-  expectedStartingPnl,
+  expectedFillPricePnl,
 } from '../helpers';
 import { wei } from '@synthetixio/wei';
 import { ethers } from 'ethers';
@@ -126,7 +126,7 @@ describe('Orders - capped margin validation', () => {
       );
 
       const availableMargin = wei(100).add(
-        expectedStartingPnl(ETH_MARKET_PRICE, fillPrice, wei(3))
+        expectedFillPricePnl(ETH_MARKET_PRICE, fillPrice, wei(3))
       );
 
       await assertRevert(
@@ -231,7 +231,7 @@ describe('Orders - capped margin validation', () => {
 
       const currentAvailableMargin = await systems().PerpsMarket.getAvailableMargin(2);
       const availableMargin = wei(currentAvailableMargin).add(
-        expectedStartingPnl(BTC_MARKET_PRICE, fillPrice, wei(5))
+        expectedFillPricePnl(BTC_MARKET_PRICE, fillPrice, wei(5))
       );
 
       await assertRevert(
@@ -333,7 +333,7 @@ describe('Orders - capped margin validation', () => {
 
       const currentAvailableMargin = await systems().PerpsMarket.getAvailableMargin(2);
       const availableMargin = wei(currentAvailableMargin).add(
-        expectedStartingPnl(BTC_MARKET_PRICE, fillPrice, wei(10))
+        expectedFillPricePnl(BTC_MARKET_PRICE, fillPrice, wei(5))
       );
 
       await assertRevert(

--- a/markets/perps-market/test/integration/Orders/Order.marginValidation.test.ts
+++ b/markets/perps-market/test/integration/Orders/Order.marginValidation.test.ts
@@ -6,7 +6,7 @@ import {
   openPosition,
   requiredMargins,
   getRequiredLiquidationRewardMargin,
-  expectedStartingPnl,
+  expectedFillPricePnl,
 } from '../helpers';
 import { wei } from '@synthetixio/wei';
 import { ethers } from 'ethers';
@@ -127,7 +127,7 @@ describe('Orders - margin validation', () => {
       );
 
       const availableMargin = wei(100).add(
-        expectedStartingPnl(ETH_MARKET_PRICE, fillPrice, wei(3))
+        expectedFillPricePnl(ETH_MARKET_PRICE, fillPrice, wei(3))
       );
 
       await assertRevert(
@@ -232,7 +232,7 @@ describe('Orders - margin validation', () => {
 
       const currentAvailableMargin = await systems().PerpsMarket.getAvailableMargin(2);
       const availableMargin = wei(currentAvailableMargin).add(
-        expectedStartingPnl(BTC_MARKET_PRICE, fillPrice, wei(5))
+        expectedFillPricePnl(BTC_MARKET_PRICE, fillPrice, wei(5))
       );
 
       await assertRevert(
@@ -335,7 +335,7 @@ describe('Orders - margin validation', () => {
 
       const currentAvailableMargin = await systems().PerpsMarket.getAvailableMargin(2);
       const availableMargin = wei(currentAvailableMargin).add(
-        expectedStartingPnl(BTC_MARKET_PRICE, fillPrice, wei(10))
+        expectedFillPricePnl(BTC_MARKET_PRICE, fillPrice, wei(5))
       );
 
       await assertRevert(

--- a/markets/perps-market/test/integration/Orders/Order.marginWithPd.test.ts
+++ b/markets/perps-market/test/integration/Orders/Order.marginWithPd.test.ts
@@ -6,7 +6,7 @@ import {
   openPosition,
   requiredMargins,
   getRequiredLiquidationRewardMargin,
-  expectedStartingPnl,
+  expectedFillPricePnl,
 } from '../helpers';
 import { wei } from '@synthetixio/wei';
 import { ethers } from 'ethers';
@@ -116,7 +116,7 @@ describe('Orders - margin validation with p/d', () => {
       );
 
       const availableMargin = startingMargin.add(
-        expectedStartingPnl(RNDR_PRICE, fillPrice, newSize)
+        expectedFillPricePnl(RNDR_PRICE, fillPrice, newSize)
       );
 
       await assertRevert(

--- a/markets/perps-market/test/integration/Position/InterestRate.reset.test.ts
+++ b/markets/perps-market/test/integration/Position/InterestRate.reset.test.ts
@@ -59,7 +59,12 @@ describe('Position - interest rates - reset', () => {
       const withdrawableUsd = wei(await systems().Core.getWithdrawableMarketUsd(superMarketId()));
       const totalCollateralValue = wei(await systems().PerpsMarket.totalGlobalCollateralValue());
       const delegatedCollateral = withdrawableUsd.sub(totalCollateralValue);
-      const minCredit = wei(await systems().PerpsMarket.minimumCredit(superMarketId()));
+
+      const snxUsdValue = wei(await systems().PerpsMarket.globalCollateralValue(0));
+      // remove snxUSD collateral value from min credit (which is added in contracts)
+      const minCredit = wei(await systems().PerpsMarket.minimumCredit(superMarketId())).sub(
+        snxUsdValue
+      );
 
       const utilRate = minCredit.div(delegatedCollateral);
       const currentInterestRate = calculateInterestRate(utilRate, interestRateParams);

--- a/markets/perps-market/test/integration/Position/InterestRate.test.ts
+++ b/markets/perps-market/test/integration/Position/InterestRate.test.ts
@@ -71,7 +71,12 @@ describe('Position - interest rates', () => {
       const withdrawableUsd = wei(await systems().Core.getWithdrawableMarketUsd(superMarketId()));
       const totalCollateralValue = wei(await systems().PerpsMarket.totalGlobalCollateralValue());
       const delegatedCollateral = withdrawableUsd.sub(totalCollateralValue);
-      const minCredit = wei(await systems().PerpsMarket.minimumCredit(superMarketId()));
+
+      const snxUsdValue = wei(await systems().PerpsMarket.globalCollateralValue(0));
+      // remove snxUSD collateral value from min credit (which is added in contracts)
+      const minCredit = wei(await systems().PerpsMarket.minimumCredit(superMarketId())).sub(
+        snxUsdValue
+      );
 
       const utilRate = minCredit.div(delegatedCollateral);
       currentInterestRate = calculateInterestRate(utilRate, interestRateParams);
@@ -214,6 +219,25 @@ describe('Position - interest rates', () => {
           .mul(normalizedTime);
         assertBn.near(owedInterest, expectedTrader2Interest.toBN(), bn(0.00001));
       });
+    });
+  });
+
+  describe('add margin to trader 1', () => {
+    let previousMarketInterestRate: Wei;
+    before('update interest rate and add margin', async () => {
+      await systems().PerpsMarket.updateInterestRate();
+      previousMarketInterestRate = wei(await systems().PerpsMarket.interestRate());
+      await systems().PerpsMarket.connect(trader1()).modifyCollateral(2, 0, bn(50_000));
+    });
+
+    before('call manual update', async () => {
+      await systems().PerpsMarket.updateInterestRate();
+    });
+
+    const { currentInterestRate } = checkMarketInterestRate();
+
+    it('does not change interest rate', async () => {
+      assertBn.equal(currentInterestRate().toBN(), previousMarketInterestRate.toBN());
     });
   });
 

--- a/markets/perps-market/test/integration/Position/InterestRate.tolerance.test.ts
+++ b/markets/perps-market/test/integration/Position/InterestRate.tolerance.test.ts
@@ -101,7 +101,9 @@ describe('InterestRate.tolerance', () => {
       const totalCollateralValue = wei(await systems().PerpsMarket.totalGlobalCollateralValue());
       const delegatedCollateral = withdrawableUsd.sub(totalCollateralValue);
 
-      const minCredit = calculateMinCredit(withMontlyTolerance);
+      const snxUsdValue = wei(await systems().PerpsMarket.globalCollateralValue(0));
+      // remove snxUSD collateral value from min credit (which is added in contracts)
+      const minCredit = calculateMinCredit(withMontlyTolerance).sub(snxUsdValue);
 
       const utilRate = minCredit.div(delegatedCollateral);
       currentInterestRate = calculateInterestRate(utilRate, interestRateParams);

--- a/markets/perps-market/test/integration/helpers/requiredMargins.ts
+++ b/markets/perps-market/test/integration/helpers/requiredMargins.ts
@@ -47,6 +47,6 @@ export const getRequiredLiquidationRewardMargin = (
   return Wei.min(Wei.max(reward, minCap), maxCap);
 };
 
-export const expectedStartingPnl = (marketPrice: Wei, fillPrice: Wei, positionSize: Wei) => {
+export const expectedFillPricePnl = (marketPrice: Wei, fillPrice: Wei, positionSize: Wei) => {
   return Wei.min(positionSize.mul(marketPrice.sub(fillPrice)), wei(0));
 };


### PR DESCRIPTION
Guardian Audit Fixes:

- [x] Fix utilization calculation to exclude snxUSD [Issue](https://www.notion.so/guardianaudits/C-02-cb3aa2725b2f41d5bc2e22ab22b37459?pvs=4)
- [x] Fix `calculateStartingPnl` using new position size instead of size delta [Issue](https://www.notion.so/guardianaudits/H-03-60ef6bbde43d46898d8a06dbfe4b221a?pvs=4)
- [x] Check market capacity during order validation to ensure market stays solvent. [Issue](https://www.notion.so/guardianaudits/H-02-9766797413ab46389b0f10ef50e1f216?pvs=4)