### PR TITLE
fix: AddressUtil remove extcodesize, replace isContract with address(…..).code.length > 0

### DIFF
--- a/utils/core-contracts/contracts/utils/AddressUtil.sol
+++ b/utils/core-contracts/contracts/utils/AddressUtil.sol
@@ -3,12 +3,6 @@ pragma solidity >=0.8.11 <0.9.0;
 
 library AddressUtil {
     function isContract(address account) internal view returns (bool) {
-        uint256 size;
-
-        assembly {
-            size := extcodesize(account)
-        }
-
-        return size > 0;
+        return account.code.length > 0;
     }
 }


### PR DESCRIPTION
isContract() in AddressUtil is used to determine whether the account is a contract or an externally owned account (EOA). However, in Solidity, there is no reliable way to definitively determine whether a given address is a contract, as there are several edge cases in which the underlying extcodesize function can return unexpected results.

```solidity
library AddressUtil {
    function isContract(address account) internal view returns (bool) {
        uint256 size;

        assembly {
            size := extcodesize(account)
        }

        return size > 0;
    }
}

```


Solidity 0.8.1 implements a shortcut for account.code.length that avoids copying code to memory. Therefore, the above code should be equivalent.

Recommendations
Consider changes below:
```diff
    function isContract(address account) internal view returns (bool) {
-        uint256 size;
-
-        assembly {
-            size := extcodesize(account)
-        }
-
-        return size > 0;
+                return account.code.length > 0;
    }
```

Link for reference:
- https://github.com/OpenZeppelin/openzeppelin-contracts/issues/3417
- https://github.com/AmazingAng/WTF-Solidity/pull/721