### PR TITLE
fix build script in core-modules

### DIFF
--- a/utils/core-modules/package.json
+++ b/utils/core-modules/package.json
@@ -14,7 +14,7 @@
     "clean": "hardhat clean && rm -rf contracts/generated",
     "build": "yarn build:contracts",
     "storage:verify": "hardhat compile --force && hardhat storage:verify",
-    "build:contracts": "hardhat compile --force && CANNON_REGISTRY_PRIORITY=local hardhat cannon:build",
+    "build:contracts": "hardhat compile --force",
     "generate-testable": "rm -rf contracts/generated && hardhat generate-testable",
     "build-testable": "hardhat compile",
     "check:storage": "git diff --exit-code storage.dump.sol",


### PR DESCRIPTION
According to @mjlescano, the `core-modules` package is imported via npm and isn't required to be built by cannon.

Currently breaking on main:


![image](https://github.com/user-attachments/assets/e8768c6d-a07d-4a4c-a589-7c5fdd8473f3)


Steps to reproduce:

1. `git checkout main`

2. `cd utils/core-modules`

3. `yarn build`

