### PR TITLE
fix: add OwnableStorage.onlyOwner and tests setMinDelegationTime

### DIFF
--- a/markets/bfp-market/contracts/interfaces/IMarketConfigurationModule.sol
+++ b/markets/bfp-market/contracts/interfaces/IMarketConfigurationModule.sol
@@ -82,6 +82,11 @@ interface IMarketConfigurationModule is IBasePerpMarket {
         IMarketConfigurationModule.ConfigureByMarketParameters memory data
     ) external;
 
+    /// @notice Updates the minimum delegation time for a market.
+    /// @param marketId Market to update
+    /// @param minDelegationTime Minimum delegation time in seconds
+    function setMinDelegationTime(uint128 marketId, uint32 minDelegationTime) external;
+
     // --- Views --- //
 
     /// @notice Returns configured global market parameters.
@@ -97,9 +102,4 @@ interface IMarketConfigurationModule is IBasePerpMarket {
     function getMarketConfigurationById(
         uint128 marketId
     ) external view returns (PerpMarketConfiguration.Data memory);
-
-    /// @notice Updates the minimum delegation time for a market.
-    /// @param marketId Market to update
-    /// @param minDelegationTime Minimum delegation time in seconds
-    function setMinDelegationTime(uint128 marketId, uint32 minDelegationTime) external;
 }

--- a/markets/bfp-market/contracts/modules/MarketConfigurationModule.sol
+++ b/markets/bfp-market/contracts/modules/MarketConfigurationModule.sol
@@ -122,6 +122,12 @@ contract MarketConfigurationModule is IMarketConfigurationModule {
         emit MarketConfigured(marketId, ERC2771Context._msgSender());
     }
 
+    /// @inheritdoc IMarketConfigurationModule
+    function setMinDelegationTime(uint128 marketId, uint32 minDelegationTime) external {
+        OwnableStorage.onlyOwner();
+        ISynthetixSystem(SYNTHETIX_CORE).setMarketMinDelegateTime(marketId, minDelegationTime);
+    }
+
     // --- Views --- //
 
     /// @inheritdoc IMarketConfigurationModule
@@ -138,10 +144,5 @@ contract MarketConfigurationModule is IMarketConfigurationModule {
         uint128 marketId
     ) external pure returns (PerpMarketConfiguration.Data memory) {
         return PerpMarketConfiguration.load(marketId);
-    }
-
-    /// @inheritdoc IMarketConfigurationModule
-    function setMinDelegationTime(uint128 marketId, uint32 minDelegationTime) external {
-        ISynthetixSystem(SYNTHETIX_CORE).setMarketMinDelegateTime(marketId, minDelegationTime);
     }
 }


### PR DESCRIPTION
Resolves an `onlyOwner` bug in previous PR https://github.com/Synthetixio/synthetix-v3/pull/2227, shuffles the fn definition to be grouped with mutations, and added new tests.