### PR TITLE
Fix for L-22 issue

### DIFF
--- a/markets/bfp-market/contracts/storage/Order.sol
+++ b/markets/bfp-market/contracts/storage/Order.sol
@@ -109,9 +109,12 @@ library Order {
         uint256 baseKeeperFeeUsd = ethPrice.mulDecimal(
             globalConfig.keeperSettlementGasUnits * block.basefee
         );
-        uint256 baseKeeperFeePlusProfitUsd = baseKeeperFeeUsd.mulDecimal(
-            DecimalMath.UNIT + globalConfig.keeperProfitMarginPercent
-        ) + keeperFeeBufferUsd;
+        uint256 baseKeeperFeePlusProfitUsd = MathUtil.max(
+            baseKeeperFeeUsd.mulDecimal(DecimalMath.UNIT + globalConfig.keeperProfitMarginPercent) +
+                keeperFeeBufferUsd,
+            baseKeeperFeeUsd + globalConfig.keeperProfitMarginUsd
+        );
+
         uint256 boundedKeeperFeeUsd = MathUtil.min(
             MathUtil.max(globalConfig.minKeeperFeeUsd, baseKeeperFeePlusProfitUsd),
             globalConfig.maxKeeperFeeUsd
@@ -126,8 +129,9 @@ library Order {
         uint256 baseKeeperFeeUsd = ethPrice.mulDecimal(
             globalConfig.keeperCancellationGasUnits * block.basefee
         );
-        uint256 baseKeeperFeePlusProfitUsd = baseKeeperFeeUsd.mulDecimal(
-            DecimalMath.UNIT + globalConfig.keeperProfitMarginPercent
+        uint256 baseKeeperFeePlusProfitUsd = MathUtil.max(
+            baseKeeperFeeUsd.mulDecimal(DecimalMath.UNIT + globalConfig.keeperProfitMarginPercent),
+            baseKeeperFeeUsd + globalConfig.keeperProfitMarginUsd
         );
         uint256 boundedKeeperFeeUsd = MathUtil.min(
             MathUtil.max(globalConfig.minKeeperFeeUsd, baseKeeperFeePlusProfitUsd),


### PR DESCRIPTION
**Description**

In the `getCancellationKeeperFee` and `getSettlementKeeperFee` functions the `keeperProfitMarginUsd` is not included in the consideration for the computed `baseKeeperFeePlusProfitUsd`.

This may be unexpected as the `getLiquidationFlagReward`, `getLiquidationKeeperFee` and `getMarginLiquidationOnlyReward` keeper fees include this static adjustment. In cases where the `baseKeeperFeeUsd` is small relative to the priority fee necessary to get the transaction recorded this can result in latent settlements and executions as the `keeperProfitMarginPercent` would not contribute as much as the static `keeperProfitMarginUsd` would have.
https://www.notion.so/guardianaudits/L-22-593481c4b88f42148cf4602e2734b51e?pvs=4