### PR TITLE
Make self-liquidate non-profitable / C02

### DIFF
--- a/markets/perps-market/contracts/storage/PerpsAccount.sol
+++ b/markets/perps-market/contracts/storage/PerpsAccount.sol
@@ -183,7 +183,7 @@ library PerpsAccount {
             .toInt();
 
         availableMargin = getAvailableMargin(self, stalenessTolerance) - totalLiquidationReward;
-        isEligible = availableMargin < 0;
+        isEligible = availableMargin < 0 && self.debt > 0;
     }
 
     function isEligibleForLiquidation(


### PR DESCRIPTION
make self-liquidate unprofitable by only allowing it if the account has outstanding debt