### PR TITLE
fix: Prevent takeSnapshot DoS, add missing supportsInterface, validate snxFeeShare

### DIFF
--- a/auxiliary/BuybackSnx/contracts/BuybackSnx.sol
+++ b/auxiliary/BuybackSnx/contracts/BuybackSnx.sol
@@ -33,6 +33,7 @@ contract BuybackSnx is IFeeCollector {
         address _snxToken,
         address _usdToken
     ) {
+        require(_snxFeeShare < DecimalMath.UNIT, "snxFeeShare must be < 100%");
         premium = _premium;
         snxFeeShare = _snxFeeShare;
         oracleManager = _oracleManager;

--- a/auxiliary/BuybackSnx/foundry.toml
+++ b/auxiliary/BuybackSnx/foundry.toml
@@ -1,0 +1,15 @@
+[profile.default]
+src = "contracts"
+out = "out"
+libs = []
+allow_paths = [
+    "../../node_modules/forge-std",
+    "../../protocol/synthetix",
+    "../../utils/core-contracts",
+]
+remappings = [
+    "forge-std=../../node_modules/forge-std/src",
+    "@synthetixio=../../node_modules/@synthetixio",
+]
+
+fs_permissions = [{ access = "read", path = "./" }]

--- a/auxiliary/BuybackSnx/test/BuybackSnxFeeShareTest.sol
+++ b/auxiliary/BuybackSnx/test/BuybackSnxFeeShareTest.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.11 <0.9.0;
+
+import {Test} from "forge-std/Test.sol";
+import {BuybackSnx} from "../contracts/BuybackSnx.sol";
+import {DecimalMath} from "@synthetixio/core-contracts/contracts/utils/DecimalMath.sol";
+
+/// @notice Regression test: BuybackSnx must reject snxFeeShare >= 100%
+contract BuybackSnxFeeShareTest is Test {
+    function test_constructor_rejects_100_percent_feeShare() public {
+        // Should revert with 100% fee share
+        vm.expectRevert("snxFeeShare must be < 100%");
+        new BuybackSnx(
+            0, // premium
+            DecimalMath.UNIT, // snxFeeShare = 100%
+            address(0x1234),
+            bytes32("snx"),
+            address(0x2345),
+            address(0x3456)
+        );
+    }
+
+    function test_constructor_rejects_over_100_percent_feeShare() public {
+        // Should revert with > 100% fee share
+        vm.expectRevert("snxFeeShare must be < 100%");
+        new BuybackSnx(
+            0, // premium
+            DecimalMath.UNIT + 1, // snxFeeShare > 100%
+            address(0x1234),
+            bytes32("snx"),
+            address(0x2345),
+            address(0x3456)
+        );
+    }
+
+    function test_constructor_accepts_valid_feeShare() public {
+        // Should succeed with < 100% fee share
+        BuybackSnx buyback = new BuybackSnx(
+            0, // premium
+            DecimalMath.UNIT / 2, // snxFeeShare = 50%
+            address(0x1234),
+            bytes32("snx"),
+            address(0x2345),
+            address(0x3456)
+        );
+
+        // Verify quoteFees returns half the amount
+        uint256 feeAmount = 1000e18;
+        uint256 quotedFee = buyback.quoteFees(0, feeAmount, address(this));
+        assertEq(quotedFee, feeAmount / 2, "quoteFees should return 50% of feeAmount");
+    }
+}

--- a/auxiliary/RewardsDistributor/src/SnapshotRewardsDistributor.sol
+++ b/auxiliary/RewardsDistributor/src/SnapshotRewardsDistributor.sol
@@ -214,6 +214,12 @@ contract SnapshotRewardsDistributor is IRewardDistributor, ISnapshotRecord {
         if (!authorizedToSnapshot[sender]) {
             revert AccessError.Unauthorized(sender);
         }
+        if (id == type(uint128).max) {
+            revert ParameterError.InvalidParameter(
+                "id",
+                "period id must be less than max uint128"
+            );
+        }
         if (id <= currentPeriodId) {
             revert ParameterError.InvalidParameter("id", "period id must always increase");
         }
@@ -246,6 +252,7 @@ contract SnapshotRewardsDistributor is IRewardDistributor, ISnapshotRecord {
     ) public view virtual override(IERC165) returns (bool) {
         return
             interfaceId == type(IRewardDistributor).interfaceId ||
+            interfaceId == type(ISnapshotRecord).interfaceId ||
             interfaceId == this.supportsInterface.selector;
     }
 }

--- a/auxiliary/RewardsDistributor/test/SnapshotRewardsDistributorUnitTest.sol
+++ b/auxiliary/RewardsDistributor/test/SnapshotRewardsDistributorUnitTest.sol
@@ -9,6 +9,7 @@ import {ParameterError} from "@synthetixio/core-contracts/contracts/errors/Param
 import {ERC20Helper} from "@synthetixio/core-contracts/contracts/token/ERC20Helper.sol";
 import {IRewardsManagerModule} from "@synthetixio/main/contracts/interfaces/IRewardsManagerModule.sol";
 import {IRewardDistributor} from "@synthetixio/main/contracts/interfaces/external/IRewardDistributor.sol";
+import {ISnapshotRecord} from "@synthetixio/governance/contracts/interfaces/external/ISnapshotRecord.sol";
 import {SnapshotRewardsDistributor} from "../src/SnapshotRewardsDistributor.sol";
 import {IVaultModule} from "@synthetixio/main/contracts/interfaces/IVaultModule.sol";
 
@@ -281,5 +282,45 @@ contract SnapshotRewardsDistributorUnitTest is Test {
         assertEq(rewardsDistributor.balanceOf(vm.addr(0xB0B)), 9000);
         assertEq(rewardsDistributor.balanceOfOnPeriod(accountId, 2), 9000);
         assertEq(rewardsDistributor.balanceOfOnPeriod(vm.addr(0xB0B), 2), 9000);
+    }
+
+    /// @notice Regression test: takeSnapshot must reject max uint128 to prevent DoS
+    function test_takeSnapshot_rejects_maxUint128() public {
+        uint128 maxId = type(uint128).max;
+
+        vm.startPrank(vm.addr(0xA11CE));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ParameterError.InvalidParameter.selector,
+                "id",
+                "period id must be less than max uint128"
+            )
+        );
+        rewardsDistributor.takeSnapshot(maxId);
+        vm.stopPrank();
+
+        // Valid IDs should still work
+        vm.startPrank(vm.addr(0xA11CE));
+        rewardsDistributor.takeSnapshot(1);
+        assertEq(rewardsDistributor.currentPeriodId(), 1);
+
+        rewardsDistributor.takeSnapshot(100);
+        assertEq(rewardsDistributor.currentPeriodId(), 100);
+        vm.stopPrank();
+    }
+
+    /// @notice Regression test: supportsInterface must advertise ISnapshotRecord
+    function test_supportsInterface_includesISnapshotRecord() public view {
+        // After fix: supportsInterface should return true for ISnapshotRecord
+        assertTrue(
+            rewardsDistributor.supportsInterface(type(ISnapshotRecord).interfaceId),
+            "supportsInterface must advertise ISnapshotRecord"
+        );
+
+        // Should still support IRewardDistributor
+        assertTrue(
+            rewardsDistributor.supportsInterface(type(IRewardDistributor).interfaceId),
+            "supportsInterface must advertise IRewardDistributor"
+        );
     }
 }


