### PR TITLE
M-08: Liquidation rewards for first window is ignored

### DIFF
--- a/markets/perps-market/contracts/storage/PerpsAccount.sol
+++ b/markets/perps-market/contracts/storage/PerpsAccount.sol
@@ -536,7 +536,7 @@ library PerpsAccount {
         uint256 costOfLiquidation = keeperCosts.getLiquidateKeeperCosts();
         uint256 liquidateAndFlagCost = globalConfig.keeperReward(
             accumulatedLiquidationRewards,
-            costOfFlagging,
+            costOfFlagging + costOfLiquidation,
             getTotalCollateralValue(self, PerpsPrice.Tolerance.DEFAULT, false)
         );
         uint256 liquidateWindowsCosts = numOfWindows == 0


### PR DESCRIPTION
**Description**

`PerpsAccount.getPossibleLiquidationReward` computes the liquidation reward as `costOfLiquidation * (numOfWindows - 1)`.

There is a wrong assumption that the first liquidation window is already accounted for in the `liquidateAndFlagCost` variable.

It is wrong because when that variable is calculated, only `costOfFlagging` is passed to `keeperReward()` .

In result, the liquidation cost for the first window will not be added towards the total liquidation cost.

**Recommendation**

When calling `keeperReward()` to compute `liquidateAndFlagCost`, pass `costOfFlagging + costOfLiquidation` as second parameter.