### PR TITLE
legacy market: remove `from` restriction on contract deploy

### DIFF
--- a/markets/legacy-market/cannonfile.toml
+++ b/markets/legacy-market/cannonfile.toml
@@ -37,7 +37,6 @@ abiOf = ["InitialModuleBundle"]
 # deploy the legacy market
 [contract.Market]
 artifact = "LegacyMarket"
-from = "<%= settings.owner %>"
 
 [invoke.upgradeProxy]
 target = ["InitialProxy"]

--- a/markets/legacy-market/package.json
+++ b/markets/legacy-market/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synthetixio/legacy-market",
-  "version": "3.3.4",
+  "version": "3.3.6",
   "description": "Contract for migration from v2x to v3",
   "private": true,
   "scripts": {


### PR DESCRIPTION
the contract in question can be deployed by any address since its accessed through a proxy, so the `from` address restriction should be removed

note: this has already been published/deployed