### PR TITLE
typo fix Update README.md

### DIFF
--- a/markets/spot-market/README.md
+++ b/markets/spot-market/README.md
@@ -84,7 +84,7 @@ The following actions are involved with asyncronous orders:
 #### Fees
 
 The `asyncFixedFee` is applied to async orders instead of the `atomicFixedFee`.  
-**Note**: if a custom fee is set for a given transactor, the custom fee takes precendence over all fixed fees.
+**Note**: if a custom fee is set for a given transactor, the custom fee takes precedence over all fixed fees.
 
 ### Wrapping
 


### PR DESCRIPTION
Specific Change:
Before:
...the custom fee takes precendence over all fixed fees.
After:
...the custom fee takes precedence over all fixed fees.
This fix enhances the readability and correctness of the documentation.