### PR TITLE
Collateral Deprecation

### DIFF
--- a/markets/treasury-market/cannonfile.test.toml
+++ b/markets/treasury-market/cannonfile.test.toml
@@ -17,7 +17,7 @@ defaultValue = "<%= imports.v3.contracts.CollateralMock.address %>"
 [setting.v3_package]
 # TODO: Make this dynamic, cannon overrides package for some reason and template is no longer working
 #defaultValue = "synthetix:<%= package.version %>-testable"
-defaultValue = "synthetix:3.12.2-testable"
+defaultValue = "synthetix:3.12.3-testable"
 
 depends = []
 

--- a/protocol/synthetix/contracts/interfaces/ICollateralConfigurationModule.sol
+++ b/protocol/synthetix/contracts/interfaces/ICollateralConfigurationModule.sol
@@ -16,6 +16,15 @@ interface ICollateralConfigurationModule {
     event CollateralConfigured(address indexed collateralType, CollateralConfiguration.Data config);
 
     /**
+     * @notice Emitted when a collateral is deprecated and its balance sent to a deprecation wallet
+     */
+    event CollateralDeprecated(
+        address indexed collateralType,
+        address deprecationReceiver,
+        uint256 deprecatedBalance
+    );
+
+    /**
      * @notice Creates or updates the configuration for the given `collateralType`.
      * @param config The CollateralConfiguration object describing the new configuration.
      *
@@ -27,6 +36,13 @@ interface ICollateralConfigurationModule {
      *
      */
     function configureCollateral(CollateralConfiguration.Data memory config) external;
+
+    /**
+     * @notice Deprecates a collateral and transfers the remaining balance in the v3 system
+     * to the specified receiver contract.
+     *
+     */
+    function deprecateCollateral(address collateralType, address deprecationReceiver) external;
 
     /**
      * @notice Returns a list of detailed information pertaining to all collateral types registered in the system.

--- a/protocol/synthetix/contracts/interfaces/ICollateralModule.sol
+++ b/protocol/synthetix/contracts/interfaces/ICollateralModule.sol
@@ -14,6 +14,11 @@ interface ICollateralModule {
     error InsufficientAccountCollateral(uint256 amount);
 
     /**
+     * @notice Thrown when a deposited collateral cannot be withdrawn because it has been deprecated.
+     */
+    error DeprecatedDeposit();
+
+    /**
      * @notice Emitted when `tokenAmount` of collateral of type `collateralType` is deposited to account `accountId` by `sender`.
      * @param accountId The id of the account that deposited collateral.
      * @param collateralType The address of the collateral that was deposited.

--- a/protocol/synthetix/contracts/modules/core/CollateralConfigurationModule.sol
+++ b/protocol/synthetix/contracts/modules/core/CollateralConfigurationModule.sol
@@ -34,7 +34,9 @@ contract CollateralConfigurationModule is ICollateralConfigurationModule {
         OwnableStorage.onlyOwner();
 
         uint256 deprecatedBalance = deprecatedCollateral.balanceOf(address(this));
-        deprecatedCollateral.safeTransfer(deprecationReceiver, deprecatedBalance);
+        if (deprecatedBalance > 0) {
+            deprecatedCollateral.safeTransfer(deprecationReceiver, deprecatedBalance);
+        }
 
         CollateralConfiguration.load(deprecatedCollateral).depositingEnabled = false;
 

--- a/protocol/synthetix/contracts/modules/core/CollateralConfigurationModule.sol
+++ b/protocol/synthetix/contracts/modules/core/CollateralConfigurationModule.sol
@@ -1,6 +1,7 @@
 //SPDX-License-Identifier: MIT
 pragma solidity >=0.8.11 <0.9.0;
 
+import "@synthetixio/core-contracts/contracts/token/ERC20Helper.sol";
 import "@synthetixio/core-contracts/contracts/ownership/OwnableStorage.sol";
 import "@synthetixio/core-contracts/contracts/utils/DecimalMath.sol";
 import "../../interfaces/ICollateralConfigurationModule.sol";
@@ -13,6 +14,7 @@ import "../../storage/CollateralConfiguration.sol";
 contract CollateralConfigurationModule is ICollateralConfigurationModule {
     using SetUtil for SetUtil.AddressSet;
     using CollateralConfiguration for CollateralConfiguration.Data;
+    using ERC20Helper for address;
 
     /**
      * @inheritdoc ICollateralConfigurationModule
@@ -23,6 +25,20 @@ contract CollateralConfigurationModule is ICollateralConfigurationModule {
         CollateralConfiguration.set(config);
 
         emit CollateralConfigured(config.tokenAddress, config);
+    }
+
+    function deprecateCollateral(
+        address deprecatedCollateral,
+        address deprecationReceiver
+    ) external override {
+        OwnableStorage.onlyOwner();
+
+        uint256 deprecatedBalance = deprecatedCollateral.balanceOf(address(this));
+        deprecatedCollateral.safeTransfer(deprecationReceiver, deprecatedBalance);
+
+        CollateralConfiguration.load(deprecatedCollateral).depositingEnabled = false;
+
+        emit CollateralDeprecated(deprecatedCollateral, deprecationReceiver, deprecatedBalance);
     }
 
     /**

--- a/protocol/synthetix/contracts/modules/core/CollateralModule.sol
+++ b/protocol/synthetix/contracts/modules/core/CollateralModule.sol
@@ -98,6 +98,11 @@ contract CollateralModule is ICollateralModule {
 
         account.collaterals[collateralType].decreaseAvailableCollateral(tokenAmountD18);
 
+        if (collateralType.balanceOf(address(this)) < tokenAmount) {
+            // if the tokens are not there, and the user has balance, it means the collateral was deprecated
+            revert DeprecatedDeposit();
+        }
+
         collateralType.safeTransfer(ERC2771Context._msgSender(), tokenAmount);
 
         emit Withdrawn(accountId, collateralType, tokenAmount, ERC2771Context._msgSender());

--- a/protocol/synthetix/contracts/modules/core/MarketCollateralModule.sol
+++ b/protocol/synthetix/contracts/modules/core/MarketCollateralModule.sol
@@ -6,6 +6,7 @@ import "@synthetixio/core-contracts/contracts/token/ERC20Helper.sol";
 import "@synthetixio/core-contracts/contracts/utils/ERC2771Context.sol";
 
 import "../../interfaces/IMarketCollateralModule.sol";
+import "../../interfaces/ICollateralModule.sol";
 import "../../storage/Market.sol";
 
 import "@synthetixio/core-modules/contracts/storage/FeatureFlag.sol";
@@ -113,6 +114,11 @@ contract MarketCollateralModule is IMarketCollateralModule {
 
         // Account for transferring out collateral
         collateralEntry.amountD18 -= systemAmount;
+
+        if (collateralType.balanceOf(address(this)) < tokenAmount) {
+            // if the tokens are not there, and the user has balance, it means the collateral was deprecated
+            revert ICollateralModule.DeprecatedDeposit();
+        }
 
         (uint256 depositedCollateralValue, bytes memory possibleError1) = marketData
             .getDepositedCollateralValue();

--- a/protocol/synthetix/test/integration/modules/core/CollateralConfigurationModule/CollateralConfigurationModule.config.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/CollateralConfigurationModule/CollateralConfigurationModule.config.test.ts
@@ -217,7 +217,7 @@ describe('CollateralModule', function () {
             it('fails with correct error when trying to withdraw', async () => {
               await assertRevert(
                 systems().Core.connect(user1).withdraw(1, AnotherCollateral.address, 1000),
-                'CollateralDeprecated',
+                'DeprecatedDeposit',
                 systems().Core
               );
             });

--- a/protocol/synthetix/test/integration/modules/core/CollateralConfigurationModule/CollateralConfigurationModule.config.test.ts
+++ b/protocol/synthetix/test/integration/modules/core/CollateralConfigurationModule/CollateralConfigurationModule.config.test.ts
@@ -215,7 +215,7 @@ describe('CollateralModule', function () {
             });
 
             it('fails with correct error when trying to withdraw', async () => {
-              assertRevert(
+              await assertRevert(
                 systems().Core.connect(user1).withdraw(1, AnotherCollateral.address, 1000),
                 'CollateralDeprecated',
                 systems().Core

--- a/utils/core-contracts/contracts/token/ERC20Helper.sol
+++ b/utils/core-contracts/contracts/token/ERC20Helper.sol
@@ -23,4 +23,8 @@ library ERC20Helper {
             revert FailedTransfer(from, to, value);
         }
     }
+
+    function balanceOf(address token, address wallet) internal view returns (uint256) {
+        return IERC20(token).balanceOf(wallet);
+    }
 }


### PR DESCRIPTION
ability to deprecate deposited collaterals and move them to a new system for claim. The owner of the contract can specify a deprecation target, and collateral will be sent to this target for further deprecation related processing outside of v3.

notes:
* once a collateral is deprecated, it is also automatically disabled, which will prevent further usage of it. It should never be re-enabled or configured again.
* the owner is expected to act rationally wrt to usage of deprecation (ex. do not use deprecated collaterals to fund markets which are actively needed for protocol operation)