### PR TITLE
Fix for L-21 issue

### DIFF
--- a/markets/bfp-market/contracts/storage/Margin.sol
+++ b/markets/bfp-market/contracts/storage/Margin.sol
@@ -414,7 +414,11 @@ library Margin {
         uint256 liqFeeWithRewardInUsd = liqFeeInUsd +
             collateralValue.mulDecimal(marketConfig.liquidationRewardPercent);
 
-        return MathUtil.min(liqFeeWithRewardInUsd, globalConfig.maxKeeperFeeUsd);
+        uint256 boundedKeeperFeeUsd = MathUtil.min(
+            MathUtil.max(globalConfig.minKeeperFeeUsd, liqFeeWithRewardInUsd),
+            globalConfig.maxKeeperFeeUsd
+        );
+        return boundedKeeperFeeUsd;
     }
 
     /// @dev Returns whether an account in a specific market's margin can be liquidated.

--- a/markets/bfp-market/contracts/storage/Position.sol
+++ b/markets/bfp-market/contracts/storage/Position.sol
@@ -455,7 +455,11 @@ library Position {
                 marketConfig.liquidationRewardPercent
             );
 
-        return MathUtil.min(flagFeeWithRewardInUsd, globalConfig.maxKeeperFeeUsd);
+        uint256 boundedKeeperFeeUsd = MathUtil.min(
+            MathUtil.max(globalConfig.minKeeperFeeUsd, flagFeeWithRewardInUsd),
+            globalConfig.maxKeeperFeeUsd
+        );
+        return boundedKeeperFeeUsd;
     }
 
     /**
@@ -559,7 +563,11 @@ library Position {
         );
         uint256 iterations = getLiquidationIterations(size, maxLiqCapacity);
 
-        return MathUtil.min(liquidationFeeInUsd * iterations, globalConfig.maxKeeperFeeUsd);
+        uint256 boundedKeeperFeeUsd = MathUtil.min(
+            MathUtil.max(globalConfig.minKeeperFeeUsd, liquidationFeeInUsd * iterations),
+            globalConfig.maxKeeperFeeUsd
+        );
+        return boundedKeeperFeeUsd;
     }
 
     /// @dev Returns the health data given the `marketId`, `config`, and position{...} details.


### PR DESCRIPTION
**Description**

The `getMarginLiquidationOnlyReward`, `getLiquidationFlagReward`, and `getLiquidationKeeperFee` functions do not apply the `minKeeperFeeUsd` to the resulting keeper reward like the `getCancellationKeeperFee` and `getSettlementKeeperFee` functions do.

https://www.notion.so/guardianaudits/L-21-b9c3a48c7b154a84b7dadacfa60fd3e3?pvs=4