### PR TITLE
Add rebalanceDebt function

### DIFF
--- a/markets/perps-market/contracts/interfaces/IPerpsAccountModule.sol
+++ b/markets/perps-market/contracts/interfaces/IPerpsAccountModule.sol
@@ -11,7 +11,7 @@ interface IPerpsAccountModule {
     error InvalidDistributor(uint128 collateralId);
 
     /**
-     * @notice Gets fired when an account colateral is modified.
+     * @notice Gets fired when an account collateral is modified.
      * @param accountId Id of the account.
      * @param collateralId Id of the synth market used as collateral. Synth market id, 0 for snxUSD.
      * @param amountDelta requested change in amount of collateral delegated to the account.
@@ -145,6 +145,13 @@ interface IPerpsAccountModule {
      * @param amount debt amount to pay off
      */
     function payDebt(uint128 accountId, uint256 amount) external;
+
+    /**
+     * @notice Allows the account owner to pay debt using it's margin
+     * @param accountId Id of the account.
+     * @param amount debt amount to pay off
+     */
+    function rebalanceDebt(uint128 accountId, uint256 amount) external;
 
     /**
      * @notice Returns account's debt

--- a/markets/perps-market/contracts/storage/PerpsAccount.sol
+++ b/markets/perps-market/contracts/storage/PerpsAccount.sol
@@ -67,6 +67,8 @@ library PerpsAccount {
         uint256 withdrawAmount
     );
 
+    error InsufficientCreditForDebtRebalance(uint128 accountId, uint256 debt, uint256 credit);
+
     error InsufficientAccountMargin(uint256 leftover);
 
     error AccountLiquidatable(uint128 accountId);
@@ -281,6 +283,35 @@ library PerpsAccount {
             ERC2771Context._msgSender(),
             debtPaid
         );
+    }
+
+    /**
+     * @notice Allows the user to repay debt using his snxUSD margin if there is any
+     */
+    function rebalanceDebt(Data storage self, uint256 amount) internal returns (uint256 debtPaid) {
+        if (self.debt == 0) {
+            revert NonexistentDebt(self.id);
+        }
+
+        /*
+            1. if the debt is less than the amount, set debt to 0 and only take from margin the debt amount
+            2. if the debt is more than the amount, subtract the amount from the debt
+            3. excess amount is ignored
+        */
+
+        PerpsMarketFactory.Data storage perpsMarketFactory = PerpsMarketFactory.load();
+
+        debtPaid = MathUtil.min(self.debt, amount);
+
+        uint256 creditAvailable = self.collateralAmounts[SNX_USD_MARKET_ID];
+
+        if (creditAvailable < debtPaid) {
+            revert InsufficientCreditForDebtRebalance(self.id, self.debt, creditAvailable);
+        }
+
+        updateAccountDebt(self, -debtPaid.toInt());
+        // charge user account the repaid debt amount
+        charge(self, -debtPaid.toInt());
     }
 
     /**


### PR DESCRIPTION
Allows repayment of debt using snxUSD from the account's margin balance.
Previously the user would have to call `payDebt` and deposit snxUSD