### PR TITLE
Fix for L-17 issue

### DIFF
--- a/markets/bfp-market/contracts/storage/Position.sol
+++ b/markets/bfp-market/contracts/storage/Position.sol
@@ -508,14 +508,10 @@ library Position {
             globalConfig
         );
 
-        uint256 liqKeeperFee = getLiquidationKeeperFee(
-            absSize,
-            ethPrice,
-            marketConfig,
-            globalConfig
-        );
+        uint256 marginAdjustment = marketConfig.minMarginUsd +
+            liqFlagReward +
+            globalConfig.maxKeeperFeeUsd;
 
-        uint256 marginAdjustment = marketConfig.minMarginUsd + liqFlagReward + liqKeeperFee;
         im = notional.mulDecimal(imr) + marginAdjustment;
         mm = notional.mulDecimal(mmr) + marginAdjustment;
     }


### PR DESCRIPTION
**Description**

In the `getLiquidationMarginUsd` function the `marginAdjustment` includes the estimated liquidation flag fee and liquidation fees. These fees are a best estimate of what the real fees may be in the event that the position were to be liquidated. However as the Initial margin aims to provide a safety buffer it may be prudent to use the maximum that these liquidation costs can be in the estimate of the margin requirements. 

This way any potential under allocation of the margin requirements with respect to liquidation fees is avoided.

**Recommendation**

Consider using the `maxKeeperFeeUsd` in the `marginAdjustment` for the liquidation flag fee and the `maxKeeperFeeUsd * iterations` for the `liqKeeperFee` instead of the estimated amounts, which are based upon the current block base fee.
https://www.notion.so/guardianaudits/L-17-3a6cba4df1064a22ac0ff906474beebd?pvs=4