### PR TITLE
Add voting power weight configuration

### DIFF
--- a/protocol/governance/cannonfile.arbitrum-sepolia.toml
+++ b/protocol/governance/cannonfile.arbitrum-sepolia.toml
@@ -67,7 +67,7 @@ args = ["<%= settings.owner %>", "100", "1"]
 # target = ["GovernanceProxy"]
 # from = "<%= settings.owner %>"
 # func = "setSnapshotContract"
-# args = ["<%= contracts.SnapshotRecordMock.address %>", true]
+# args = ["<%= contracts.SnapshotRecordMock.address %>", 0, true]
 
 [invoke.set_registered_emitters]
 target = ["GovernanceProxy"]

--- a/protocol/governance/cannonfile.optimistic-sepolia.toml
+++ b/protocol/governance/cannonfile.optimistic-sepolia.toml
@@ -86,4 +86,4 @@ args = ["100000"]
 from = "<%= settings.owner %>"
 target = ["GovernanceProxy"]
 func = "setSnapshotContract"
-args = ["<%= contracts.SnapshotRecordMock.address %>", true]
+args = ["<%= contracts.SnapshotRecordMock.address %>", 0, true]

--- a/protocol/governance/contracts/interfaces/ISnapshotVotePowerModule.sol
+++ b/protocol/governance/contracts/interfaces/ISnapshotVotePowerModule.sol
@@ -1,6 +1,8 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {SnapshotVotePower} from "../storage/SnapshotVotePower.sol";
+
 interface ISnapshotVotePowerModule {
     error SnapshotAlreadyTaken(uint128 snapshotId);
     error BallotAlreadyPrepared(address voter, uint256 electionId);
@@ -8,7 +10,11 @@ interface ISnapshotVotePowerModule {
     error NoPower(uint256, address);
     error InvalidSnapshotContract();
 
-    function setSnapshotContract(address snapshotContract, bool enabled) external;
+    function setSnapshotContract(
+        address snapshotContract,
+        bool enabled,
+        SnapshotVotePower.WeightType weight
+    ) external;
 
     function takeVotePowerSnapshot(address snapshotContract) external returns (uint128 snapshotId);
 

--- a/protocol/governance/contracts/interfaces/ISnapshotVotePowerModule.sol
+++ b/protocol/governance/contracts/interfaces/ISnapshotVotePowerModule.sol
@@ -12,8 +12,8 @@ interface ISnapshotVotePowerModule {
 
     function setSnapshotContract(
         address snapshotContract,
-        bool enabled,
-        SnapshotVotePower.WeightType weight
+        SnapshotVotePower.WeightType weight,
+        bool enabled
     ) external;
 
     function takeVotePowerSnapshot(address snapshotContract) external returns (uint128 snapshotId);
@@ -21,5 +21,5 @@ interface ISnapshotVotePowerModule {
     function prepareBallotWithSnapshot(
         address snapshotContract,
         address voter
-    ) external returns (uint256 power);
+    ) external returns (uint256 votingPower);
 }

--- a/protocol/governance/contracts/modules/core/SnapshotVotePowerModule.sol
+++ b/protocol/governance/contracts/modules/core/SnapshotVotePowerModule.sol
@@ -14,7 +14,11 @@ import {SnapshotVotePowerEpoch} from "../../storage/SnapshotVotePowerEpoch.sol";
 contract SnapshotVotePowerModule is ISnapshotVotePowerModule {
     using SafeCastU256 for uint256;
 
-    function setSnapshotContract(address snapshotContract, bool enabled) external override {
+    function setSnapshotContract(
+        address snapshotContract,
+        bool enabled,
+        VotePowerType votePowerType,
+    ) external override {
         OwnableStorage.onlyOwner();
         Council.onlyInPeriod(Epoch.ElectionPeriod.Administration);
 
@@ -85,7 +89,11 @@ contract SnapshotVotePowerModule is ISnapshotVotePowerModule {
         }
 
         Ballot.Data storage ballot = Ballot.load(currentEpoch, voter, block.chainid);
-        ballot.votingPower += power;
+        ballot.votingPower += getVotePower(power);
         snapshotVotePower.epochs[currentEpoch].recordedVotingPower[voter] = power;
+    }
+
+    function getVotePower(power, algorthim) {
+
     }
 }

--- a/protocol/governance/contracts/storage/SnapshotVotePower.sol
+++ b/protocol/governance/contracts/storage/SnapshotVotePower.sol
@@ -27,7 +27,7 @@ library SnapshotVotePower {
         }
     }
 
-    function calculateVotePower(
+    function calculateVotingPower(
         SnapshotVotePower.WeightType weight,
         uint256 ballotBalance
     ) internal pure returns (uint256 votePower) {

--- a/protocol/governance/contracts/storage/SnapshotVotePower.sol
+++ b/protocol/governance/contracts/storage/SnapshotVotePower.sol
@@ -4,8 +4,15 @@ pragma solidity ^0.8.0;
 import {SnapshotVotePowerEpoch} from "./SnapshotVotePowerEpoch.sol";
 
 library SnapshotVotePower {
+    enum VotePowerType {
+        SQRT,
+        LINEAR,
+        SARASA,
+    }
+
     struct Data {
         bool enabled;
+        VotePowerType votePowerType;
         mapping(uint128 => SnapshotVotePowerEpoch.Data) epochs;
     }
 

--- a/protocol/governance/contracts/storage/SnapshotVotePower.sol
+++ b/protocol/governance/contracts/storage/SnapshotVotePower.sol
@@ -1,18 +1,20 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {MathUtil} from "../utils/MathUtil.sol";
 import {SnapshotVotePowerEpoch} from "./SnapshotVotePowerEpoch.sol";
 
 library SnapshotVotePower {
-    enum VotePowerType {
-        SQRT,
-        LINEAR,
-        SARASA,
+    error InvalidWeightType();
+
+    enum WeightType {
+        Sqrt,
+        Linear
     }
 
     struct Data {
         bool enabled;
-        VotePowerType votePowerType;
+        SnapshotVotePower.WeightType weight;
         mapping(uint128 => SnapshotVotePowerEpoch.Data) epochs;
     }
 
@@ -23,5 +25,20 @@ library SnapshotVotePower {
         assembly {
             self.slot := s
         }
+    }
+
+    function calculateVotePower(
+        SnapshotVotePower.WeightType weight,
+        uint256 ballotBalance
+    ) internal pure returns (uint256 votePower) {
+        if (weight == WeightType.Sqrt) {
+            return MathUtil.sqrt(ballotBalance);
+        }
+
+        if (weight == WeightType.Linear) {
+            return ballotBalance;
+        }
+
+        revert InvalidWeightType();
     }
 }

--- a/protocol/governance/contracts/utils/MathUtil.sol
+++ b/protocol/governance/contracts/utils/MathUtil.sol
@@ -1,0 +1,66 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/*
+    Reference implementations:
+    * Solmate - https://github.com/Rari-Capital/solmate/blob/main/src/utils/FixedPointMathLib.sol
+*/
+
+library MathUtil {
+    function sqrt(uint256 x) internal pure returns (uint256 z) {
+        assembly {
+            // Start off with z at 1.
+            z := 1
+
+            // Used below to help find a nearby power of 2.
+            let y := x
+
+            // Find the lowest power of 2 that is at least sqrt(x).
+            if iszero(lt(y, 0x100000000000000000000000000000000)) {
+                y := shr(128, y) // Like dividing by 2 ** 128.
+                z := shl(64, z) // Like multiplying by 2 ** 64.
+            }
+            if iszero(lt(y, 0x10000000000000000)) {
+                y := shr(64, y) // Like dividing by 2 ** 64.
+                z := shl(32, z) // Like multiplying by 2 ** 32.
+            }
+            if iszero(lt(y, 0x100000000)) {
+                y := shr(32, y) // Like dividing by 2 ** 32.
+                z := shl(16, z) // Like multiplying by 2 ** 16.
+            }
+            if iszero(lt(y, 0x10000)) {
+                y := shr(16, y) // Like dividing by 2 ** 16.
+                z := shl(8, z) // Like multiplying by 2 ** 8.
+            }
+            if iszero(lt(y, 0x100)) {
+                y := shr(8, y) // Like dividing by 2 ** 8.
+                z := shl(4, z) // Like multiplying by 2 ** 4.
+            }
+            if iszero(lt(y, 0x10)) {
+                y := shr(4, y) // Like dividing by 2 ** 4.
+                z := shl(2, z) // Like multiplying by 2 ** 2.
+            }
+            if iszero(lt(y, 0x8)) {
+                // Equivalent to 2 ** z.
+                z := shl(1, z)
+            }
+
+            // Shifting right by 1 is like dividing by 2.
+            z := shr(1, add(z, div(x, z)))
+            z := shr(1, add(z, div(x, z)))
+            z := shr(1, add(z, div(x, z)))
+            z := shr(1, add(z, div(x, z)))
+            z := shr(1, add(z, div(x, z)))
+            z := shr(1, add(z, div(x, z)))
+            z := shr(1, add(z, div(x, z)))
+
+            // Compute a rounded down version of z.
+            let zRoundDown := div(x, z)
+
+            // If zRoundDown is smaller, use it.
+            if lt(zRoundDown, z) {
+                z := zRoundDown
+            }
+        }
+    }
+}

--- a/protocol/governance/storage.dump.sol
+++ b/protocol/governance/storage.dump.sol
@@ -342,8 +342,13 @@ library Epoch {
 
 // @custom:artifact contracts/storage/SnapshotVotePower.sol:SnapshotVotePower
 library SnapshotVotePower {
+    enum WeightType {
+        Sqrt,
+        Linear
+    }
     struct Data {
         bool enabled;
+        SnapshotVotePower.WeightType weight;
         mapping(uint128 => SnapshotVotePowerEpoch.Data) epochs;
     }
     function load(address snapshotContract) internal pure returns (Data storage self) {

--- a/protocol/governance/test/contracts/SnapshotVotePowerModule.test.ts
+++ b/protocol/governance/test/contracts/SnapshotVotePowerModule.test.ts
@@ -23,7 +23,7 @@ describe('SnapshotVotePowerModule', function () {
 
     it('should revert when not owner', async function () {
       await assertRevert(
-        c.GovernanceProxy.connect(user).setSnapshotContract(c.SnapshotRecordMock.address, true),
+        c.GovernanceProxy.connect(user).setSnapshotContract(c.SnapshotRecordMock.address, 0, true),
         `Unauthorized("${await user.getAddress()}"`,
         c.GovernanceProxy
       );
@@ -37,7 +37,7 @@ describe('SnapshotVotePowerModule', function () {
     });
 
     it('should set snapshot contract', async function () {
-      await c.GovernanceProxy.setSnapshotContract(c.SnapshotRecordMock.address, true);
+      await c.GovernanceProxy.setSnapshotContract(c.SnapshotRecordMock.address, 0, true);
       assert.equal(
         await c.GovernanceProxy.SnapshotVotePower_get_enabled(c.SnapshotRecordMock.address),
         true
@@ -45,7 +45,7 @@ describe('SnapshotVotePowerModule', function () {
     });
 
     it('should unset snapshot contract', async function () {
-      await c.GovernanceProxy.setSnapshotContract(c.SnapshotRecordMock.address, false);
+      await c.GovernanceProxy.setSnapshotContract(c.SnapshotRecordMock.address, 0, false);
       assert.equal(
         await c.GovernanceProxy.SnapshotVotePower_get_enabled(c.SnapshotRecordMock.address),
         false
@@ -59,11 +59,11 @@ describe('SnapshotVotePowerModule', function () {
     const disabledSnapshotContract = ethers.Wallet.createRandom().address;
     before('setup snapshot contracts', async function () {
       // setup main snapshot contract
-      await c.GovernanceProxy.setSnapshotContract(c.SnapshotRecordMock.address, true);
+      await c.GovernanceProxy.setSnapshotContract(c.SnapshotRecordMock.address, 0, true);
 
       // setup and disable an snapshot contract
-      await c.GovernanceProxy.setSnapshotContract(disabledSnapshotContract, true);
-      await c.GovernanceProxy.setSnapshotContract(disabledSnapshotContract, false);
+      await c.GovernanceProxy.setSnapshotContract(disabledSnapshotContract, 0, true);
+      await c.GovernanceProxy.setSnapshotContract(disabledSnapshotContract, 0, false);
     });
 
     it('should revert when not correct epoch phase', async function () {
@@ -131,12 +131,12 @@ describe('SnapshotVotePowerModule', function () {
 
     before('setup disabled snapshot contract', async function () {
       // setup and disable an snapshot contract
-      await c.GovernanceProxy.setSnapshotContract(disabledSnapshotContract, true);
-      await c.GovernanceProxy.setSnapshotContract(disabledSnapshotContract, false);
+      await c.GovernanceProxy.setSnapshotContract(disabledSnapshotContract, 0, true);
+      await c.GovernanceProxy.setSnapshotContract(disabledSnapshotContract, 0, false);
     });
 
     before('set snapshot contract', async function () {
-      await c.GovernanceProxy.setSnapshotContract(c.SnapshotRecordMock.address, true);
+      await c.GovernanceProxy.setSnapshotContract(c.SnapshotRecordMock.address, 0, true);
       const settings = await c.GovernanceProxy.getEpochSchedule();
       await fastForwardTo(settings.nominationPeriodStartDate.toNumber(), getProvider());
       await c.GovernanceProxy.takeVotePowerSnapshot(c.SnapshotRecordMock.address);
@@ -189,7 +189,7 @@ describe('SnapshotVotePowerModule', function () {
           await user.getAddress()
         );
 
-        assertBn.equal(foundVotingPower, 100);
+        assertBn.equal(foundVotingPower, 10);
 
         const ballotVotingPower = await c.GovernanceProxy.Ballot_get_votingPower(
           await c.GovernanceProxy.Council_get_currentElectionId(),
@@ -197,7 +197,7 @@ describe('SnapshotVotePowerModule', function () {
           13370 // precinct is current chain id
         );
 
-        assertBn.equal(ballotVotingPower, 100);
+        assertBn.equal(ballotVotingPower, 10);
       });
     });
   });

--- a/protocol/governance/test/integration/CrossChainElections.test.ts
+++ b/protocol/governance/test/integration/CrossChainElections.test.ts
@@ -108,10 +108,12 @@ describe('cross chain election testing', function () {
   describe('successful voting on all chains', function () {
     before('prepare snapshot record on all chains', async function () {
       for (const chain of typedValues(chains)) {
-        await chain.GovernanceProxy.connect(chain.signer).setSnapshotContract(
+        const tx = await chain.GovernanceProxy.connect(chain.signer).setSnapshotContract(
           chain.SnapshotRecordMock.address,
+          0,
           true
         );
+        await tx.wait();
       }
     });
 
@@ -130,7 +132,7 @@ describe('cross chain election testing', function () {
         await chain.GovernanceProxy.takeVotePowerSnapshot(chain.SnapshotRecordMock.address);
         await chain.SnapshotRecordMock.setBalanceOfOnPeriod(
           await voter[chainName].getAddress(),
-          ethers.utils.parseEther('100'),
+          100,
           snapshotId1.toString()
         );
         await chain.GovernanceProxy.prepareBallotWithSnapshot(
@@ -145,7 +147,7 @@ describe('cross chain election testing', function () {
 
       const tx = await mothership.GovernanceProxy.connect(voter.mothership).cast(
         [await nominee.mothership.getAddress()],
-        [ethers.utils.parseEther('100')],
+        [10],
         {
           gasLimit: 9000000,
         }
@@ -165,7 +167,7 @@ describe('cross chain election testing', function () {
 
       const tx = await satellite1.GovernanceProxy.connect(voter.satellite1).cast(
         [await nominee.mothership.getAddress()],
-        [ethers.utils.parseEther('100')]
+        [10]
       );
 
       await deliverCrossChainCast(
@@ -187,7 +189,7 @@ describe('cross chain election testing', function () {
 
       const tx = await satellite2.GovernanceProxy.connect(voter.satellite2).cast(
         [await nominee.mothership.getAddress()],
-        [ethers.utils.parseEther('100')]
+        [10]
       );
 
       await deliverCrossChainCast(

--- a/protocol/governance/test/integration/Elections.test.ts
+++ b/protocol/governance/test/integration/Elections.test.ts
@@ -106,14 +106,17 @@ describe('SynthetixElectionModule - Elections', () => {
     const { mothership, satellite1, satellite2 } = chains;
     await mothership.GovernanceProxy.setSnapshotContract(
       mothership.SnapshotRecordMock.address,
+      0,
       true
     );
     await satellite1.GovernanceProxy.setSnapshotContract(
       satellite1.SnapshotRecordMock.address,
+      0,
       true
     );
     await satellite2.GovernanceProxy.setSnapshotContract(
       satellite2.SnapshotRecordMock.address,
+      0,
       true
     );
   });
@@ -240,6 +243,7 @@ describe('SynthetixElectionModule - Elections', () => {
             await assertRevert(
               mothership.GovernanceProxy.setSnapshotContract(
                 mothership.SnapshotRecordMock.address,
+                0,
                 true
               ),
               'NotCallableInCurrentPeriod'
@@ -247,6 +251,7 @@ describe('SynthetixElectionModule - Elections', () => {
             await assertRevert(
               satellite1.GovernanceProxy.setSnapshotContract(
                 satellite1.SnapshotRecordMock.address,
+                0,
                 true
               ),
               'NotCallableInCurrentPeriod'
@@ -254,6 +259,7 @@ describe('SynthetixElectionModule - Elections', () => {
             await assertRevert(
               satellite2.GovernanceProxy.setSnapshotContract(
                 satellite2.SnapshotRecordMock.address,
+                0,
                 true
               ),
               'NotCallableInCurrentPeriod'
@@ -274,27 +280,27 @@ describe('SynthetixElectionModule - Elections', () => {
 
           await mothership.SnapshotRecordMock.setBalanceOfOnPeriod(
             addresses[0].address,
-            ethers.utils.parseEther('100'),
+            100,
             snapshotId.toString()
           );
           await mothership.SnapshotRecordMock.setBalanceOfOnPeriod(
             addresses[1].address,
-            ethers.utils.parseEther('100'),
+            100,
             snapshotId.toString()
           );
           await mothership.SnapshotRecordMock.setBalanceOfOnPeriod(
             addresses[2].address,
-            ethers.utils.parseEther('100'),
+            100,
             snapshotId.toString()
           );
           await mothership.SnapshotRecordMock.setBalanceOfOnPeriod(
             addresses[3].address,
-            ethers.utils.parseEther('100'),
+            100,
             snapshotId.toString()
           );
           await mothership.SnapshotRecordMock.setBalanceOfOnPeriod(
             addresses[4].address,
-            ethers.utils.parseEther('100'),
+            100,
             snapshotId.toString()
           );
 
@@ -309,27 +315,27 @@ describe('SynthetixElectionModule - Elections', () => {
 
           await satellite1.SnapshotRecordMock.setBalanceOfOnPeriod(
             addresses[0].address,
-            ethers.utils.parseEther('100'),
+            100,
             snapshotId1.toString()
           );
           await satellite1.SnapshotRecordMock.setBalanceOfOnPeriod(
             addresses[1].address,
-            ethers.utils.parseEther('100'),
+            100,
             snapshotId1.toString()
           );
           await satellite1.SnapshotRecordMock.setBalanceOfOnPeriod(
             addresses[2].address,
-            ethers.utils.parseEther('100'),
+            100,
             snapshotId1.toString()
           );
           await satellite1.SnapshotRecordMock.setBalanceOfOnPeriod(
             addresses[3].address,
-            ethers.utils.parseEther('100'),
+            100,
             snapshotId1.toString()
           );
           await satellite1.SnapshotRecordMock.setBalanceOfOnPeriod(
             addresses[4].address,
-            ethers.utils.parseEther('100'),
+            100,
             snapshotId1.toString()
           );
 
@@ -344,27 +350,27 @@ describe('SynthetixElectionModule - Elections', () => {
 
           await satellite2.SnapshotRecordMock.setBalanceOfOnPeriod(
             addresses[0].address,
-            ethers.utils.parseEther('100'),
+            100,
             snapshotId2.toString()
           );
           await satellite2.SnapshotRecordMock.setBalanceOfOnPeriod(
             addresses[1].address,
-            ethers.utils.parseEther('100'),
+            100,
             snapshotId2.toString()
           );
           await satellite2.SnapshotRecordMock.setBalanceOfOnPeriod(
             addresses[2].address,
-            ethers.utils.parseEther('100'),
+            100,
             snapshotId2.toString()
           );
           await satellite2.SnapshotRecordMock.setBalanceOfOnPeriod(
             addresses[3].address,
-            ethers.utils.parseEther('100'),
+            100,
             snapshotId2.toString()
           );
           await satellite2.SnapshotRecordMock.setBalanceOfOnPeriod(
             addresses[4].address,
-            ethers.utils.parseEther('100'),
+            100,
             snapshotId2.toString()
           );
         });
@@ -625,28 +631,28 @@ describe('SynthetixElectionModule - Elections', () => {
 
                   await mothership.GovernanceProxy.connect(
                     addresses[0].connect(mothership.provider)
-                  ).cast([epoch.winners()[0]], [ethers.utils.parseEther('100')]);
+                  ).cast([epoch.winners()[0]], [10]);
 
                   await mothership.GovernanceProxy.connect(
                     addresses[1].connect(mothership.provider)
-                  ).cast([epoch.winners()[0]], [ethers.utils.parseEther('100')]);
+                  ).cast([epoch.winners()[0]], [10]);
 
                   // addresses[2] didn't declare cross chain debt shares yet
                   await assertRevert(
                     mothership.GovernanceProxy.connect(
                       addresses[2].connect(mothership.provider)
-                    ).cast([addresses[4].address], [ethers.utils.parseEther('100')]),
+                    ).cast([addresses[4].address], [10]),
                     'NoVotingPower',
                     mothership.GovernanceProxy
                   );
 
                   await mothership.GovernanceProxy.connect(
                     addresses[3].connect(mothership.provider)
-                  ).cast([addresses[1].address], [ethers.utils.parseEther('100')]);
+                  ).cast([addresses[1].address], [10]);
 
                   await mothership.GovernanceProxy.connect(
                     addresses[4].connect(mothership.provider)
-                  ).cast([epoch.winners()[0]], [ethers.utils.parseEther('100')]);
+                  ).cast([epoch.winners()[0]], [10]);
                 });
 
                 it('do not allow partial voting', async () => {
@@ -654,7 +660,7 @@ describe('SynthetixElectionModule - Elections', () => {
                   await assertRevert(
                     mothership.GovernanceProxy.connect(
                       addresses[0].connect(mothership.provider)
-                    ).cast([addresses[3].address], [ethers.utils.parseEther('10')]),
+                    ).cast([addresses[3].address], [13]),
                     'InvalidBallot',
                     mothership.GovernanceProxy
                   );
@@ -699,11 +705,7 @@ describe('SynthetixElectionModule - Elections', () => {
                       ballotForFirstAddress.votedCandidates,
                       ballotForFirstAddress.votingPower,
                     ],
-                    [
-                      [ethers.utils.parseEther('100')],
-                      [epoch.winners()[0]],
-                      ethers.utils.parseEther('100'),
-                    ]
+                    [[ethers.BigNumber.from(10)], [epoch.winners()[0]], ethers.BigNumber.from(10)]
                   );
 
                   assert.deepEqual(
@@ -712,11 +714,7 @@ describe('SynthetixElectionModule - Elections', () => {
                       ballotForSecondAddress.votedCandidates,
                       ballotForSecondAddress.votingPower,
                     ],
-                    [
-                      [ethers.utils.parseEther('100')],
-                      [epoch.winners()[0]],
-                      ethers.utils.parseEther('100'),
-                    ]
+                    [[ethers.BigNumber.from(10)], [epoch.winners()[0]], ethers.BigNumber.from(10)]
                   );
 
                   //  should be empty
@@ -726,7 +724,7 @@ describe('SynthetixElectionModule - Elections', () => {
                       ballotForThirdAddress.votedCandidates,
                       ballotForThirdAddress.votingPower,
                     ],
-                    [[], [], ethers.utils.parseEther('0')]
+                    [[], [], ethers.BigNumber.from(0)]
                   );
 
                   assert.deepEqual(
@@ -735,11 +733,7 @@ describe('SynthetixElectionModule - Elections', () => {
                       ballotForFourthAddress.votedCandidates,
                       ballotForFourthAddress.votingPower,
                     ],
-                    [
-                      [ethers.utils.parseEther('100')],
-                      [addresses[1].address],
-                      ethers.utils.parseEther('100'),
-                    ]
+                    [[ethers.BigNumber.from(10)], [addresses[1].address], ethers.BigNumber.from(10)]
                   );
 
                   assert.deepEqual(
@@ -748,11 +742,7 @@ describe('SynthetixElectionModule - Elections', () => {
                       ballotForFifthAddress.votedCandidates,
                       ballotForFifthAddress.votingPower,
                     ],
-                    [
-                      [ethers.utils.parseEther('100')],
-                      [epoch.winners()[0]],
-                      ethers.utils.parseEther('100'),
-                    ]
+                    [[ethers.BigNumber.from(10)], [epoch.winners()[0]], ethers.BigNumber.from(10)]
                   );
                 });
 


### PR DESCRIPTION
This PR adds the possibility to set how the voting power is calculated for the given snapshot contract balance. It defaults to the square root of the balance, which on previous versions was the default.