### PR DESCRIPTION
## Summary

This PR addresses three security vulnerabilities discovered during automated security analysis in the auxiliary contracts:

### 1. [MEDIUM] takeSnapshot DoS via max uint128 period ID

**File:** `auxiliary/RewardsDistributor/src/SnapshotRewardsDistributor.sol`

The `takeSnapshot` function allows setting `currentPeriodId` to `type(uint128).max`. Once this happens, no subsequent snapshots can ever be taken because the function requires `id > currentPeriodId`, and there is no value greater than `type(uint128).max`. This permanently bricks the snapshot functionality.

**Fix:** Added validation to reject `type(uint128).max` as a period ID before it can be set.

### 2. [LOW] supportsInterface missing ISnapshotRecord

**File:** `auxiliary/RewardsDistributor/src/SnapshotRewardsDistributor.sol`

The contract implements `ISnapshotRecord` interface but the `supportsInterface` function doesn't advertise this capability, violating ERC-165.

**Fix:** Added `type(ISnapshotRecord).interfaceId` to the supportsInterface check.

### 3. [LOW] BuybackSnx allows 100%+ snxFeeShare

**File:** `auxiliary/BuybackSnx/contracts/BuybackSnx.sol`

The constructor allows `snxFeeShare` to be set to `DecimalMath.UNIT` (100%) or higher, breaking the invariant that buyback should only take a portion of fees.

**Fix:** Added constructor validation requiring `snxFeeShare < DecimalMath.UNIT`.

## Test plan

- [x] Added regression test `test_takeSnapshot_rejects_maxUint128` for DoS prevention
- [x] Added regression test `test_supportsInterface_includesISnapshotRecord` for ERC-165 compliance
- [x] Added `BuybackSnxFeeShareTest.sol` with constructor validation tests

Prepared by Kai Agent