### PR TITLE
Fix to skip empty pool collateral distribution reverts

### DIFF
--- a/protocol/synthetix/contracts/modules/core/RewardsManagerModule.sol
+++ b/protocol/synthetix/contracts/modules/core/RewardsManagerModule.sol
@@ -316,7 +316,7 @@ contract RewardsManagerModule is IRewardsManagerModule {
             );
         }
 
-        Distribution.Data distData = collateralType == address(0)
+        Distribution.Data storage distData = collateralType == address(0)
             ? pool.vaultsDebtDistribution
             : pool.vaults[collateralType].currentEpoch().accountsDebtDistribution;
 

--- a/protocol/synthetix/contracts/modules/core/RewardsManagerModule.sol
+++ b/protocol/synthetix/contracts/modules/core/RewardsManagerModule.sol
@@ -316,11 +316,18 @@ contract RewardsManagerModule is IRewardsManagerModule {
             );
         }
 
+        Distribution.Data distData = collateralType == address(0)
+            ? pool.vaultsDebtDistribution
+            : pool.vaults[collateralType].currentEpoch().accountsDebtDistribution;
+
+        // If the amount to distribute is 0 or the total shares are 0, we can skip the distribution
+        if (amount == 0 || distData.totalSharesD18 == 0) {
+            return 0;
+        }
+
         (int256 diffReward, int256 cancelledAmount) = rd.distribute(
             // if the rewards to be distributed are at the pool level, we want to use the pool distribution (trickle down happens later)
-            collateralType == address(0)
-                ? pool.vaultsDebtDistribution
-                : pool.vaults[collateralType].currentEpoch().accountsDebtDistribution,
+            distData,
             amount.toInt(),
             start,
             duration


### PR DESCRIPTION
Prevents reverts on attempts to distribute rewards to an empty pool collateral.

Issue link:
https://www.notion.so/guardianaudits/M-21-1a8104646bc74f5abd6d35c8a3e6e096?pvs=4