### PR TITLE
add constructor args so that cannon can verify proxy contracts

### DIFF
--- a/markets/bfp-market/cannonfile.toml
+++ b/markets/bfp-market/cannonfile.toml
@@ -110,6 +110,10 @@ func = "upgradeTo"
 args = ["<%= contracts.BfpMarketRouter.address %>"]
 factory.BfpMarketProxy.abiOf = ["BfpMarketRouter"]
 factory.BfpMarketProxy.artifact = "contracts/Proxy.sol:Proxy"
+factory.BfpMarketProxy.constructorArgs = [
+    "<%= contracts.CoreModule.address %>",
+    "<%= settings.owner %>",
+]
 factory.BfpMarketProxy.event = "Upgraded"
 factory.BfpMarketProxy.arg = 0
 factory.BfpMarketProxy.highlight = true

--- a/markets/legacy-market/cannonfile.toml
+++ b/markets/legacy-market/cannonfile.toml
@@ -43,6 +43,10 @@ func = "upgradeTo"
 args = ["<%= contracts.Market.address %>"]
 factory.Proxy.abiOf = ["Market"]
 factory.Proxy.artifact = "Proxy"
+factory.Proxy.constructorArgs = [
+    "<%= contracts.InitialModuleBundle.address %>",
+    "<%= settings.owner %>",
+]
 factory.Proxy.event = "Upgraded"
 factory.Proxy.arg = 0
 factory.Proxy.highlight = true

--- a/markets/perps-market/cannonfile.toml
+++ b/markets/perps-market/cannonfile.toml
@@ -101,6 +101,10 @@ func = "upgradeTo"
 args = ["<%= contracts.PerpsMarketRouter.address %>"]
 factory.PerpsMarketProxy.abiOf = ["PerpsMarketRouter"]
 factory.PerpsMarketProxy.artifact = "contracts/Proxy.sol:Proxy"
+factory.PerpsMarketProxy.constructorArgs = [
+    "<%= contracts.CoreModule.address %>",
+    "<%= settings.owner %>",
+]
 factory.PerpsMarketProxy.event = "Upgraded"
 factory.PerpsMarketProxy.arg = 0
 factory.PerpsMarketProxy.highlight = true

--- a/markets/spot-market/cannonfile.toml
+++ b/markets/spot-market/cannonfile.toml
@@ -75,6 +75,10 @@ fromCall.func = "owner"
 func = "upgradeTo"
 args = ["<%= contracts.SpotMarketRouter.address %>"]
 factory.SpotMarketProxy.artifact = "contracts/Proxy.sol:Proxy"
+factory.SpotMarketProxy.constructorArgs = [
+    "<%= contracts.CoreModule.address %>",
+    "<%= settings.owner %>",
+]
 factory.SpotMarketProxy.abiOf = ["SpotMarketRouter"]
 factory.SpotMarketProxy.event = "Upgraded"
 factory.SpotMarketProxy.arg = 0

--- a/markets/treasury-market/cannonfile.toml
+++ b/markets/treasury-market/cannonfile.toml
@@ -51,6 +51,10 @@ func = "upgradeTo"
 args = ["<%= contracts.MarketImpl.address %>"]
 factory.Proxy.abiOf = ["MarketImpl"]
 factory.Proxy.artifact = "SynthetixTreasuryProxy"
+factory.Proxy.constructorArgs = [
+    "<%= contracts.InitialModuleBundle.address %>",
+    "<%= settings.owner %>",
+]
 factory.Proxy.event = "Upgraded"
 factory.Proxy.arg = 0
 factory.Proxy.highlight = true

--- a/protocol/oracle-manager/cannonfile.toml
+++ b/protocol/oracle-manager/cannonfile.toml
@@ -40,6 +40,10 @@ func = "upgradeTo"
 args = ["<%= contracts.OracleRouter.address %>"]
 factory.Proxy.abiOf = ["OracleRouter"]
 factory.Proxy.artifact = "Proxy"
+factory.Proxy.constructorArgs = [
+    "<%= contracts.CoreModule.address %>",
+    "<%= settings.owner %>",
+]
 factory.Proxy.event = "Upgraded"
 factory.Proxy.arg = 0
 factory.Proxy.highlight = true

--- a/protocol/synthetix/cannonfile.common.toml
+++ b/protocol/synthetix/cannonfile.common.toml
@@ -131,6 +131,10 @@ func = "upgradeTo"
 args = ["<%= contracts.CoreRouter.address %>"]
 factory.CoreProxy.abiOf = ["CoreRouter"]
 factory.CoreProxy.artifact = "contracts/Proxy.sol:Proxy"
+factory.CoreProxy.constructorArgs = [
+    "<%= contracts.InitialModuleBundle.address %>",
+    "<%= settings.owner %>",
+]
 factory.CoreProxy.event = "Upgraded"
 factory.CoreProxy.arg = 0
 factory.CoreProxy.highlight = true


### PR DESCRIPTION
should fix an error during contract verification with `cannon verify` where it doesn't have the correct constructor arguments to do the verification.