### PR TITLE
Fix typo Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Do **NOT** manually update `package.json` of any package.
     ```sh
     git reset --hard
     ```
-    And ensure workign tree is clean again
+    And ensure working tree is clean again
     ```sh
     git diff --exit-code
     ```


### PR DESCRIPTION
It looks like you're working on fixing a typo in the README.md file. The issue is with the phrase "And ensure workign tree is clean again." The word "workign" is a typo, and it should be "working."

Your change is making this correction:

Original: "And ensure workign tree is clean again"
Updated: "And ensure working tree is clean again"
This is a good fix as it improves readability and ensures the instructions are clear to users.