### PR TITLE
when checking capacity locked, also add the deposited collateral value

### DIFF
--- a/protocol/synthetix/contracts/storage/Market.sol
+++ b/protocol/synthetix/contracts/storage/Market.sol
@@ -298,7 +298,14 @@ library Market {
      *
      */
     function isCapacityLocked(Data storage self) internal view returns (bool) {
-        return self.creditCapacityD18 < getLockedCreditCapacity(self).toInt();
+        (
+            uint256 depositedCollateralValue,
+            bytes memory possibleError
+        ) = getDepositedCollateralValue(self);
+        RevertUtil.revertIfError(possibleError);
+        return
+            self.creditCapacityD18 + depositedCollateralValue.toInt() <
+            getLockedCreditCapacity(self).toInt();
     }
 
     /**


### PR DESCRIPTION
this is a much more correct calculation for determining if capacity is sufficient or not.

Its good that this issue turned out to be so benign.